### PR TITLE
feat(jicofo): wire jibri busy-retries env vars for nomad shards

### DIFF
--- a/nomad/jitsi_packs/packs/jitsi_meet_backend/templates/jitsi_meet_backend.nomad.tpl
+++ b/nomad/jitsi_packs/packs/jitsi_meet_backend/templates/jitsi_meet_backend.nomad.tpl
@@ -929,7 +929,7 @@ EOF
         JICOFO_CONF_SOURCE_SIGNALING_DELAYS="[[ or (env "CONFIG_jicofo_source_signaling_delay") "{ 50: 1000, 100: 2000 }" ]]"
         JIBRI_PENDING_TIMEOUT="[[ or (env "CONFIG_jicofo_jibri_pending_timeout") "90" ]] seconds"
         JIBRI_BUSY_RETRIES="[[ env "CONFIG_jicofo_jibri_busy_retries" ]]"
-        JIBRI_BUSY_RETRY_DELAY="[[ env "CONFIG_jicofo_jibri_busy_retry_delay" ]]"
+        JIBRI_BUSY_RETRY_DELAY="[[ if (env "CONFIG_jicofo_jibri_busy_retry_delay") ]][[ env "CONFIG_jicofo_jibri_busy_retry_delay" ]] seconds[[ end ]]"
         JICOFO_MAX_MEMORY="1536m"
         JICOFO_BRIDGE_REGION_GROUPS = "[\"eu-central-1\", \"eu-west-1\", \"eu-west-2\", \"eu-west-3\", \"uk-london-1\", \"eu-amsterdam-1\", \"eu-frankfurt-1\"],[\"us-east-1\", \"us-west-2\", \"us-ashburn-1\", \"us-phoenix-1\"],[\"ap-mumbai-1\", \"ap-tokyo-1\", \"ap-south-1\", \"ap-northeast-1\"],[\"ap-sydney-1\", \"ap-southeast-2\"],[\"ca-toronto-1\", \"ca-central-1\"],[\"me-jeddah-1\", \"me-south-1\"],[\"sa-saopaulo-1\", \"sa-east-1\"]"
         JICOFO_ENABLE_HEALTH_CHECKS="1"

--- a/nomad/jitsi_packs/packs/jitsi_meet_backend/templates/jitsi_meet_backend.nomad.tpl
+++ b/nomad/jitsi_packs/packs/jitsi_meet_backend/templates/jitsi_meet_backend.nomad.tpl
@@ -928,6 +928,8 @@ EOF
         JICOFO_MULTI_STREAM_BACKWARD_COMPAT="1"
         JICOFO_CONF_SOURCE_SIGNALING_DELAYS="[[ or (env "CONFIG_jicofo_source_signaling_delay") "{ 50: 1000, 100: 2000 }" ]]"
         JIBRI_PENDING_TIMEOUT="[[ or (env "CONFIG_jicofo_jibri_pending_timeout") "90" ]] seconds"
+        JIBRI_BUSY_RETRIES="[[ env "CONFIG_jicofo_jibri_busy_retries" ]]"
+        JIBRI_BUSY_RETRY_DELAY="[[ env "CONFIG_jicofo_jibri_busy_retry_delay" ]]"
         JICOFO_MAX_MEMORY="1536m"
         JICOFO_BRIDGE_REGION_GROUPS = "[\"eu-central-1\", \"eu-west-1\", \"eu-west-2\", \"eu-west-3\", \"uk-london-1\", \"eu-amsterdam-1\", \"eu-frankfurt-1\"],[\"us-east-1\", \"us-west-2\", \"us-ashburn-1\", \"us-phoenix-1\"],[\"ap-mumbai-1\", \"ap-tokyo-1\", \"ap-south-1\", \"ap-northeast-1\"],[\"ap-sydney-1\", \"ap-southeast-2\"],[\"ca-toronto-1\", \"ca-central-1\"],[\"me-jeddah-1\", \"me-south-1\"],[\"sa-saopaulo-1\", \"sa-east-1\"]"
         JICOFO_ENABLE_HEALTH_CHECKS="1"


### PR DESCRIPTION
## What

Adds two env vars to the jicofo task in the `jitsi_meet_backend` nomad pack, driven by optional `CONFIG_*` values:

- `JIBRI_BUSY_RETRIES` ← `CONFIG_jicofo_jibri_busy_retries`
- `JIBRI_BUSY_RETRY_DELAY` ← `CONFIG_jicofo_jibri_busy_retry_delay`

Both are empty unless configured, so the feature is **off by default**.

## Why

When all Jibri instances are momentarily busy (demand spike at the top of the hour while the autoscaler catches up, or two requests racing for the last free instance), jicofo currently fails the recording start immediately. The new jicofo `busy-retries` feature (jitsi/jicofo#1288) lets it wait briefly for the pool to free up.

## Dependency

The nomad shards build `/config/jicofo.conf` from the docker image template, which must map these env vars to the `busy-retries` / `busy-retry-delay` HOCON keys. That mapping is added in the companion **docker-jitsi-meet** PR (mirrors the existing `JIBRI_REQUEST_RETRIES`→`num-retries` pattern). Until that image change ships, these env vars are inert.

## Related
- jicofo: jitsi/jicofo#1288
- ansible path: jitsi/infra-configuration#924

🤖 Generated with [Claude Code](https://claude.com/claude-code)