### PR TITLE
fix: make assign_public_ip explicitly false

### DIFF
--- a/terraform/consul-server/create-consul-server-oracle.tf
+++ b/terraform/consul-server/create-consul-server-oracle.tf
@@ -344,6 +344,7 @@ resource "oci_core_instance_configuration" "oci_instance_configuration_a" {
       }
 
       create_vnic_details {
+        assign_public_ip = false
         subnet_id = var.subnet_ocid
         nsg_ids = [oci_core_network_security_group.consul_security_group.id]
       }
@@ -388,6 +389,7 @@ resource "oci_core_instance_configuration" "oci_instance_configuration_b" {
       }
 
       create_vnic_details {
+        assign_public_ip = false
         subnet_id = var.subnet_ocid
         nsg_ids = [oci_core_network_security_group.consul_security_group.id]
       }
@@ -432,6 +434,7 @@ resource "oci_core_instance_configuration" "oci_instance_configuration_c" {
       }
 
       create_vnic_details {
+        assign_public_ip = false
         subnet_id = var.subnet_ocid
         nsg_ids = [oci_core_network_security_group.consul_security_group.id]
       }

--- a/terraform/nomad-instance-pool/nomad-instance-pool-stack.tf
+++ b/terraform/nomad-instance-pool/nomad-instance-pool-stack.tf
@@ -95,6 +95,7 @@ resource "oci_core_instance_configuration" "oci_instance_configuration" {
       }
 
       create_vnic_details {
+        assign_public_ip = false
         subnet_id = var.pool_subnet_ocid
         nsg_ids = [var.security_group_id]
       }

--- a/terraform/nomad-server/nomad-server-stack.tf
+++ b/terraform/nomad-server/nomad-server-stack.tf
@@ -85,6 +85,7 @@ resource "oci_core_instance_configuration" "oci_instance_configuration" {
       }
 
       create_vnic_details {
+        assign_public_ip = false
         subnet_id = var.private_subnet_ocid
         nsg_ids = [var.security_group_id]
       }


### PR DESCRIPTION
the oci provider breaks if this isn't explicitly set to false if the instance config is for a subnet that does not allow public