### PR TITLE
feat(vector,loki): reduce infra self-log volume

### DIFF
--- a/nomad/loki-cluster.hcl
+++ b/nomad/loki-cluster.hcl
@@ -95,6 +95,8 @@ job "[JOB_NAME]" {
   server:
     http_listen_port: {{ env "NOMAD_HOST_PORT_http" }}
     http_listen_address: 0.0.0.0
+    # reduce Loki self-log volume (default is info, which is very chatty)
+    log_level: warn
     grpc_listen_port: {{ env "NOMAD_HOST_PORT_grpc" }}
     grpc_listen_address: 0.0.0.0
 

--- a/nomad/loki.hcl
+++ b/nomad/loki.hcl
@@ -74,8 +74,6 @@ job "[JOB_NAME]" {
 auth_enabled: false
 server:
   http_listen_port: 3100
-  # reduce Loki self-log volume (default is info, which is very chatty)
-  log_level: warn
 
 ingester:
   lifecycler:

--- a/nomad/loki.hcl
+++ b/nomad/loki.hcl
@@ -74,6 +74,8 @@ job "[JOB_NAME]" {
 auth_enabled: false
 server:
   http_listen_port: 3100
+  # reduce Loki self-log volume (default is info, which is very chatty)
+  log_level: warn
 
 ingester:
   lifecycler:

--- a/nomad/vector.hcl
+++ b/nomad/vector.hcl
@@ -185,7 +185,9 @@ job "[JOB_NAME]" {
               {}
             . = merge(., structured) ?? .
             .timestamp = parse_timestamp(.ts, "%+") ?? .timestamp"""
-          # drop Fabio health-check and internal-push access logs to reduce volume
+          # drop Fabio health-check and internal-push access logs to reduce volume.
+          # only drop successful (200/204) requests so failing pushes/health-checks
+          # are still logged for debugging.
           [transforms.logs_drop_noise]
             type = "filter"
             inputs = ["logs"]
@@ -193,8 +195,9 @@ job "[JOB_NAME]" {
             name = to_string(.container_name) ?? ""
             is_fabio = starts_with(name, "int-fabio") || starts_with(name, "ext-fabio")
             msg = to_string(.message) ?? ""
-            is_noise = match(msg, r'"(GET /health|GET /-/healthy|POST /loki/api/v1/push|POST /api/v1/write|POST /otlp/v1/logs|POST /v1/logs|POST /v1/metrics|POST /v1/traces)') || match(msg, r'Consul Health Check')
-            !(is_fabio && is_noise)
+            is_endpoint = match(msg, r'"(GET /health|GET /-/healthy|POST /loki/api/v1/push|POST /api/v1/write|POST /otlp/v1/logs|POST /v1/logs|POST /v1/metrics|POST /v1/traces) HTTP/[^"]+" (200|204) ')
+            is_consul = match(msg, r'Consul Health Check') && match(msg, r'" (200|204) ')
+            !(is_fabio && (is_endpoint || is_consul))
             '''
           [transforms.message_to_structure]
             type = "remap"

--- a/nomad/vector.hcl
+++ b/nomad/vector.hcl
@@ -131,10 +131,15 @@ job "[JOB_NAME]" {
             type = "syslog"
             address = "0.0.0.0:9000"
             mode = "tcp"
+          # drop Loki self-logs at info/debug to reduce volume (keep warn and above)
+          [transforms.loki_drop_noise]
+            type = "filter"
+            inputs = ["loki_to_structure"]
+            condition = '!includes(["info", "debug"], to_string(.level) ?? "info")'
           [sinks.loki_lokilogs]
             remove_timestamp = false
             type = "loki"
-            inputs = ["loki_to_structure"]
+            inputs = ["loki_drop_noise"]
             endpoint = "[[ if ne "${var.loki_endpoint}" "" ]]${var.loki_endpoint}[[ else ]]https://[[ env "meta.environment" ]]-[[ env "meta.cloud_region" ]]-loki.${var.top_level_domain}[[ end ]]"
             encoding.codec = "json"
             healthcheck.enabled = true
@@ -180,9 +185,20 @@ job "[JOB_NAME]" {
               {}
             . = merge(., structured) ?? .
             .timestamp = parse_timestamp(.ts, "%+") ?? .timestamp"""
+          # drop Fabio health-check and internal-push access logs to reduce volume
+          [transforms.logs_drop_noise]
+            type = "filter"
+            inputs = ["logs"]
+            condition = '''
+            name = to_string(.container_name) ?? ""
+            is_fabio = starts_with(name, "int-fabio") || starts_with(name, "ext-fabio")
+            msg = to_string(.message) ?? ""
+            is_noise = match(msg, r'"(GET /health|GET /-/healthy|POST /loki/api/v1/push|POST /api/v1/write)') || match(msg, r'Consul Health Check')
+            !(is_fabio && is_noise)
+            '''
           [transforms.message_to_structure]
             type = "remap"
-            inputs = ["logs","jibri_logs","jicofo_logs","jvb_logs","prosody_logs"]
+            inputs = ["logs_drop_noise","jibri_logs","jicofo_logs","jvb_logs","prosody_logs"]
             source = """
             structured =
               parse_json(.message) ??

--- a/nomad/vector.hcl
+++ b/nomad/vector.hcl
@@ -193,7 +193,7 @@ job "[JOB_NAME]" {
             name = to_string(.container_name) ?? ""
             is_fabio = starts_with(name, "int-fabio") || starts_with(name, "ext-fabio")
             msg = to_string(.message) ?? ""
-            is_noise = match(msg, r'"(GET /health|GET /-/healthy|POST /loki/api/v1/push|POST /api/v1/write)') || match(msg, r'Consul Health Check')
+            is_noise = match(msg, r'"(GET /health|GET /-/healthy|POST /loki/api/v1/push|POST /api/v1/write|POST /otlp/v1/logs|POST /v1/logs|POST /v1/metrics|POST /v1/traces)') || match(msg, r'Consul Health Check')
             !(is_fabio && is_noise)
             '''
           [transforms.message_to_structure]


### PR DESCRIPTION
## Summary
Infrastructure self-logs dominate prod-8x8 Loki ingest (a volume review after the Vector→Alloy migration showed `loki-*` and `fabio` as the top producers, ahead of application logs). This cuts the noise at both the producer and in Vector.

## Changes
- **`nomad/loki-cluster.hcl`** — set `server.log_level: warn` (default `info` is very chatty: compaction, flushes, per-request 200s). This is the deployed Loki config (v3.5.9, memberlist) used by `deploy-nomad-loki.sh`; the legacy single-node `loki.hcl` is not deployed.
- **`nomad/vector.hcl`** — add `loki_drop_noise` filter that drops Loki self-logs at `info`/`debug` (keeps `warn`+), repoint the `loki_lokilogs` sink to it.
- **`nomad/vector.hcl`** — add `logs_drop_noise` filter that drops Fabio health-check / internal-push access lines (`GET /health`, `GET /-/healthy`, `POST /loki/api/v1/push` 204, `POST /api/v1/write` 204, Consul Health Check). Real 4xx/5xx routing diagnostics are preserved.

Filtering happens in Vector **before** logs reach Loki, so this saves ingest, storage and cost — not just query-time noise.

## Rollout plan
- Validate on **lonely** + **ops-dev** first, then **stage-8x8**.
- Roll out via `provision-nomad-vector` + `provision-nomad-loki`. Central change, so a redeploy applies per-environment.
- Prod rollout under a separate RP (TBD), careful given the recent exit-78 episode.
- Verify post-deploy with the `topk by (service_name)` volume query against the OCI Loki tenant.

## Tickets
- JIT-15909
- Related: RP-103167 (Vector→Alloy migration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)