### PR TITLE
feat: Jenkins job to build ops-agent docker image

### DIFF
--- a/jenkins/groovy/build-docker-image-ops-agent/Jenkinsfile
+++ b/jenkins/groovy/build-docker-image-ops-agent/Jenkinsfile
@@ -1,0 +1,27 @@
+pipeline {
+    agent any
+    options {
+        ansiColor('xterm')
+        timestamps()
+        buildDiscarder(logRotator(numToKeepStr: '10', artifactNumToKeepStr: '10'))
+    }
+    stages {
+        stage('Build and Push Docker Image') {
+            steps {
+                withCredentials([usernamePassword(credentialsId: 'dockerhub', usernameVariable: 'DOCKER_USER', passwordVariable: 'DOCKER_PASS')]) {
+                    dir('docker/ops-agent') {
+                        sh '''#!/bin/bash
+                        DOCKER_AUTH=$(echo -n "$DOCKER_USER:$DOCKER_PASS" | base64)
+                        export DOCKER_CONFIG="$(pwd)/.docker-ops-agent"
+                        mkdir -p "$DOCKER_CONFIG"
+                        echo '{"auths":{"https://index.docker.io/v1/":{"auth":"'"$DOCKER_AUTH"'"}}}' > "$DOCKER_CONFIG/config.json"
+                        docker buildx create --name mybuilder --driver docker-container --bootstrap --use
+                        [ -z "$TAG" ] && export TAG="$(git rev-parse --short HEAD)"
+                        ./build.sh
+                        '''
+                    }
+                }
+            }
+        }
+    }
+}

--- a/jenkins/jobs/build-docker-image-ops-agent.yaml
+++ b/jenkins/jobs/build-docker-image-ops-agent.yaml
@@ -1,0 +1,30 @@
+- job:
+    name: build-docker-image-ops-agent
+    display-name: build docker image ops-agent
+    concurrent: false
+    parameters:
+      - string:
+          name: VIDEO_INFRA_BRANCH
+          default: main
+          description: "Controls checkout branch for infra repos, defaults to 'main'."
+          trim: true
+      - string:
+          name: TAG
+          description: "Docker image tag; defaults to git short hash if not set."
+          trim: true
+
+    project-type: pipeline
+    sandbox: true
+    pipeline-scm:
+      scm:
+        - git:
+            url: git@github.com:jitsi/infra-provisioning.git
+            credentials-id: "video-infra"
+            branches:
+              - "origin/${{VIDEO_INFRA_BRANCH}}"
+            browser: githubweb
+            browser-url: https://github.com/jitsi/infra-provisioning
+            submodule:
+              recursive: true
+      script-path: jenkins/groovy/build-docker-image-ops-agent/Jenkinsfile
+      lightweight-checkout: true


### PR DESCRIPTION
## Summary
Adds a new Jenkins job that builds and pushes the `ops-agent` Docker image, modeled on the existing `build-docker-image-ops-jenkins` job.

- `jenkins/jobs/build-docker-image-ops-agent.yaml` — JJB pipeline job definition with `VIDEO_INFRA_BRANCH` and `TAG` parameters.
- `jenkins/groovy/build-docker-image-ops-agent/Jenkinsfile` — runs in `docker/ops-agent`, configures dockerhub credentials + a buildx builder, defaults `TAG` to the git short hash, then runs `./build.sh`.

The existing `docker/ops-agent/build.sh` already performs the multi-arch `buildx ... --push` to `aaronkvanmeerten/ops-agent:$TAG` and `:latest`, so no changes were needed there.

## Test plan
- [x] JJB validates the new job YAML
- [x] Run the job and confirm the multi-arch `ops-agent` image is pushed to dockerhub

🤖 Generated with [Claude Code](https://claude.com/claude-code)