### PR TITLE
fix(synthetic-dial-in): Enables a 10 minute timeout.

### DIFF
--- a/jenkins/groovy/synthetic-dialin/Jenkinsfile
+++ b/jenkins/groovy/synthetic-dialin/Jenkinsfile
@@ -20,6 +20,7 @@ pipeline {
       ansiColor('xterm')
       timestamps()
       buildDiscarder(logRotator(daysToKeepStr: '14'))
+      timeout(time: 10, unit: 'MINUTES')
     }
     stages {
         stage ("setup") {


### PR DESCRIPTION
To avoid hanging due to some npm issues.