### PR TITLE
feat: Jenkins jobs to release/deploy coturn on nomad

### DIFF
--- a/jenkins/jobs/deploy-nomad-coturn.yaml
+++ b/jenkins/jobs/deploy-nomad-coturn.yaml
@@ -1,0 +1,59 @@
+- job:
+    name: provision-nomad-coturn
+    display-name: provision nomad coturn
+    description: Deploys coturn to nomad in a single region
+    concurrent: true
+    parameters:
+      - string:
+          name: VIDEO_INFRA_BRANCH
+          default: main
+          description: "Controls checkout branch for infra repos, defaults to 'main'."
+          trim: true
+      - string:
+          name: ENVIRONMENT
+          description: "Environment to provision in"
+          trim: true
+      - string:
+          name: ORACLE_REGION
+          description: "Region to provision in"
+          trim: true
+      - string:
+          name: JOB_TYPE
+          default: coturn
+          description: "Nomad job type to provision, defaults to 'coturn' do not change"
+          trim: true
+      - string:
+          name: DESIRED_CAPACITY
+          default: 2
+          description: "Number of coturn allocations to run, defaults to 2."
+          trim: true
+      - string:
+          name: COTURN_CERTIFICATE_NAME
+          description: "SSL certificate name to use, defaults to the environment's site_ssl_certificate (or star.jitsi.net)."
+          trim: true
+      - string:
+          name: INFRA_CONFIGURATION_REPO
+          default: git@github.com:jitsi/infra-configuration.git
+          description: "Repo for configuration code (ansible etc), defaults to 'git@github.com:jitsi/infra-configuration.git'."
+          trim: true
+      - string:
+          name: INFRA_CUSTOMIZATIONS_REPO
+          default: git@github.com:jitsi/infra-customizations.git
+          description: "Repo with customized configurations, defaults to 'git@github.com:jitsi/infra-customizations.git'."
+          trim: true
+
+    project-type: pipeline
+    sandbox: true
+    pipeline-scm:
+      scm:
+        - git:
+            url: git@github.com:jitsi/infra-provisioning.git
+            credentials-id: "video-infra"
+            branches:
+              - "origin/${{VIDEO_INFRA_BRANCH}}"
+            browser: githubweb
+            browser-url: https://github.com/jitsi/infra-provisioning
+            submodule:
+              recursive: true
+      script-path: jenkins/groovy/provision-nomad-job/Jenkinsfile
+      lightweight-checkout: true

--- a/jenkins/jobs/release-nomad-coturn.yaml
+++ b/jenkins/jobs/release-nomad-coturn.yaml
@@ -1,0 +1,60 @@
+- job:
+    name: release-nomad-coturn
+    display-name: release nomad coturn
+    description: "release coturn to nomad in one or more regions in an environment."
+    concurrent: true
+    parameters:
+      - string:
+          name: VIDEO_INFRA_BRANCH
+          default: main
+          description: "Controls checkout branch for infra repos, defaults to 'main'."
+          trim: true
+      - string:
+          name: ENVIRONMENT
+          default: lonely
+          description: "Environment to build in, defaults to 'lonely'."
+          trim: true
+      - string:
+          name: REGIONS
+          description: "REGIONS to build in, defaults to NOMAD_REGIONS for the environment."
+          trim: true
+      - string:
+          name: JOB_TYPE
+          default: coturn
+          description: "Nomad job type to release, defaults to 'coturn' do not change"
+          trim: true
+      - string:
+          name: DESIRED_CAPACITY
+          default: 2
+          description: "Number of coturn allocations to run per region, defaults to 2."
+          trim: true
+      - string:
+          name: COTURN_CERTIFICATE_NAME
+          description: "SSL certificate name to use, defaults to the environment's site_ssl_certificate (or star.jitsi.net)."
+          trim: true
+      - string:
+          name: INFRA_CONFIGURATION_REPO
+          default: git@github.com:jitsi/infra-configuration.git
+          description: "Repo for configuration code (ansible etc), defaults to 'git@github.com:jitsi/infra-configuration.git'."
+          trim: true
+      - string:
+          name: INFRA_CUSTOMIZATIONS_REPO
+          default: git@github.com:jitsi/infra-customizations.git
+          description: "Repo with customized configurations, defaults to 'git@github.com:jitsi/infra-customizations.git'."
+          trim: true
+
+    project-type: pipeline
+    sandbox: true
+    pipeline-scm:
+      scm:
+        - git:
+            url: git@github.com:jitsi/infra-provisioning.git
+            credentials-id: "video-infra"
+            branches:
+              - "origin/${{VIDEO_INFRA_BRANCH}}"
+            browser: githubweb
+            browser-url: https://github.com/jitsi/infra-provisioning
+            submodule:
+              recursive: true
+      script-path: jenkins/groovy/release-nomad-job/Jenkinsfile
+      lightweight-checkout: true


### PR DESCRIPTION
## Summary
Adds two Jenkins job definitions for managing coturn on Nomad, alongside the existing coturn jobs in this repo:

- **`release-nomad-coturn`** — uses the generic `release-nomad-job/Jenkinsfile` with `JOB_TYPE=coturn`. Splits `REGIONS` for the `ENVIRONMENT` and fans out in parallel, triggering `provision-nomad-coturn` once per region.
- **`provision-nomad-coturn`** (file `deploy-nomad-coturn.yaml`) — uses the generic `provision-nomad-job/Jenkinsfile` with `JOB_TYPE=coturn`. Runs `scripts/deploy-nomad-coturn.sh` for a single `ORACLE_REGION`, which renders `nomad/coturn.hcl` and does `nomad job run`.

## Details
- The deploy job is named `provision-nomad-coturn` because the release Jenkinsfile triggers `build job: "provision-nomad-${JOB_TYPE.toLowerCase()}"`.
- Exposes `ORACLE_REGION` (coturn is multi-region — the Nomad job is named `coturn-$ORACLE_REGION`).
- Adds `DESIRED_CAPACITY` (→ `NOMAD_VAR_coturn_count`, default 2) and `COTURN_CERTIFICATE_NAME` (→ `NOMAD_VAR_ssl_cert_name`), matching what the deploy script reads.
- `INFRA_CUSTOMIZATIONS_REPO` defaults to the public `infra-customizations.git`, consistent with the existing `release-coturn` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)