### PR TITLE
fix(build-image-oracle): default IMAGE_ARCH per type when locking

### DIFF
--- a/jenkins/groovy/Utils.groovy
+++ b/jenkins/groovy/Utils.groovy
@@ -318,6 +318,21 @@ echo \$IMAGE_ARCH"""
     }
 }
 
+// default image architecture for an image type when IMAGE_ARCH is not set,
+// matching the per-type default used by the build scripts (see scripts/image-arch.sh)
+def DefaultImageArch(image_type) {
+    dir('infra-provisioning') {
+        def arch = sh(
+        returnStdout: true,
+        script: """#!/bin/bash
+. ./scripts/image-arch.sh
+default_arch_from_type ${image_type}
+echo \$IMAGE_ARCH"""
+        ).trim();
+        return arch
+    }
+}
+
 // get the shape of the signal image via DEFAULT_SIGNAL_SHAPE variable
 def SignalShapeFromEnvironment(environment) {
     dir('infra-provisioning') {

--- a/jenkins/groovy/build-image-oracle/Jenkinsfile
+++ b/jenkins/groovy/build-image-oracle/Jenkinsfile
@@ -42,7 +42,7 @@ pipeline {
       steps {
         dir('infra-provisioning') {
           script {
-            def imageArch = env.IMAGE_ARCH ?: "x86_64"
+            def imageArch = env.IMAGE_ARCH ?: utils.DefaultImageArch(env.IMAGE_TYPE)
             lock("image-build-${env.IMAGE_TYPE}-${imageArch}") {
               utils.SetupAnsible()
               withCredentials([

--- a/jenkins/groovy/build-image-oracle/Jenkinsfile
+++ b/jenkins/groovy/build-image-oracle/Jenkinsfile
@@ -40,9 +40,11 @@ pipeline {
         expression {skipCheck == false}
       }
       steps {
-        dir('infra-provisioning') {
-          script {
-            def imageArch = env.IMAGE_ARCH ?: utils.DefaultImageArch(env.IMAGE_TYPE)
+        script {
+          // resolve the effective arch (matching the build scripts' per-type default)
+          // BEFORE entering infra-provisioning, since DefaultImageArch re-enters it itself
+          def imageArch = env.IMAGE_ARCH ?: utils.DefaultImageArch(env.IMAGE_TYPE)
+          dir('infra-provisioning') {
             lock("image-build-${env.IMAGE_TYPE}-${imageArch}") {
               utils.SetupAnsible()
               withCredentials([

--- a/scripts/build-coturn-oracle.sh
+++ b/scripts/build-coturn-oracle.sh
@@ -30,6 +30,7 @@ fi
 #pull in cloud-specific variables, e.g. tenancy
 [ -e "$LOCAL_PATH/../clouds/all.sh" ] && . $LOCAL_PATH/../clouds/all.sh
 [ -e "$LOCAL_PATH/../clouds/oracle.sh" ] && . $LOCAL_PATH/../clouds/oracle.sh
+[ -e "$LOCAL_PATH/image-arch.sh" ] && . $LOCAL_PATH/image-arch.sh
 
 if [ -z "$ORACLE_REGION" ]; then
   echo "No ORACLE_REGION found.  Exiting..."
@@ -41,7 +42,7 @@ fi
 ORACLE_CLOUD_NAME="$ORACLE_REGION-$ENVIRONMENT-oracle"
 [ -e "$LOCAL_PATH/../clouds/${ORACLE_CLOUD_NAME}.sh" ] && . $LOCAL_PATH/../clouds/${ORACLE_CLOUD_NAME}.sh
 
-[ -z "$IMAGE_ARCH" ] && IMAGE_ARCH="aarch64"
+[ -z "$IMAGE_ARCH" ] && default_arch_from_type "coTURN"
 
 if [[ "$IMAGE_ARCH" == "aarch64" ]]; then
   [ -z "$SHAPE" ] && SHAPE="$SHAPE_A_1"

--- a/scripts/build-focal-base-oracle.sh
+++ b/scripts/build-focal-base-oracle.sh
@@ -37,6 +37,7 @@ fi
 
 #pull in cloud-specific variables, e.g. tenancy
 [ -e "$LOCAL_PATH/../clouds/oracle.sh" ] && . $LOCAL_PATH/../clouds/oracle.sh
+[ -e "$LOCAL_PATH/image-arch.sh" ] && . $LOCAL_PATH/image-arch.sh
 
 if [ -z "$ORACLE_REGION" ]; then
   echo "No ORACLE_REGION found.  Exiting..."
@@ -48,7 +49,7 @@ fi
 ORACLE_CLOUD_NAME="$ORACLE_REGION-$ENVIRONMENT-oracle"
 [ -e "$LOCAL_PATH/../clouds/${ORACLE_CLOUD_NAME}.sh" ] && . $LOCAL_PATH/../clouds/${ORACLE_CLOUD_NAME}.sh
 
-[ -z "$IMAGE_ARCH" ] && IMAGE_ARCH="x86_64"
+[ -z "$IMAGE_ARCH" ] && default_arch_from_type "FocalBase"
 
 if [[ "$IMAGE_ARCH" == "aarch64" ]]; then
   [ -z "$SHAPE" ] && SHAPE="$SHAPE_A_1"

--- a/scripts/build-gpu-oracle.sh
+++ b/scripts/build-gpu-oracle.sh
@@ -37,6 +37,7 @@ fi
 
 #pull in cloud-specific variables, e.g. tenancy
 [ -e "$LOCAL_PATH/../clouds/oracle.sh" ] && . $LOCAL_PATH/../clouds/oracle.sh
+[ -e "$LOCAL_PATH/image-arch.sh" ] && . $LOCAL_PATH/image-arch.sh
 
 if [ -z "$ORACLE_REGION" ]; then
   echo "No ORACLE_REGION found.  Exiting..."
@@ -48,7 +49,7 @@ fi
 ORACLE_CLOUD_NAME="$ORACLE_REGION-$ENVIRONMENT-oracle"
 [ -e "$LOCAL_PATH/../clouds/${ORACLE_CLOUD_NAME}.sh" ] && . $LOCAL_PATH/../clouds/${ORACLE_CLOUD_NAME}.sh
 
-[ -z "$IMAGE_ARCH" ] && IMAGE_ARCH="x86_64"
+[ -z "$IMAGE_ARCH" ] && default_arch_from_type "GPU"
 
 if [[ "$IMAGE_ARCH" == "aarch64" ]]; then
   [ -z "$SHAPE" ] && SHAPE="$SHAPE_A_1"

--- a/scripts/build-jammy-base-oracle.sh
+++ b/scripts/build-jammy-base-oracle.sh
@@ -37,6 +37,7 @@ fi
 
 #pull in cloud-specific variables, e.g. tenancy
 [ -e "$LOCAL_PATH/../clouds/oracle.sh" ] && . $LOCAL_PATH/../clouds/oracle.sh
+[ -e "$LOCAL_PATH/image-arch.sh" ] && . $LOCAL_PATH/image-arch.sh
 
 if [ -z "$ORACLE_REGION" ]; then
   echo "No ORACLE_REGION found.  Exiting..."
@@ -48,7 +49,7 @@ fi
 ORACLE_CLOUD_NAME="$ORACLE_REGION-$ENVIRONMENT-oracle"
 [ -e "$LOCAL_PATH/../clouds/${ORACLE_CLOUD_NAME}.sh" ] && . $LOCAL_PATH/../clouds/${ORACLE_CLOUD_NAME}.sh
 
-[ -z "$IMAGE_ARCH" ] && IMAGE_ARCH="aarch64"
+[ -z "$IMAGE_ARCH" ] && default_arch_from_type "JammyBase"
 
 if [[ "$IMAGE_ARCH" == "aarch64" ]]; then
   [ -z "$SHAPE" ] && SHAPE="$SHAPE_A_1"

--- a/scripts/build-java-jibri-oracle.sh
+++ b/scripts/build-java-jibri-oracle.sh
@@ -30,6 +30,7 @@ fi
 #pull in cloud-specific variables, e.g. tenancy
 [ -e "$LOCAL_PATH/../clouds/all.sh" ] && . $LOCAL_PATH/../clouds/all.sh
 [ -e "$LOCAL_PATH/../clouds/oracle.sh" ] && . $LOCAL_PATH/../clouds/oracle.sh
+[ -e "$LOCAL_PATH/image-arch.sh" ] && . $LOCAL_PATH/image-arch.sh
 
 if [ -z "$ORACLE_REGION" ]; then
   echo "No ORACLE_REGION found.  Exiting..."
@@ -48,7 +49,7 @@ fi
 ORACLE_CLOUD_NAME="$ORACLE_REGION-$ENVIRONMENT-oracle"
 [ -e "$LOCAL_PATH/../clouds/${ORACLE_CLOUD_NAME}.sh" ] && . $LOCAL_PATH/../clouds/${ORACLE_CLOUD_NAME}.sh
 
-[ -z "$IMAGE_ARCH" ] && IMAGE_ARCH="x86_64"
+[ -z "$IMAGE_ARCH" ] && default_arch_from_type "JavaJibri"
 
 if [[ "$IMAGE_ARCH" == "aarch64" ]]; then
   [ -z "$SHAPE" ] && SHAPE="$SHAPE_A_1"

--- a/scripts/build-jicofo-hotfix-oracle.sh
+++ b/scripts/build-jicofo-hotfix-oracle.sh
@@ -34,6 +34,7 @@ fi
 #pull in cloud-specific variables, e.g. tenancy
 [ -e "$LOCAL_PATH/../clouds/all.sh" ] && . $LOCAL_PATH/../clouds/all.sh
 [ -e "$LOCAL_PATH/../clouds/oracle.sh" ] && . $LOCAL_PATH/../clouds/oracle.sh
+[ -e "$LOCAL_PATH/image-arch.sh" ] && . $LOCAL_PATH/image-arch.sh
 
 if [ -z "$ORACLE_REGION" ]; then
   echo "No ORACLE_REGION found.  Exiting..."
@@ -63,7 +64,7 @@ PROSODY_VERSION=$(echo $BASE_SIGNAL_VERSION | cut -d'-' -f3)
 ORACLE_CLOUD_NAME="$ORACLE_REGION-$ENVIRONMENT-oracle"
 [ -e "$LOCAL_PATH/../clouds/${ORACLE_CLOUD_NAME}.sh" ] && . $LOCAL_PATH/../clouds/${ORACLE_CLOUD_NAME}.sh
 
-[ -z "$IMAGE_ARCH" ] && IMAGE_ARCH="aarch64"
+[ -z "$IMAGE_ARCH" ] && default_arch_from_type "JicofoHotfix"
 
 if [[ "$IMAGE_ARCH" == "aarch64" ]]; then
   [ -z "$SHAPE" ] && SHAPE="$SHAPE_A_1"

--- a/scripts/build-jigasi-oracle.sh
+++ b/scripts/build-jigasi-oracle.sh
@@ -24,6 +24,7 @@ LOCAL_PATH=$(realpath $(dirname "${BASH_SOURCE[0]}"))
 #pull in cloud-specific variables, e.g. tenancy
 [ -e "$LOCAL_PATH/../clouds/all.sh" ] && . $LOCAL_PATH/../clouds/all.sh
 [ -e "$LOCAL_PATH/../clouds/oracle.sh" ] && . $LOCAL_PATH/../clouds/oracle.sh
+[ -e "$LOCAL_PATH/image-arch.sh" ] && . $LOCAL_PATH/image-arch.sh
 
 if [ -z "$ORACLE_REGION" ]; then
   echo "No ORACLE_REGION found.  Exiting..."
@@ -42,7 +43,7 @@ fi
 ORACLE_CLOUD_NAME="$ORACLE_REGION-$ENVIRONMENT-oracle"
 [ -e "$LOCAL_PATH/../clouds/${ORACLE_CLOUD_NAME}.sh" ] && . $LOCAL_PATH/../clouds/${ORACLE_CLOUD_NAME}.sh
 
-[ -z "$IMAGE_ARCH" ] && IMAGE_ARCH="aarch64"
+[ -z "$IMAGE_ARCH" ] && default_arch_from_type "Jigasi"
 
 if [[ "$IMAGE_ARCH" == "aarch64" ]]; then
   [ -z "$SHAPE" ] && SHAPE="$SHAPE_A_1"

--- a/scripts/build-jvb-oracle.sh
+++ b/scripts/build-jvb-oracle.sh
@@ -35,6 +35,7 @@ fi
 #pull in cloud-specific variables, e.g. tenancy
 [ -e "$LOCAL_PATH/../clouds/all.sh" ] && . $LOCAL_PATH/../clouds/all.sh
 [ -e "$LOCAL_PATH/../clouds/oracle.sh" ] && . $LOCAL_PATH/../clouds/oracle.sh
+[ -e "$LOCAL_PATH/image-arch.sh" ] && . $LOCAL_PATH/image-arch.sh
 
 if [ -z "$ORACLE_REGION" ]; then
   echo "No ORACLE_REGION found.  Exiting..."
@@ -44,7 +45,7 @@ fi
 ORACLE_CLOUD_NAME="$ORACLE_REGION-$ENVIRONMENT-oracle"
 [ -e "$LOCAL_PATH/../clouds/${ORACLE_CLOUD_NAME}.sh" ] && . $LOCAL_PATH/../clouds/${ORACLE_CLOUD_NAME}.sh
 
-[ -z "$IMAGE_ARCH" ] && IMAGE_ARCH="aarch64"
+[ -z "$IMAGE_ARCH" ] && default_arch_from_type "JVB"
 
 if [[ "$IMAGE_ARCH" == "aarch64" ]]; then
   [ -z "$SHAPE" ] && SHAPE="$SHAPE_A_1"  

--- a/scripts/build-noble-base-oracle.sh
+++ b/scripts/build-noble-base-oracle.sh
@@ -37,6 +37,7 @@ fi
 
 #pull in cloud-specific variables, e.g. tenancy
 [ -e "$LOCAL_PATH/../clouds/oracle.sh" ] && . $LOCAL_PATH/../clouds/oracle.sh
+[ -e "$LOCAL_PATH/image-arch.sh" ] && . $LOCAL_PATH/image-arch.sh
 
 if [ -z "$ORACLE_REGION" ]; then
   echo "No ORACLE_REGION found.  Exiting..."
@@ -48,7 +49,7 @@ fi
 ORACLE_CLOUD_NAME="$ORACLE_REGION-$ENVIRONMENT-oracle"
 [ -e "$LOCAL_PATH/../clouds/${ORACLE_CLOUD_NAME}.sh" ] && . $LOCAL_PATH/../clouds/${ORACLE_CLOUD_NAME}.sh
 
-[ -z "$IMAGE_ARCH" ] && IMAGE_ARCH="aarch64"
+[ -z "$IMAGE_ARCH" ] && default_arch_from_type "NobleBase"
 
 if [[ "$IMAGE_ARCH" == "aarch64" ]]; then
   [ -z "$SHAPE" ] && SHAPE="$SHAPE_A_1"

--- a/scripts/build-selenium-grid-oracle.sh
+++ b/scripts/build-selenium-grid-oracle.sh
@@ -33,6 +33,7 @@ fi
 #pull in cloud-specific variables, e.g. tenancy
 [ -e "$LOCAL_PATH/../clouds/all.sh" ] && . $LOCAL_PATH/../clouds/all.sh
 [ -e "$LOCAL_PATH/../clouds/oracle.sh" ] && . $LOCAL_PATH/../clouds/oracle.sh
+[ -e "$LOCAL_PATH/image-arch.sh" ] && . $LOCAL_PATH/image-arch.sh
 
 if [ -z "$ORACLE_REGION" ]; then
   echo "No ORACLE_REGION found.  Exiting..."
@@ -44,7 +45,7 @@ fi
 ORACLE_CLOUD_NAME="$ORACLE_REGION-$ENVIRONMENT-oracle"
 [ -e "$LOCAL_PATH/../clouds/${ORACLE_CLOUD_NAME}.sh" ] && . $LOCAL_PATH/../clouds/${ORACLE_CLOUD_NAME}.sh
 
-[ -z "$IMAGE_ARCH" ] && IMAGE_ARCH="x86_64"
+[ -z "$IMAGE_ARCH" ] && default_arch_from_type "SeleniumGrid"
 
 if [[ "$IMAGE_ARCH" == "aarch64" ]]; then
   [ -z "$SHAPE" ] && SHAPE="$SHAPE_A_1"

--- a/scripts/build-signal-oracle.sh
+++ b/scripts/build-signal-oracle.sh
@@ -34,6 +34,7 @@ fi
 #pull in cloud-specific variables, e.g. tenancy
 [ -e "$LOCAL_PATH/../clouds/all.sh" ] && . $LOCAL_PATH/../clouds/all.sh
 [ -e "$LOCAL_PATH/../clouds/oracle.sh" ] && . $LOCAL_PATH/../clouds/oracle.sh
+[ -e "$LOCAL_PATH/image-arch.sh" ] && . $LOCAL_PATH/image-arch.sh
 
 if [ -z "$ORACLE_REGION" ]; then
   echo "No ORACLE_REGION found.  Exiting..."
@@ -45,7 +46,7 @@ fi
 ORACLE_CLOUD_NAME="$ORACLE_REGION-$ENVIRONMENT-oracle"
 [ -e "$LOCAL_PATH/../clouds/${ORACLE_CLOUD_NAME}.sh" ] && . $LOCAL_PATH/../clouds/${ORACLE_CLOUD_NAME}.sh
 
-[ -z "$IMAGE_ARCH" ] && IMAGE_ARCH="aarch64"
+[ -z "$IMAGE_ARCH" ] && default_arch_from_type "Signal"
 
 if [[ "$IMAGE_ARCH" == "aarch64" ]]; then
   [ -z "$SHAPE" ] && SHAPE="$SHAPE_A_1"

--- a/scripts/check-build-oracle-image.sh
+++ b/scripts/check-build-oracle-image.sh
@@ -12,17 +12,12 @@ fi
 LOCAL_PATH=$(dirname "${BASH_SOURCE[0]}")
 
 [ -e "$LOCAL_PATH/../clouds/oracle.sh" ] && . $LOCAL_PATH/../clouds/oracle.sh
+[ -e "$LOCAL_PATH/image-arch.sh" ] && . $LOCAL_PATH/image-arch.sh
 
 [ -z "$ORACLE_REGION" ] && ORACLE_REGION=$DEFAULT_ORACLE_REGION
 
-if [ -z "$IMAGE_ARCH" ]; then
-  # sensible default based on image type
-  if [[ "$IMAGE_TYPE" == "JavaJibri" ]]; then
-    IMAGE_ARCH="x86_64"
-  fi
-fi
-
-[ -z "$IMAGE_ARCH" ] && IMAGE_ARCH="aarch64"
+# sensible default architecture based on image type (see scripts/image-arch.sh)
+[ -z "$IMAGE_ARCH" ] && default_arch_from_type "$IMAGE_TYPE"
 
 # #pull in region-specific variables
 # [ -e "../all/regions/${ORACLE_REGION}-oracle.sh" ] && . ../all/regions/${ORACLE_REGION}-oracle.sh

--- a/scripts/image-arch.sh
+++ b/scripts/image-arch.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Single source of truth for the default image architecture per IMAGE_TYPE.
+#
+# Most image types build aarch64 by default; only the types listed below default
+# to x86_64. This is sourced by the build-*-oracle.sh scripts, by
+# check-build-oracle-image.sh, and (via Utils.groovy DefaultImageArch) by the
+# build-image-oracle Jenkins pipeline when constructing its concurrency lock, so
+# that the lock name always matches the architecture actually built.
+#
+# Sets and exports IMAGE_ARCH. Callers typically guard with:
+#   [ -z "$IMAGE_ARCH" ] && default_arch_from_type "<IMAGE_TYPE>"
+function default_arch_from_type() {
+    DTYPE="$1"
+    IMAGE_ARCH="aarch64"
+    case "$DTYPE" in
+        FocalBase|GPU|JavaJibri|SeleniumGrid)
+            IMAGE_ARCH="x86_64"
+            ;;
+    esac
+    export IMAGE_ARCH
+}


### PR DESCRIPTION
## Problem

During a routine `build-image-oracle` build with `IMAGE_ARCH` left blank, the NobleBase image correctly built as `aarch64` (the build script's default), but the Jenkins `lock()` string was constructed as `x86_64` — so the lock name (`image-build-NobleBase-x86_64`) did not match the architecture actually being built. The lock could not do its job of serializing concurrent builds of the same image+arch.

Root cause: the per-type default architecture was duplicated in many places that disagreed:
- `Jenkinsfile` hardcoded `env.IMAGE_ARCH ?: "x86_64"` for the lock.
- Each `build-*-oracle.sh` had its own inline default (most `aarch64`; only `FocalBase`/`GPU`/`JavaJibri`/`SeleniumGrid` → `x86_64`).
- `check-build-oracle-image.sh` had a *third* variant that only special-cased `JavaJibri → x86_64` (latently wrong for `GPU`/`SeleniumGrid`/`FocalBase`).

## Change

Introduce **`scripts/image-arch.sh`** as the single source of truth — `default_arch_from_type()` maps `IMAGE_TYPE → default arch` (x86_64 only for `FocalBase`, `GPU`, `JavaJibri`, `SeleniumGrid`; aarch64 otherwise). Used by:

- **Jenkinsfile lock** via a new `Utils.groovy` `DefaultImageArch()` wrapper (mirrors the existing `ImageArchFromShape`). `def imageArch = env.IMAGE_ARCH ?: utils.DefaultImageArch(env.IMAGE_TYPE)`.
- **`check-build-oracle-image.sh`** — also fixes its latent miss for `GPU`/`SeleniumGrid`/`FocalBase`.
- **All 11 `build-*-oracle.sh` scripts** — behavior-identical (each map entry reproduces that script's prior default); this just removes the duplicated literals so the default lives in one place.

> Note: the per-type map lives in a tracked `infra-provisioning` file (`scripts/image-arch.sh`) rather than `clouds/oracle.sh`, since `clouds/` is a symlink into the separate `infra-customizations-private` repo — keeping the source of truth here keeps this to a single repo/PR. It's sourced alongside `clouds/oracle.sh` using the same `[ -e ... ] &&` guard pattern.

## Verification

- `bash -n` passes on all 13 modified/new shell scripts.
- `default_arch_from_type` spot-check returns `x86_64` only for `FocalBase`/`GPU`/`JavaJibri`/`SeleniumGrid`, `aarch64` for everything else (incl. unknown types and `coTURN`/`CoTURN`).
- Explicit `IMAGE_ARCH` is still respected (the `[ -z "$IMAGE_ARCH" ] &&` guard is unchanged).
- Recommended end-to-end check after merge: run `build-image-oracle` for `NobleBase` with blank `IMAGE_ARCH` and confirm the log shows the lock acquired as `image-build-NobleBase-aarch64` and packer running `image_architecture=aarch64`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)