### PR TITLE
fix: migrate jicofo/jvb/jibri/prosody/web to s6-overlay v3 / rootless

### DIFF
--- a/nomad/jibri.hcl
+++ b/nomad/jibri.hcl
@@ -161,12 +161,26 @@ job "[JOB_NAME]" {
         ports = ["http"]
         volumes = [
           "local/xmpp-servers:/opt/jitsi/xmpp-servers",
-          "local/01-xmpp-servers:/etc/cont-init.d/01-xmpp-servers",
-          "local/11-status-cron:/etc/cont-init.d/11-status-cron",
           "local/reload-config.sh:/opt/jitsi/scripts/reload-config.sh",
           "local/jibri-status.sh:/opt/jitsi/scripts/jibri-status.sh",
-          "local/cron-service-run:/etc/services.d/60-cron/run",
-          "local/config:/config"
+          "local/config:/config",
+          # Migrated to s6-overlay v3 / rootless.
+          #
+          # env oneshot: seeds JIBRI_VERSION / XMPP_SERVER into the s6 container
+          # environment, ordered before the image's 01-config.
+          "local/jibri-env-type:/etc/s6-overlay/s6-rc.d/00-jibri-env/type",
+          "local/jibri-env-up:/etc/s6-overlay/s6-rc.d/00-jibri-env/up",
+          "local/jibri-env-contents:/etc/s6-overlay/s6-rc.d/user/contents.d/00-jibri-env",
+          "local/jibri-env-config-dep:/etc/s6-overlay/s6-rc.d/01-config/dependencies.d/00-jibri-env",
+          "local/jibri-env-script:/etc/s6-overlay/scripts/jibri-env",
+          # status reporter: replaces the old cron (cron + netcat are not in the
+          # rootless image and can't be apt-installed at runtime). A v3 longrun
+          # loops every 60s; jibri-status.sh now sends statsd over bash /dev/udp.
+          "local/jibri-status-type:/etc/s6-overlay/s6-rc.d/60-jibri-status/type",
+          "local/jibri-status-run:/etc/s6-overlay/s6-rc.d/60-jibri-status/run",
+          "local/jibri-status-dep:/etc/s6-overlay/s6-rc.d/60-jibri-status/dependencies.d/40-jibri",
+          "local/jibri-status-contents:/etc/s6-overlay/s6-rc.d/user/contents.d/60-jibri-status",
+          "local/jibri-status-loop:/etc/s6-overlay/scripts/jibri-status-loop"
     	  ]
       }
       volume_mount {
@@ -229,16 +243,50 @@ EOF
         destination = "secrets/asap.key"
       }
 
+      # --- 00-jibri-env: oneshot seeding JIBRI_VERSION / XMPP_SERVER into the s6
+      # container environment, ordered before the image's 01-config. The script
+      # both exports (so reload-config.sh can source it) and writes the s6
+      # container_environment (so longrun services started later see the values). ---
       template {
         data = <<EOF
-#!/usr/bin/with-contenv bash
-export JIBRI_VERSION="$(dpkg -s jibri | grep Version | awk '{print $2}' | sed 's/..$//')"
-echo -n "$JIBRI_VERSION" > /var/run/s6/container_environment/JIBRI_VERSION
-
-export XMPP_SERVER="$(cat /opt/jitsi/xmpp-servers/servers)"
-echo -n "$XMPP_SERVER" > /var/run/s6/container_environment/XMPP_SERVER
+oneshot
 EOF
-        destination = "local/01-xmpp-servers"
+        destination = "local/jibri-env-type"
+        perms = "644"
+      }
+      template {
+        data = <<EOF
+/etc/s6-overlay/scripts/jibri-env
+EOF
+        destination = "local/jibri-env-up"
+        perms = "644"
+      }
+      template {
+        data = <<EOF
+# managed by nomad
+EOF
+        destination = "local/jibri-env-contents"
+        perms = "644"
+      }
+      template {
+        data = <<EOF
+# managed by nomad
+EOF
+        destination = "local/jibri-env-config-dep"
+        perms = "644"
+      }
+      template {
+        data = <<EOF
+#!/command/with-contenv bash
+JIBRI_VERSION="$(dpkg -s jibri | grep Version | awk '{print $2}' | sed 's/..$//')"
+export JIBRI_VERSION
+printf '%s' "$JIBRI_VERSION" > /run/s6/container_environment/JIBRI_VERSION
+
+XMPP_SERVER="$(cat /opt/jitsi/xmpp-servers/servers)"
+export XMPP_SERVER
+printf '%s' "$XMPP_SERVER" > /run/s6/container_environment/XMPP_SERVER
+EOF
+        destination = "local/jibri-env-script"
         perms = "755"
       }
 
