### PR TITLE
Remove legacy jibri auth, use B when provisioning jibri

### DIFF
--- a/nomad/jibri.hcl
+++ b/nomad/jibri.hcl
@@ -8,9 +8,19 @@ variable jibri_recorder_password {
     default = "replaceme_recorder"
 }
 
+variable jibri_recorder_username {
+    type = string
+    default = "jibrib"
+}
+
 variable jibri_xmpp_password {
     type = string
     default = "replaceme_jibri"
+}
+
+variable jibri_xmpp_username {
+    type = string
+    default = "jibrib"
 }
 
 variable "jibri_tag" {
@@ -168,9 +178,9 @@ job "[JOB_NAME]" {
         XMPP_ENV_NAME = "${var.environment}"
         XMPP_DOMAIN = "${var.domain}"
         PUBLIC_URL="https://${var.domain}/"
-        JIBRI_RECORDER_USER = "recorder"
+        JIBRI_RECORDER_USER = "${var.jibri_recorder_username}"
         JIBRI_RECORDER_PASSWORD = "${var.jibri_recorder_password}"
-        JIBRI_XMPP_USER = "jibri"
+        JIBRI_XMPP_USER = "${var.jibri_xmpp_username}"
         JIBRI_XMPP_PASSWORD = "${var.jibri_xmpp_password}"
         # Internal XMPP domain for authenticated services
         XMPP_AUTH_DOMAIN = "auth.${var.domain}"

--- a/scripts/deploy-nomad-prosody-brewery.sh
+++ b/scripts/deploy-nomad-prosody-brewery.sh
@@ -57,12 +57,12 @@ if [[ "$JIBRI_AUTH_TYPE" == "A" ]]; then
     JIBRI_XMPP_PASSWORD_VARIABLE="secrets_jibri_brewery_by_environment_A.\"$ENVIRONMENT\""
     JIBRI_XMPP_USERNAME="jibria"
     JIBRI_RECORDER_PASSWORD_VARIABLE="secrets_jibri_selenium_by_environment_A.\"$ENVIRONMENT\""
-    JIBRI_RECORDER_USERNAME="recordera"
+    JIBRI_RECORDER_USERNAME="jibria"
 if [[ "$JIBRI_AUTH_TYPE" == "B" ]]; then
     JIBRI_XMPP_PASSWORD_VARIABLE="secrets_jibri_brewery_by_environment_B.\"$ENVIRONMENT\""
     JIBRI_XMPP_USERNAME="jibrib"
     JIBRI_RECORDER_PASSWORD_VARIABLE="secrets_jibri_selenium_by_environment_B.\"$ENVIRONMENT\""
-    JIBRI_RECORDER_USERNAME="recorderb"
+    JIBRI_RECORDER_USERNAME="jibrib"
 else
     echo "Invalid JIBRI_AUTH_TYPE $JIBRI_AUTH_TYPE"
     exit 1

--- a/scripts/deploy-nomad-prosody-brewery.sh
+++ b/scripts/deploy-nomad-prosody-brewery.sh
@@ -50,15 +50,10 @@ NOMAD_DC="$ENVIRONMENT-$ORACLE_REGION"
 
 JIBRI_AUTH_TYPE="$(cat $ENVIRONMENT_CONFIGURATION_FILE | yq eval .jibri_auth_type -)"
 if [[ "$JIBRI_AUTH_TYPE" == "null" ]]; then
-    JIBRI_AUTH_TYPE="legacy"
+    JIBRI_AUTH_TYPE="B"
 fi
 
-if [[ "$JIBRI_AUTH_TYPE" == "legacy" ]]; then
-    JIBRI_XMPP_PASSWORD_VARIABLE="jibri_auth_password"
-    JIBRI_XMPP_USERNAME="jibri"
-    JIBRI_RECORDER_PASSWORD_VARIABLE="jibri_selenium_auth_password"
-    JIBRI_RECORDER_USERNAME="recorder"
-elif [[ "$JIBRI_AUTH_TYPE" == "A" ]]; then
+if [[ "$JIBRI_AUTH_TYPE" == "A" ]]; then
     JIBRI_XMPP_PASSWORD_VARIABLE="secrets_jibri_brewery_by_environment_A.\"$ENVIRONMENT\""
     JIBRI_XMPP_USERNAME="jibria"
     JIBRI_RECORDER_PASSWORD_VARIABLE="secrets_jibri_selenium_by_environment_A.\"$ENVIRONMENT\""

--- a/scripts/deploy-nomad-shard-backend.sh
+++ b/scripts/deploy-nomad-shard-backend.sh
@@ -84,15 +84,10 @@ NOMAD_DC="$ENVIRONMENT-$ORACLE_REGION"
 
 JIBRI_AUTH_TYPE="$(cat $ENVIRONMENT_CONFIGURATION_FILE | yq eval .jibri_auth_type -)"
 if [[ "$JIBRI_AUTH_TYPE" == "null" ]]; then
-    JIBRI_AUTH_TYPE="legacy"
+    JIBRI_AUTH_TYPE="B"
 fi
 
-if [[ "$JIBRI_AUTH_TYPE" == "legacy" ]]; then
-    JIBRI_XMPP_PASSWORD_VARIABLE="jibri_auth_password"
-    JIBRI_XMPP_USERNAME="jibri"
-    JIBRI_RECORDER_PASSWORD_VARIABLE="jibri_selenium_auth_password"
-    JIBRI_RECORDER_USERNAME="recorder"
-elif [[ "$JIBRI_AUTH_TYPE" == "A" ]]; then
+if [[ "$JIBRI_AUTH_TYPE" == "A" ]]; then
     JIBRI_XMPP_PASSWORD_VARIABLE="secrets_jibri_brewery_by_environment_A.\"$ENVIRONMENT\""
     JIBRI_XMPP_USERNAME="jibria"
     JIBRI_RECORDER_PASSWORD_VARIABLE="secrets_jibri_selenium_by_environment_A.\"$ENVIRONMENT\""


### PR DESCRIPTION
- **Remove jibri legacy auth, default to B.**
- **fix: Fix jibri recorder username.**
- **fix: Deploy jibri with the correct credentials (default to B).**
