### PR TITLE
feat(jitsi-meet-web): wire jitsi_meet_enable_virtual_background_v2

### DIFF
--- a/nomad/jitsi_packs/packs/jitsi_meet_web/templates/_custom-config.js.tpl
+++ b/nomad/jitsi_packs/packs/jitsi_meet_web/templates/_custom-config.js.tpl
@@ -215,6 +215,10 @@ config.enableWebHIDFeature=true;
 config.disableIframeAPI=true;
 [[- end ]]
 
+[[ if eq (env "CONFIG_jitsi_meet_enable_virtual_background_v2") "true" -]]
+config.virtualBackground={enableV2:true};
+[[- end ]]
+
 config.faceLandmarks={
     enableFaceCentering: [[ or (env "CONFIG_jitsi_meet_enable_face_landmarks_enable_centering") "false" ]],
     enableFaceExpressionsDetection: [[ or (env "CONFIG_jitsi_meet_enable_face_landmarks_detect_expressions") "false" ]],


### PR DESCRIPTION
## Summary
- Threads the new `jitsi_meet_enable_virtual_background_v2` flag through the Nomad `jitsi_meet_web` pack.
- When `CONFIG_jitsi_meet_enable_virtual_background_v2` is `"true"` (exported per-site by `yamltoenv` from `sites/<env>/vars.yml`), the rendered `config.js` gets `config.virtualBackground = { enableV2: true }`.
- Defaults to off: when the env var is unset / not `"true"`, no `virtualBackground` block is emitted and the web client uses V1.

Companion change:
- `infra-configuration` PR adds the matching ansible var + `config.js.j2` block.

## Test plan
- [ ] Deploy a site with the var unset — verify rendered `config.js` has no `virtualBackground` line.
- [ ] Deploy a site with the var set to true — verify rendered `config.js` contains `config.virtualBackground={enableV2:true};`.