@@ -264,46 +312,66 @@ EOF
       }
       template {
         data = <<EOF
-#!/usr/bin/with-contenv bash
+#!/command/with-contenv bash
 
-. /etc/cont-init.d/01-xmpp-servers
-/etc/cont-init.d/10-config
+# Refresh XMPP_SERVER from the updated servers file, re-render config into
+# /run/jibri/config, then ask jibri to reconnect to the new shard list.
+. /etc/s6-overlay/scripts/jibri-env
+/etc/s6-overlay/scripts/config
 /opt/jitsi/jibri/reload.sh
-cp /etc/jitsi/jibri/* /config
 EOF
         destination = "local/reload-config.sh"
         perms = "755"
       }
 
+      # --- 60-jibri-status: v3 longrun that runs jibri-status.sh every 60s,
+      # replacing the old per-minute cron (cron is not in the rootless image). ---
       template {
         data = <<EOF
-#!/usr/bin/with-contenv bash
-cp /etc/jitsi/jibri/* /config
-
-apt-get update && apt-get -y install cron netcat-openbsd
-
-echo '* * * * * /opt/jitsi/scripts/jibri-status.sh' | crontab 
-
+longrun
 EOF
-        destination = "local/11-status-cron"
+        destination = "local/jibri-status-type"
+        perms = "644"
+      }
+      template {
+        data = <<EOF
+#!/command/execlineb -P
+
+/etc/s6-overlay/scripts/jibri-status-loop
+EOF
+        destination = "local/jibri-status-run"
+        perms = "755"
+      }
+      template {
+        data = <<EOF
+# managed by nomad
+EOF
+        destination = "local/jibri-status-dep"
+        perms = "644"
+      }
+      template {
+        data = <<EOF
+# managed by nomad
+EOF
+        destination = "local/jibri-status-contents"
+        perms = "644"
+      }
+      template {
+        data = <<EOF
+#!/command/with-contenv bash
+
+while true; do
+  sleep 60
+  /opt/jitsi/scripts/jibri-status.sh
+done
+EOF
+        destination = "local/jibri-status-loop"
         perms = "755"
       }
 
       template {
         data = <<EOF
-#!/usr/bin/with-contenv bash
-
-exec cron -f
-
-EOF
-        destination = "local/cron-service-run"
-        perms = "755"
-
-      }
-
-      template {
-        data = <<EOF
-#!/usr/bin/with-contenv bash
+#!/command/with-contenv bash
 
 [ -z "$JIBRI_STATSD_HOST" ] && JIBRI_STATSD_HOST="localhost"
 [ -z "$JIBRI_STATSD_PORT" ] && JIBRI_STATSD_PORT="8125"
@@ -313,7 +381,6 @@ EOF
 JIBRI_STATSD_TAGS="role:java-jibri,jibri_version:$JIBRI_VERSION,jibri:$JIBRI_INSTANCE_ID"
 
 CURL_BIN="/usr/bin/curl"
-NC_BIN="/bin/nc"
 
 STATUS_URL="http://localhost:$JIBRI_HTTP_API_EXTERNAL_PORT/jibri/api/v1.0/health"
 
@@ -355,10 +422,14 @@ if [[ $healthyValue -eq 0 ]]; then
     availableValue=0
 fi
 
-# send metrics to statsd
-echo "jibri.available:$availableValue|g|#$JIBRI_STATSD_TAGS" | $NC_BIN -C -w 1 -u $JIBRI_STATSD_HOST $JIBRI_STATSD_PORT
-echo "jibri.healthy:$healthyValue|g|#$JIBRI_STATSD_TAGS" | $NC_BIN -C -w 1 -u $JIBRI_STATSD_HOST $JIBRI_STATSD_PORT
-echo "jibri.recording:$recordingValue|g|#$JIBRI_STATSD_TAGS" | $NC_BIN -C -w 1 -u $JIBRI_STATSD_HOST $JIBRI_STATSD_PORT
+# send metrics to statsd over UDP via bash /dev/udp (netcat is not in the
+# rootless image). Each redirection opens, writes one datagram, and closes.
+sendStatsd() {
+    echo "$1" > "/dev/udp/$JIBRI_STATSD_HOST/$JIBRI_STATSD_PORT" 2>/dev/null || true
+}
+sendStatsd "jibri.available:$availableValue|g|#$JIBRI_STATSD_TAGS"
+sendStatsd "jibri.healthy:$healthyValue|g|#$JIBRI_STATSD_TAGS"
+sendStatsd "jibri.recording:$recordingValue|g|#$JIBRI_STATSD_TAGS"
 
 EOF
         destination = "local/jibri-status.sh"

--- a/nomad/jitsi_packs/packs/jitsi_meet_backend/templates/jitsi_meet_backend.nomad.tpl
+++ b/nomad/jitsi_packs/packs/jitsi_meet_backend/templates/jitsi_meet_backend.nomad.tpl
@@ -534,14 +534,19 @@ EOF
         force_pull = [[ or (env "CONFIG_force_pull") "false" ]]
         image        = "[[ env "CONFIG_prosody_repo" ]]:[[ env "CONFIG_prosody_tag" ]]"
         ports = ["prosody-http","prosody-client"]
-        # TODO(JIT-15926): same s6-overlay v3 / rootless migration needed here as
-        # for jicofo below. The v1 /etc/cont-init.d mount + #!/usr/bin/with-contenv
-        # shebang will 127-crash prosody on the new image, and patch-prosody.sh's
-        # `sed -i` on /usr/lib/prosody (read-only root) cannot work at runtime --
-        # move the mod_c2s log-level tweak into prosody config or drop it.
         volumes = [
-          "local/patch-prosody.sh:/etc/cont-init.d/08-patch-prosody",
           "local/config:/config",
+          # Migrated to s6-overlay v3 / rootless. patch-prosody is now an 08-patch-
+          # prosody oneshot (ordered before 10-config) that overrides core mod_c2s
+          # via /prosody-plugins-custom (searched before the core module dir) since
+          # the unprivileged user cannot write /usr/lib/prosody. Best-effort: it
+          # never fails the container, so prosody falls back to the core module if
+          # the plugin dir is not writable.
+          "local/patch-prosody-type:/etc/s6-overlay/s6-rc.d/08-patch-prosody/type",
+          "local/patch-prosody-up:/etc/s6-overlay/s6-rc.d/08-patch-prosody/up",
+          "local/patch-prosody-contents:/etc/s6-overlay/s6-rc.d/user/contents.d/08-patch-prosody",
+          "local/patch-prosody-config-dep:/etc/s6-overlay/s6-rc.d/10-config/dependencies.d/08-patch-prosody",
+          "local/patch-prosody-script:/etc/s6-overlay/scripts/patch-prosody",
         ]
         labels {
           release = "[[ env "CONFIG_release_number" ]]"
@@ -590,20 +595,62 @@ EOF
 [[- end ]]
       }
 
+      # --- 08-patch-prosody: oneshot (ordered before 10-config) ---
       template {
         data = <<EOF
-#!/usr/bin/with-contenv bash
-sed -i 's/"debug", "Client XML parse error/"info", "Client XML parse error/' /usr/lib/prosody/modules/mod_c2s.lua
+oneshot
 EOF
-        destination = "local/patch-prosody.sh"
+        destination = "local/patch-prosody-type"
+        perms = "644"
+      }
+      template {
+        data = <<EOF
+/etc/s6-overlay/scripts/patch-prosody
+EOF
+        destination = "local/patch-prosody-up"
+        perms = "644"
+      }
+      template {
+        data = <<EOF
+# managed by nomad
+EOF
+        destination = "local/patch-prosody-contents"
+        perms = "644"
+      }
+      template {
+        data = <<EOF
+# managed by nomad
+EOF
+        destination = "local/patch-prosody-config-dep"
+        perms = "644"
+      }
+      template {
+        data = <<EOF
+#!/command/with-contenv bash
+# Override core mod_c2s with a copy that logs "Client XML parse error" at info
+# instead of debug. /prosody-plugins-custom is searched before the core module
+# dir. The unprivileged user cannot write /usr/lib/prosody, hence the copy.
+# Best-effort: always exits 0 so a non-writable plugin dir never crashes prosody
+# (it just falls back to the unpatched core module).
+SRC=/usr/lib/prosody/modules/mod_c2s.lua
+DST=/prosody-plugins-custom/mod_c2s.lua
+if mkdir -p /prosody-plugins-custom 2>/dev/null && cp "$SRC" "$DST" 2>/dev/null; then
+  sed -i 's/"debug", "Client XML parse error/"info", "Client XML parse error/' "$DST" 2>/dev/null || true
+else
+  echo "patch-prosody: could not write $DST; using core mod_c2s unpatched"
+fi
+exit 0
+EOF
+        destination = "local/patch-prosody-script"
         perms = "755"
       }
 
 [[ if eq (or (env "CONFIG_jigasi_vault_enabled") "true") "true" ]]
       template {
         data = <<EOF
-#!/usr/bin/with-contenv bash
-PROSODY_CFG="/config/prosody.cfg.lua"
+#!/command/with-contenv bash
+# The rootless image renders the live config under /run/prosody/config.
+PROSODY_CFG="/run/prosody/config/prosody.cfg.lua"
 
 . /secrets/jigasi_xmpp
 prosodyctl --config $PROSODY_CFG register $JIGASI_XMPP_USER $XMPP_AUTH_DOMAIN $JIGASI_XMPP_PASSWORD

--- a/nomad/jitsi_packs/packs/jitsi_meet_backend/templates/jitsi_meet_backend.nomad.tpl
+++ b/nomad/jitsi_packs/packs/jitsi_meet_backend/templates/jitsi_meet_backend.nomad.tpl
@@ -902,7 +902,16 @@ EOF
           "local/rtcstats-push-dep:/etc/s6-overlay/s6-rc.d/60-jicofo-rtcstats-push/dependencies.d/jicofo",
           "local/rtcstats-push-contents:/etc/s6-overlay/s6-rc.d/user/contents.d/60-jicofo-rtcstats-push",
           "local/jicofo-rtcstats-push-script:/etc/s6-overlay/scripts/jicofo-rtcstats-push",
-          "local/jicofo-rtcstats-push:/opt/jicofo-rtcstats-push"
+          "local/jicofo-rtcstats-push:/opt/jicofo-rtcstats-push",
+          # Periodic in-place truncation of JICOFO_LOG_FILE. Safe now that the
+          # image tees with -a (append) -- docker-jitsi-meet#2268 -- so writes go
+          # to EOF and an in-place truncate actually shrinks the file without
+          # restarting jicofo.
+          "local/log-truncate-type:/etc/s6-overlay/s6-rc.d/62-jicofo-log-truncate/type",
+          "local/log-truncate-run:/etc/s6-overlay/s6-rc.d/62-jicofo-log-truncate/run",
+          "local/log-truncate-dep:/etc/s6-overlay/s6-rc.d/62-jicofo-log-truncate/dependencies.d/jicofo",
+          "local/log-truncate-contents:/etc/s6-overlay/s6-rc.d/user/contents.d/62-jicofo-log-truncate",
+          "local/jicofo-log-truncate-script:/etc/s6-overlay/scripts/jicofo-log-truncate"
         ]
         labels {
           release = "[[ env "CONFIG_release_number" ]]"
@@ -958,6 +967,9 @@ EOF
         # uid-1000 user may not be able to write the Nomad alloc dir (/local) on the
         # rootless image.
         JICOFO_LOG_FILE = "/tmp/jicofo.log"
+        # How often (seconds) the 62-jicofo-log-truncate service truncates the log
+        # above. Defaults to hourly, matching the old cron behaviour.
+        JICOFO_LOG_TRUNCATE_INTERVAL = "[[ or (env "CONFIG_jicofo_log_truncate_interval") "3600" ]]"
         VISITORS_XMPP_AUTH_DOMAIN="auth.[[ env "CONFIG_domain" ]]"
       }
 
@@ -1021,6 +1033,65 @@ EOF
 exec node /opt/jicofo-rtcstats-push/app.js
 EOF
         destination = "local/jicofo-rtcstats-push-script"
+        perms = "755"
+      }
+
+      # --- jicofo-log-truncate as an s6-overlay v3 longrun service ---
+      # type
+      template {
+        data = <<EOF
+longrun
+EOF
+        destination = "local/log-truncate-type"
+        perms = "644"
+      }
+
+      # run: execlineb wrapper that execs our bash service body
+      template {
+        data = <<EOF
+#!/command/execlineb -P
+
+/etc/s6-overlay/scripts/jicofo-log-truncate
+EOF
+        destination = "local/log-truncate-run"
+        perms = "755"
+      }
+
+      # dependencies.d/jicofo: start after jicofo (which creates/writes the log).
+      template {
+        data = <<EOF
+# managed by nomad
+EOF
+        destination = "local/log-truncate-dep"
+        perms = "644"
+      }
+
+      # user/contents.d entry: registers the service in the user bundle.
+      template {
+        data = <<EOF
+# managed by nomad
+EOF
+        destination = "local/log-truncate-contents"
+        perms = "644"
+      }
+
+      # service body. Periodically truncates JICOFO_LOG_FILE in place. Safe now
+      # that the image tees with -a (docker-jitsi-meet#2268): writes go to EOF, so
+      # truncation actually shrinks the file and the rtcstats-push tailer resyncs.
+      template {
+        data = <<EOF
+#!/command/with-contenv bash
+
+# Nothing to do if no log file is configured; stay up so s6-rc is happy.
+[ -z "$JICOFO_LOG_FILE" ] && exec sleep infinity
+
+# JICOFO_LOG_TRUNCATE_INTERVAL is always set by the task env (defaults to 3600).
+while true; do
+  sleep "$JICOFO_LOG_TRUNCATE_INTERVAL"
+  : > "$JICOFO_LOG_FILE"
+done
+EOF
+        destination = "local/jicofo-log-truncate-script"
         perms = "755"
       }
 

--- a/nomad/jitsi_packs/packs/jitsi_meet_backend/templates/jitsi_meet_backend.nomad.tpl
+++ b/nomad/jitsi_packs/packs/jitsi_meet_backend/templates/jitsi_meet_backend.nomad.tpl
@@ -534,6 +534,11 @@ EOF
         force_pull = [[ or (env "CONFIG_force_pull") "false" ]]
         image        = "[[ env "CONFIG_prosody_repo" ]]:[[ env "CONFIG_prosody_tag" ]]"
         ports = ["prosody-http","prosody-client"]
+        # TODO(JIT-15926): same s6-overlay v3 / rootless migration needed here as
+        # for jicofo below. The v1 /etc/cont-init.d mount + #!/usr/bin/with-contenv
+        # shebang will 127-crash prosody on the new image, and patch-prosody.sh's
+        # `sed -i` on /usr/lib/prosody (read-only root) cannot work at runtime --
+        # move the mod_c2s log-level tweak into prosody config or drop it.
         volumes = [
           "local/patch-prosody.sh:/etc/cont-init.d/08-patch-prosody",
           "local/config:/config",
@@ -888,9 +893,16 @@ EOF
         ports = ["jicofo-http"]
         volumes = [
           "local/config:/config",
-          "local/jicofo-service-run:/etc/services.d/jicofo/run",
-          "local/11-jicofo-rtcstats-push:/etc/cont-init.d/11-jicofo-rtcstats-push",
-          "local/jicofo-rtcstats-push-service-run:/etc/services.d/60-jicofo-rtcstats-push/run"
+          # rtcstats-push sidecar, migrated to the s6-overlay v3 (s6-rc.d) layout.
+          # The image (rootless, uid 1000, read-only root) ships its own jicofo
+          # longrun service and nodejs, so we no longer override the main service
+          # run script nor apt-get/unzip anything at runtime.
+          "local/rtcstats-push-type:/etc/s6-overlay/s6-rc.d/60-jicofo-rtcstats-push/type",
+          "local/rtcstats-push-run:/etc/s6-overlay/s6-rc.d/60-jicofo-rtcstats-push/run",
+          "local/rtcstats-push-dep:/etc/s6-overlay/s6-rc.d/60-jicofo-rtcstats-push/dependencies.d/jicofo",
+          "local/rtcstats-push-contents:/etc/s6-overlay/s6-rc.d/user/contents.d/60-jicofo-rtcstats-push",
+          "local/jicofo-rtcstats-push-script:/etc/s6-overlay/scripts/jicofo-rtcstats-push",
+          "local/jicofo-rtcstats-push:/opt/jicofo-rtcstats-push"
         ]
         labels {
           release = "[[ env "CONFIG_release_number" ]]"
@@ -939,74 +951,77 @@ EOF
         JICOFO_VISITORS_REQUIRE_MUC_CONFIG = "[[ env "CONFIG_jicofo_require_muc_config_flag" ]]"
         RTCSTATS_SERVER="[[ env "CONFIG_jicofo_rtcstats_push_rtcstats_server" ]]"
         INTERVAL=10000
-        JICOFO_LOG_FILE = "/local/jicofo.log"
+        # rtcstats-push tails this file and pushes jicofo log lines alongside the
+        # rtcstats data. The upstream image's own jicofo service tees stdout here
+        # when JICOFO_LOG_FILE is set, so no custom run-script override is needed.
+        # Path is under /tmp (world-writable, disk-backed) because the unprivileged
+        # uid-1000 user may not be able to write the Nomad alloc dir (/local) on the
+        # rootless image.
+        JICOFO_LOG_FILE = "/tmp/jicofo.log"
         VISITORS_XMPP_AUTH_DOMAIN="auth.[[ env "CONFIG_domain" ]]"
       }
 
+      # Unzip the rtcstats-push node app on the Nomad client. The container now
+      # runs rootless on a read-only root fs, so it can no longer apt-get/unzip
+      # at runtime. Nomad auto-extracts the .zip into the destination directory,
+      # which we bind-mount read-only at /opt/jicofo-rtcstats-push.
       artifact {
         source      = "https://github.com/jitsi/jicofo-rtcstats-push/releases/download/release-0.0.1/jicofo-rtcstats-push.zip"
-        mode = "file"
-        destination = "local/jicofo-rtcstats-push.zip"
-        options {
-          archive = false
-        }
+        destination = "local/jicofo-rtcstats-push"
       }
+
+      # --- rtcstats-push as an s6-overlay v3 longrun service ---
+      # type
       template {
         data = <<EOF
-#!/usr/bin/with-contenv bash
-
-JAVA_SYS_PROPS="-Djava.util.logging.config.file=/config/logging.properties -Dconfig.file=/config/jicofo.conf"
-DAEMON=/usr/share/jicofo/jicofo.sh
-DAEMON_DIR=/usr/share/jicofo/
-
-JICOFO_CMD="exec $DAEMON"
-
-[ -n "$JICOFO_LOG_FILE" ] && JICOFO_CMD="$JICOFO_CMD 2>&1 | tee $JICOFO_LOG_FILE"
-
-exec s6-setuidgid jicofo /bin/bash -c "cd $DAEMON_DIR; JAVA_SYS_PROPS=\"$JAVA_SYS_PROPS\" $JICOFO_CMD"
+longrun
 EOF
-        destination = "local/jicofo-service-run"
+        destination = "local/rtcstats-push-type"
+        perms = "644"
+      }
+
+      # run: execlineb wrapper that execs our bash service body
+      template {
+        data = <<EOF
+#!/command/execlineb -P
+
+/etc/s6-overlay/scripts/jicofo-rtcstats-push
+EOF
+        destination = "local/rtcstats-push-run"
         perms = "755"
       }
 
-
+      # dependencies.d/jicofo: start after jicofo (whose REST API we poll).
+      # s6 ignores the file content; the file name is the dependency.
       template {
         data = <<EOF
-#!/usr/bin/with-contenv bash
-
-apt-get update && apt-get -y install unzip cron
-
-mkdir -p /jicofo-rtcstats-push
-cd /jicofo-rtcstats-push
-unzip /local/jicofo-rtcstats-push.zip
-
-echo '0 * * * * /local/jicofo-log-truncate.sh' | crontab
-
+# managed by nomad
 EOF
-        destination = "local/11-jicofo-rtcstats-push"
-        perms = "755"
+        destination = "local/rtcstats-push-dep"
+        perms = "644"
       }
 
+      # user/contents.d entry: registers the service in the user bundle so
+      # s6-rc brings it up. Bind-mounted alongside the image's own entries.
       template {
         data = <<EOF
-#!/usr/bin/with-contenv bash
-
-echo > $JICOFO_LOG_FILE
+# managed by nomad
 EOF
-        destination = "local/jicofo-log-truncate.sh"
-        perms = "755"
+        destination = "local/rtcstats-push-contents"
+        perms = "644"
       }
 
+      # service body. nodejs ships in base-java; the app is bind-mounted at
+      # /opt/jicofo-rtcstats-push. with-contenv imports the container env
+      # (JICOFO_ADDRESS, RTCSTATS_SERVER, INTERVAL, ...).
       template {
         data = <<EOF
-#!/usr/bin/with-contenv bash
+#!/command/with-contenv bash
 
-exec node /jicofo-rtcstats-push/app.js
-
+exec node /opt/jicofo-rtcstats-push/app.js
 EOF
-        destination = "local/jicofo-rtcstats-push-service-run"
+        destination = "local/jicofo-rtcstats-push-script"
         perms = "755"
-
       }
 
       template {

--- a/nomad/jitsi_packs/packs/jitsi_meet_backend/templates/jitsi_meet_backend.nomad.tpl
+++ b/nomad/jitsi_packs/packs/jitsi_meet_backend/templates/jitsi_meet_backend.nomad.tpl
@@ -534,19 +534,12 @@ EOF
         force_pull = [[ or (env "CONFIG_force_pull") "false" ]]
         image        = "[[ env "CONFIG_prosody_repo" ]]:[[ env "CONFIG_prosody_tag" ]]"
         ports = ["prosody-http","prosody-client"]
+        # The mod_c2s "Client XML parse error" log-level patch is now baked into
+        # the branding-built prosody image at build time (8x8Cloud/jitsi-meet-
+        # branding docker/prosody/Dockerfile) rather than patched at boot -- the
+        # rootless image cannot sed /usr/lib/prosody as uid 1000.
         volumes = [
           "local/config:/config",
-          # Migrated to s6-overlay v3 / rootless. patch-prosody is now an 08-patch-
-          # prosody oneshot (ordered before 10-config) that overrides core mod_c2s
-          # via /prosody-plugins-custom (searched before the core module dir) since
-          # the unprivileged user cannot write /usr/lib/prosody. Best-effort: it
-          # never fails the container, so prosody falls back to the core module if
-          # the plugin dir is not writable.
-          "local/patch-prosody-type:/etc/s6-overlay/s6-rc.d/08-patch-prosody/type",
-          "local/patch-prosody-up:/etc/s6-overlay/s6-rc.d/08-patch-prosody/up",
-          "local/patch-prosody-contents:/etc/s6-overlay/s6-rc.d/user/contents.d/08-patch-prosody",
-          "local/patch-prosody-config-dep:/etc/s6-overlay/s6-rc.d/10-config/dependencies.d/08-patch-prosody",
-          "local/patch-prosody-script:/etc/s6-overlay/scripts/patch-prosody",
         ]
         labels {
           release = "[[ env "CONFIG_release_number" ]]"
@@ -593,56 +586,6 @@ EOF
 [[- if ne (env "CONFIG_prosody_muc_max_occupants") "false"]]
         MAX_PARTICIPANTS=[[ env "CONFIG_prosody_muc_max_occupants" ]]
 [[- end ]]
-      }
-
-      # --- 08-patch-prosody: oneshot (ordered before 10-config) ---
-      template {
-        data = <<EOF
-oneshot
-EOF
-        destination = "local/patch-prosody-type"
-        perms = "644"
-      }
-      template {
-        data = <<EOF
-/etc/s6-overlay/scripts/patch-prosody
-EOF
-        destination = "local/patch-prosody-up"
-        perms = "644"
-      }
-      template {
-        data = <<EOF
-# managed by nomad
-EOF
-        destination = "local/patch-prosody-contents"
-        perms = "644"
-      }
-      template {
-        data = <<EOF
-# managed by nomad
-EOF
-        destination = "local/patch-prosody-config-dep"
-        perms = "644"
-      }
-      template {
-        data = <<EOF
-#!/command/with-contenv bash
-# Override core mod_c2s with a copy that logs "Client XML parse error" at info
-# instead of debug. /prosody-plugins-custom is searched before the core module
-# dir. The unprivileged user cannot write /usr/lib/prosody, hence the copy.
-# Best-effort: always exits 0 so a non-writable plugin dir never crashes prosody
-# (it just falls back to the unpatched core module).
-SRC=/usr/lib/prosody/modules/mod_c2s.lua
-DST=/prosody-plugins-custom/mod_c2s.lua
-if mkdir -p /prosody-plugins-custom 2>/dev/null && cp "$SRC" "$DST" 2>/dev/null; then
-  sed -i 's/"debug", "Client XML parse error/"info", "Client XML parse error/' "$DST" 2>/dev/null || true
-else
-  echo "patch-prosody: could not write $DST; using core mod_c2s unpatched"
-fi
-exit 0
-EOF
-        destination = "local/patch-prosody-script"
-        perms = "755"
       }
 
 [[ if eq (or (env "CONFIG_jigasi_vault_enabled") "true") "true" ]]

--- a/nomad/jitsi_packs/packs/jitsi_meet_jvb/templates/_helpers.tpl
+++ b/nomad/jitsi_packs/packs/jitsi_meet_jvb/templates/_helpers.tpl
@@ -182,7 +182,7 @@ block
 [[- end ]]
 
 [[ define "reload-shards" -]]
-#!/usr/bin/with-contenv bash
+#!/command/with-contenv bash
 
 SHARD_FILE=/config/shards.json
 UPLOAD_FILE=/config/upload.json

--- a/nomad/jitsi_packs/packs/jitsi_meet_jvb/templates/jitsi_meet_jvb.nomad.tpl
+++ b/nomad/jitsi_packs/packs/jitsi_meet_jvb/templates/jitsi_meet_jvb.nomad.tpl
@@ -159,14 +159,34 @@ EOF
         ports = ["http","media","colibri"]
         volumes = [
           "local/reload-shards.sh:/opt/jitsi/scripts/reload-shards.sh",
-          "local/01-jvb-env:/etc/cont-init.d/01-jvb-env",
           "local/config:/config",
           "local/jvb.conf:/defaults/jvb.conf",
           "local/logging.properties:/defaults/logging.properties",
-          "local/jvb-service-run:/etc/services.d/jvb/run",
-          "local/11-jvb-rtcstats-push:/etc/cont-init.d/11-jvb-rtcstats-push",
-          "local/jvb-rtcstats-push-service-run:/etc/services.d/60-jvb-rtcstats-push/run"
-
+          # Migrated to s6-overlay v3 / rootless. The image ships its own jvb
+          # longrun (tees JVB_LOG_FILE with -a) and nodejs (base-java), so we no
+          # longer override the main service run script nor apt-get/unzip at runtime.
+          #
+          # env oneshot: seeds JVB_VERSION / JVB_NAT_PORT into the s6 container
+          # environment. Ordered before 10-config (which renders jvb.conf via tpl)
+          # by adding a dependency into the image's 10-config service.
+          "local/jvb-env-type:/etc/s6-overlay/s6-rc.d/00-jvb-env/type",
+          "local/jvb-env-up:/etc/s6-overlay/s6-rc.d/00-jvb-env/up",
+          "local/jvb-env-contents:/etc/s6-overlay/s6-rc.d/user/contents.d/00-jvb-env",
+          "local/jvb-env-config-dep:/etc/s6-overlay/s6-rc.d/10-config/dependencies.d/00-jvb-env",
+          "local/jvb-env-script:/etc/s6-overlay/scripts/jvb-env",
+          # rtcstats-push sidecar (v3 longrun)
+          "local/rtcstats-push-type:/etc/s6-overlay/s6-rc.d/60-jvb-rtcstats-push/type",
+          "local/rtcstats-push-run:/etc/s6-overlay/s6-rc.d/60-jvb-rtcstats-push/run",
+          "local/rtcstats-push-dep:/etc/s6-overlay/s6-rc.d/60-jvb-rtcstats-push/dependencies.d/jvb",
+          "local/rtcstats-push-contents:/etc/s6-overlay/s6-rc.d/user/contents.d/60-jvb-rtcstats-push",
+          "local/jvb-rtcstats-push-script:/etc/s6-overlay/scripts/jvb-rtcstats-push",
+          "local/jvb-rtcstats-push:/opt/jvb-rtcstats-push",
+          # log-truncate sidecar (v3 longrun); safe because the image tees with -a
+          "local/log-truncate-type:/etc/s6-overlay/s6-rc.d/62-jvb-log-truncate/type",
+          "local/log-truncate-run:/etc/s6-overlay/s6-rc.d/62-jvb-log-truncate/run",
+          "local/log-truncate-dep:/etc/s6-overlay/s6-rc.d/62-jvb-log-truncate/dependencies.d/jvb",
+          "local/log-truncate-contents:/etc/s6-overlay/s6-rc.d/user/contents.d/62-jvb-log-truncate",
+          "local/jvb-log-truncate-script:/etc/s6-overlay/scripts/jvb-log-truncate"
     	  ]
         labels {
           release = "[[ env "CONFIG_release_number" ]]"
@@ -186,7 +206,9 @@ EOF
         # JVB auth password
         JVB_AUTH_USER="jvb"
         JVB_AUTH_PASSWORD = "[[ env "CONFIG_jvb_auth_password" ]]"
-        JVB_LOG_FILE="/local/jvb.log"
+        JVB_LOG_FILE="/tmp/jvb.log"
+        # How often (seconds) 62-jvb-log-truncate truncates JVB_LOG_FILE (hourly default).
+        JVB_LOG_TRUNCATE_INTERVAL = "[[ or (env "CONFIG_jvb_log_truncate_interval") "3600" ]]"
         JVB_XMPP_INTERNAL_MUC_DOMAIN = "muc.jvb.[[ env "CONFIG_domain" ]]"
         JVB_XMPP_AUTH_DOMAIN = "auth.jvb.[[ env "CONFIG_domain" ]]"
         ENABLE_JVB_XMPP_SERVER="1"
@@ -218,13 +240,11 @@ EOF
 #        CHROMIUM_FLAGS="--start-maximized,--kiosk,--enabled,--autoplay-policy=no-user-gesture-required,--use-fake-ui-for-media-stream,--enable-logging,--v=1"
       }
 
+      # Unzip the rtcstats-push node app on the Nomad client (rootless, read-only
+      # root means no runtime apt-get/unzip). Bind-mounted at /opt/jvb-rtcstats-push.
       artifact {
         source      = "https://github.com/jitsi/jvb-rtcstats-push/releases/download/0.0.3/jvb-rtcstats-push.zip"
-        mode = "file"
-        destination = "local/jvb-rtcstats-push.zip"
-        options {
-          archive = false
-        }
+        destination = "local/jvb-rtcstats-push"
       }
 
       template {
@@ -242,72 +262,136 @@ EOF
         destination = "secrets/asap.key"
       }
 
+      # --- 00-jvb-env: oneshot that seeds JVB_VERSION / JVB_NAT_PORT into the s6
+      # container environment, ordered before 10-config so jvb.conf rendering sees
+      # them. ---
       template {
         data = <<EOF
-#!/usr/bin/with-contenv bash
-
-export JAVA_SYS_PROPS="-Dnet.java.sip.communicator.SC_HOME_DIR_LOCATION=/ -Dnet.java.sip.communicator.SC_HOME_DIR_NAME=config -Djava.util.logging.config.file=/config/logging.properties -Dconfig.file=/config/jvb.conf"
-
-DAEMON=/usr/share/jitsi-videobridge/jvb.sh
-
-JVB_CMD="exec $DAEMON"
-[ -n "$JVB_LOG_FILE" ] && JVB_CMD="$JVB_CMD 2>&1 | tee $JVB_LOG_FILE"
-
-exec s6-setuidgid jvb /bin/bash -c "$JVB_CMD"
+oneshot
 EOF
-        destination = "local/jvb-service-run"
+        destination = "local/jvb-env-type"
+        perms = "644"
+      }
+      template {
+        data = <<EOF
+/etc/s6-overlay/scripts/jvb-env
+EOF
+        destination = "local/jvb-env-up"
+        perms = "644"
+      }
+      template {
+        data = <<EOF
+# managed by nomad
+EOF
+        destination = "local/jvb-env-contents"
+        perms = "644"
+      }
+      # makes the image's 10-config wait for 00-jvb-env
+      template {
+        data = <<EOF
+# managed by nomad
+EOF
+        destination = "local/jvb-env-config-dep"
+        perms = "644"
+      }
+      template {
+        data = <<EOF
+#!/command/with-contenv bash
+JVB_VERSION="$(dpkg -s jitsi-videobridge2 | grep Version | awk '{print $2}' | sed 's/..$//')"
+printf '%s' "$JVB_VERSION" > /run/s6/container_environment/JVB_VERSION
+
+JVB_NAT_PORT="$(cat /alloc/data/JVB_NAT_PORT)"
+printf '%s' "$JVB_NAT_PORT" > /run/s6/container_environment/JVB_NAT_PORT
+EOF
+        destination = "local/jvb-env-script"
         perms = "755"
       }
 
+      # --- 60-jvb-rtcstats-push: v3 longrun ---
       template {
         data = <<EOF
-#!/usr/bin/with-contenv bash
-
-apt-get update && apt-get -y install unzip cron
-
-mkdir -p /jvb-rtcstats-push
-cd /jvb-rtcstats-push
-unzip /local/jvb-rtcstats-push.zip
-
-echo '0 * * * * /local/jvb-log-truncate.sh' | crontab 
-
+longrun
 EOF
-        destination = "local/11-jvb-rtcstats-push"
+        destination = "local/rtcstats-push-type"
+        perms = "644"
+      }
+      template {
+        data = <<EOF
+#!/command/execlineb -P
+
+/etc/s6-overlay/scripts/jvb-rtcstats-push
+EOF
+        destination = "local/rtcstats-push-run"
+        perms = "755"
+      }
+      template {
+        data = <<EOF
+# managed by nomad
+EOF
+        destination = "local/rtcstats-push-dep"
+        perms = "644"
+      }
+      template {
+        data = <<EOF
+# managed by nomad
+EOF
+        destination = "local/rtcstats-push-contents"
+        perms = "644"
+      }
+      template {
+        data = <<EOF
+#!/command/with-contenv bash
+
+exec node /opt/jvb-rtcstats-push/app.js
+EOF
+        destination = "local/jvb-rtcstats-push-script"
         perms = "755"
       }
 
+      # --- 62-jvb-log-truncate: v3 longrun; safe because the image tees with -a ---
       template {
         data = <<EOF
-#!/usr/bin/with-contenv bash
-
-echo > $JVB_LOG_FILE
+longrun
 EOF
-        destination = "local/jvb-log-truncate.sh"
+        destination = "local/log-truncate-type"
+        perms = "644"
+      }
+      template {
+        data = <<EOF
+#!/command/execlineb -P
+
+/etc/s6-overlay/scripts/jvb-log-truncate
+EOF
+        destination = "local/log-truncate-run"
         perms = "755"
       }
-
       template {
         data = <<EOF
-#!/usr/bin/with-contenv bash
-
-exec node /jvb-rtcstats-push/app.js
-
+# managed by nomad
 EOF
-        destination = "local/jvb-rtcstats-push-service-run"
-        perms = "755"
-
+        destination = "local/log-truncate-dep"
+        perms = "644"
       }
-
       template {
         data = <<EOF
-#!/usr/bin/with-contenv bash
-export JVB_VERSION="$(dpkg -s jitsi-videobridge2 | grep Version | awk '{print $2}' | sed 's/..$//')"
-echo -n "$JVB_VERSION" > /var/run/s6/container_environment/JVB_VERSION
-
-export JVB_NAT_PORT="$(cat /alloc/data/JVB_NAT_PORT)"
-echo -n "$JVB_NAT_PORT" > /var/run/s6/container_environment/JVB_NAT_PORT
+# managed by nomad
 EOF
-        destination = "local/01-jvb-env"
+        destination = "local/log-truncate-contents"
+        perms = "644"
+      }
+      template {
+        data = <<EOF
+#!/command/with-contenv bash
+
+[ -z "$JVB_LOG_FILE" ] && exec sleep infinity
+
+# JVB_LOG_TRUNCATE_INTERVAL is always set by the task env (defaults to 3600).
+while true; do
+  sleep "$JVB_LOG_TRUNCATE_INTERVAL"
+  : > "$JVB_LOG_FILE"
+done
+EOF
+        destination = "local/jvb-log-truncate-script"
         perms = "755"
       }
 

--- a/nomad/jitsi_packs/packs/jitsi_meet_web/templates/jitsi_meet_web.nomad.tpl
+++ b/nomad/jitsi_packs/packs/jitsi_meet_web/templates/jitsi_meet_web.nomad.tpl
@@ -114,9 +114,6 @@ job [[ template "job_name" . ]] {
         image        = "[[ env "CONFIG_web_repo" ]]:[[ env "CONFIG_web_tag" ]]"
         ports = ["http","https","nginx-status"]
         volumes = [
-[[ if eq (env "CONFIG_jitsi_meet_cdn_cloudflare_enabled") "true" -]]
-          "local/init-cdn:/etc/cont-init.d/11-init-cdn",
-[[ end -]]
           "local/_unlock:/usr/share/[[ or (env "CONFIG_jitsi_meet_branding_override") "jitsi-meet" ]]/_unlock",
           "local/_unlock:/usr/share/[[ or (env "CONFIG_jitsi_meet_branding_override") "jitsi-meet" ]]/_health",
           "local/nginx.conf:/defaults/nginx.conf",
@@ -210,16 +207,14 @@ EOF
 OK
 EOF
       }
-[[ if eq (env "CONFIG_jitsi_meet_cdn_cloudflare_enabled") "true" ]]
-      template {
-        destination = "local/init-cdn"
-        perms = "0755"
-        data = <<EOF
-#!/bin/sh
-sed -i -e "s/web-cdn.jitsi.net/[[ env "CONFIG_domain" ]]\/v1\/_cdn/" /usr/share/*/base.html
-EOF
-      }
-[[ end ]]
+      # NOTE: the old 11-init-cdn cont-init (sed-rewrote /usr/share/*/base.html to
+      # point the asset <base href> at <domain>/v1/_cdn) is gone. It could not run
+      # on the rootless image (uid 1000 cannot write /usr/share) and crashed the
+      # container under s6-overlay v3. base.html is now generated host-relative by
+      # the branding build (<base href="/v1/_cdn/<prefix><version>/">). Requests
+      # under /v1/_cdn are intercepted by Cloudflare on every site and served from
+      # the R2 asset bucket (published per <prefix><version> directory), so they
+      # never reach this origin -- nothing to rewrite or serve locally here.
       template {
         destination = "local/nginx.conf"
         # overriding the delimiters to [< >] to avoid conflicts with tpl's native templating, which also uses {{ }}


### PR DESCRIPTION
## Problem

The new `docker-jitsi-meet` images (rootless commit; s6-overlay upgraded v1.22 → v3.2.3.0, processes run as the unprivileged `s6` user uid 1000) put the Java services into a deterministic crash loop. Our packs inject s6 **v1**-style files (`/etc/cont-init.d`, `/etc/services.d`) with a `#!/usr/bin/with-contenv` shebang; in v3 the interpreter moved to `/command/with-contenv`, so each script exits **127 (not found)** and s6-rc fatally stops the container.

## Scope

Migrates **jicofo, jvb, jibri, and prosody** to the s6-overlay v3 / rootless layout. (transcriber, multitrack-recorder, and web use the same v1 pattern and are **not** in this PR — follow-up.)

### Common pattern
- Inject services under `/etc/s6-overlay/s6-rc.d/<svc>/{type,run,dependencies.d}` + a `user/contents.d/<svc>` registration entry + the body under `/etc/s6-overlay/scripts/`. Shebangs → `/command/with-contenv` and `/command/execlineb`.
- Drop custom main service-run overrides (the images ship their own longruns reading `/run/<svc>/config`; no `s6-setuidgid` — there is no per-service user).
- No runtime `apt-get`/`mkdir /`/`unzip` (impossible as uid 1000): node app zips are auto-extracted by the Nomad `artifact` stanza and bind-mounted under `/opt`; `nodejs` ships in base-java.

### jicofo
- rtcstats-push → `60-jicofo-rtcstats-push` longrun; `JICOFO_LOG_FILE` → `/tmp/jicofo.log`; `62-jicofo-log-truncate` longrun (safe in-place truncation now that the image tees with `-a`, [docker-jitsi-meet#2268](https://github.com/jitsi/docker-jitsi-meet/pull/2268), merged).

### jvb
- rtcstats-push + log-truncate longruns (mirrors jicofo); `JVB_LOG_FILE` → `/tmp/jvb.log`. `01-jvb-env` cont-init → `00-jvb-env` oneshot seeding `JVB_VERSION`/`JVB_NAT_PORT` into `/run/s6/container_environment`, ordered before the image's `10-config`. `reload-shards.sh` shebang fixed.

### jibri
- `01-xmpp-servers` → `00-jibri-env` oneshot. Per-minute status **cron replaced by a `60-jibri-status` longrun** (cron + netcat are absent from the rootless image); `jibri-status.sh` now emits statsd over bash `/dev/udp`. `reload-config.sh` paths updated; dropped the obsolete `cp /etc/jitsi/jibri/* /config`.

### prosody
- `08-patch-prosody` → oneshot that overrides core `mod_c2s` via `/prosody-plugins-custom` (the unprivileged user can't write `/usr/lib/prosody`); **best-effort, always exits 0** so it can't crash prosody. `jigasi_xmpp.sh` shebang fixed and pointed at `/run/prosody/config/prosody.cfg.lua`.

## Validation needed (on a real deploy)
- Render the packs; deploy to beta-meet-jit-si; confirm all four services + sidecars come up and rtcstats/stats flow.
- jibri: confirm `/opt/jitsi/jibri/reload.sh` still ships in the package and that the built-in autoscaler-sidecar covers scaling.
- prosody: confirm `/prosody-plugins-custom` is writable by uid 1000 (else the Client XML parse-error log-level tweak is skipped — logged, not fatal).

Refs JIT-15926

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### web (added)
The `11-init-cdn` sed cont-init (rewrote `/usr/share/*/base.html`, impossible as uid 1000) is **removed**. base.html is now generated **host-relative** by the branding build (`<base href="/v1/_cdn/<prefix><version>/">`). Requests under `/v1/_cdn` are intercepted by **Cloudflare on every site and served from the R2 asset bucket** (published per `<prefix><version>` directory) — they never reach this origin, so there is nothing to rewrite or serve locally. `CDN_PREFIX` stays in the path as the per-brand R2 namespace; no fabio/nginx change.

**Depends on** [8x8Cloud/jitsi-meet-branding#382](https://github.com/8x8Cloud/jitsi-meet-branding/pull/382) — emits the host-relative base href. (Supersedes the SSI approach in #381, closed.)

### prosody (build-time patch)
The `08-patch-prosody` boot oneshot is **removed**. The mod_c2s "Client XML parse error" log-level tweak is now baked into the branding-built prosody image at build time (root, writable fs) — see [8x8Cloud/jitsi-meet-branding#383](https://github.com/8x8Cloud/jitsi-meet-branding/pull/383). The prosody task keeps only the `jigasi_xmpp.sh` change_script (shebang + `/run/prosody/config` path fixed).

Scope: jicofo, jvb, jibri, prosody, **web**. Branding deps: #382 (web), #383 (prosody). Remaining v1 pattern: transcriber, multitrack-recorder (follow-up).
