### PR TITLE
Always explicitly specify JVB's bwe algorithm.

### DIFF
--- a/nomad/jitsi_packs/packs/jitsi_meet_jvb/templates/_jvb.conf.tpl
+++ b/nomad/jitsi_packs/packs/jitsi_meet_jvb/templates/_jvb.conf.tpl
@@ -221,11 +221,13 @@ jmt {
         bitrate-threshold = [[ or (env "CONFIG_jvb_loss_bitrate_threshold_kbps") "1000" ]] kbps
       }
     }
-[[ if ne (or (env "CONFIG_jvb_use_google_cc2_bwe") "true") "false" ]]
    estimator {
+[[ if ne (or (env "CONFIG_jvb_use_google_cc2_bwe") "true") "false" ]]
        engine = GoogleCc2
-    }
+[[ else ]]
+       engine = GoogleCc
 [[ end ]]
+    }
   }
 [[ if eq (or (env "CONFIG_jvb_skip_authentication_for_silence") "false") "true" ]]
   srtp {


### PR DESCRIPTION
So that deployments don't change behavior if we change the JVB's default.