### PR TITLE
feat(ops-repo): dual-sign InRelease for Debian Trixie / APT 3.0 (JIT-15930)

### DIFF
--- a/scripts/sign-release.sh
+++ b/scripts/sign-release.sh
@@ -38,7 +38,14 @@ if [ -z "$USER" ]; then
 fi
 # This is just a default value
 #KEYID=$(getent passwd $USER | cut -f 5 -d : | cut -f 1 -d ,)
+# KEYID is the legacy signing key (DSA-1024 "SIP Communicator", 2008). Kept for backward
+# compatibility with existing clients.
 [ -z "$KEYID" ] && KEYID="SIP Communicator"
+# NEW_KEYID is the modern signing key (RSA-4096 / Ed25519). When set AND present in the
+# keyring, we additionally emit a dual-signed InRelease so Debian Trixie / APT 3.0 (which
+# rejects the legacy DSA-1024 + SHA-1 key outright) can verify the repo via the modern key.
+# Until it is provisioned this stays empty and signing behaves exactly as before. See JIT-15930.
+NEW_KEYID="${NEW_KEYID:-}"
 PASSPHRASE=$(cat "$GNUPGHOME/passphrase")
 # These should fail if for some reason the directory isn't owned by us
 chown "$USER" "$GNUPGHOME"
@@ -46,6 +53,35 @@ chmod 0700 "$GNUPGHOME"
 # Initialize GPG
 gpg --help 1>/dev/null 2>&1 || true
 
-rm -f Release.gpg.tmp
-echo "$PASSPHRASE" | gpg --no-tty --batch --pinentry-mode loopback --passphrase-fd=0 --default-key "$KEYID" --detach-sign -o Release.gpg.tmp "$1"
-mv Release.gpg.tmp Release.gpg
+# mini-dinstall invokes this script with the Release file as $1, from the distribution
+# directory; emit signatures alongside it.
+RELEASE="$1"
+RELEASE_DIR=$(dirname "$RELEASE")
+
+gpg_sign() {
+    # Wrapper that feeds the passphrase on fd 0; remaining args are passed to gpg.
+    echo "$PASSPHRASE" | gpg --no-tty --batch --pinentry-mode loopback --passphrase-fd=0 "$@"
+}
+
+# 1) Detached Release.gpg, signed by the legacy key only.
+#    APT 3.0 (Sequoia sqv) cannot parse a detached signature file that contains a DSA
+#    signature ("unsupported binary format"), so we deliberately keep this single-key and
+#    let Trixie/modern clients verify via InRelease below. Older clients without InRelease
+#    support continue to use this. See JIT-15930.
+rm -f "$RELEASE_DIR/Release.gpg.tmp"
+gpg_sign --default-key "$KEYID" --detach-sign -o "$RELEASE_DIR/Release.gpg.tmp" "$RELEASE"
+mv "$RELEASE_DIR/Release.gpg.tmp" "$RELEASE_DIR/Release.gpg"
+
+# 2) Inline-signed InRelease. Modern APT prefers InRelease over Release+Release.gpg, and
+#    unlike a detached signature it tolerates a DSA signature packet sitting next to a good
+#    RSA one. When a modern key is configured we dual-sign with SHA-256 so existing clients
+#    verify via the legacy key and Trixie verifies via the modern key.
+if [ -n "$NEW_KEYID" ] && gpg --list-keys "$NEW_KEYID" >/dev/null 2>&1; then
+    rm -f "$RELEASE_DIR/InRelease.tmp"
+    gpg_sign --digest-algo SHA256 -u "$KEYID" -u "$NEW_KEYID" --clearsign -o "$RELEASE_DIR/InRelease.tmp" "$RELEASE"
+    mv "$RELEASE_DIR/InRelease.tmp" "$RELEASE_DIR/InRelease"
+else
+    # No modern key provisioned yet: preserve the previous behaviour exactly (Release.gpg
+    # only, no InRelease) so this change is a no-op until NEW_KEYID is configured.
+    echo "sign-release.sh: NEW_KEYID not set; skipping InRelease (Trixie support disabled). See JIT-15930." >&2
+fi


### PR DESCRIPTION
## Why

Debian Trixie ships **APT 3.0**, which verifies repository signatures in-process (Sequoia `sqv` by default; the legacy `gpgv` method was also rewritten and no longer execs GnuPG). Its crypto policy **rejects the legacy ops-repo signing key outright** — DSA-1024, SHA-1 self-signature, 2008 — and **no client-side apt option can relax it**. So `apt update` against `ops-repo.jitsi.net` fails on Trixie.

Validated empirically in a `debian:trixie` container (APT 3.0.3):
- A **detached `Release.gpg` containing a DSA signature** is rejected as `unsupported binary format` — even alongside a valid RSA signature, even at SHA-256.
- A **clearsigned `InRelease` signed by a modern RSA key is accepted**, and tolerates a co-located DSA signature (whether SHA-1 or SHA-256). Modern APT prefers `InRelease`.

## What

[`scripts/sign-release.sh`](https://github.com/jitsi/infra-provisioning/blob/aaron/JIT-15930-ops-repo-dual-sign/scripts/sign-release.sh) (the mini-dinstall `release_signscript`) now, **when `NEW_KEYID` is set**, additionally emits a **dual-signed `InRelease`** (legacy DSA + modern RSA, SHA-256) next to the existing single-key `Release.gpg`:

- **Trixie / modern clients** verify via the modern key (through `InRelease`).
- **Existing clients** verify via the legacy key (`InRelease` or the unchanged `Release.gpg`).
- When `NEW_KEYID` is **unset**, behaviour is **exactly as before** (`Release.gpg` only) — so this is a no-op until the modern key is provisioned.

`Release.gpg` stays single-DSA on purpose (a detached sig with a DSA packet breaks Trixie; Trixie ignores `Release.gpg` when `InRelease` is present).

## Ops follow-up (tracked in JIT-15930)

1. Generate a modern signing key (RSA-4096 or Ed25519, SHA-256+ self-sig).
2. Add it to the `ops-repo-secring` Jenkins credential (alongside the legacy key).
3. Export the **combined** (legacy + modern) public key to `debian/unstable/archive.key`.
4. Set `NEW_KEYID` in the signing environment (e.g. the `reconfigure-ops-repo` job).
5. Verify on Trixie that `apt update` succeeds.

Pairs with the client-side change in **infra-configuration** (`jitsi-repo` role → `signed-by`). **Deploy this repo-side change first** so the dual-signed `InRelease` and combined key are published before clients switch to verification.

Ref: JIT-15930