### PR TITLE
feat(ops-repo): test bucket + parameterized reconfigure for Trixie dual-sign validation (JIT-15930)

### DIFF
--- a/docs/ops-repo-test-env.md
+++ b/docs/ops-repo-test-env.md
@@ -1,0 +1,129 @@
+# ops-repo test environment (Debian Trixie dual-signing)
+
+Runbook for standing up a throwaway ops-repo in **ops-dev** backed by a separate
+`ops-repo-test` bucket, to validate the Debian Trixie / APT 3.0 dual-signing flow
+end-to-end **without touching the production `ops-repo` bucket**. See JIT-15930.
+
+The production repo is unaffected throughout: every step targets a distinct
+bucket (`ops-repo-test`), Nomad job (`ops-repo-test`), hostname, and Vault path.
+
+## What got parameterized
+
+| Knob | Where | Default (prod) | Test value |
+|------|-------|----------------|------------|
+| `OPS_REPO_BUCKET` | `reconfigure-ops-repo` param / `update-ops-repo.sh` / `deploy-nomad-ops-repo.sh` | `ops-repo` | `ops-repo-test` |
+| `NEW_KEYID` | `reconfigure-ops-repo` param → `sign-release.sh` | empty (legacy single-sign) | modern key fingerprint |
+| `OPS_REPO_*_CREDENTIAL_ID` | `reconfigure-ops-repo` params | `ops-repo-{secring,pubring,secring-passphrase}` | combined-key test credentials |
+| `JOB_NAME` | `deploy-nomad-ops-repo.sh` (→ `nomad/ops-repo.hcl`) | `ops-repo` | `ops-repo-test` |
+| `OPS_REPO_HOSTNAME` | `deploy-nomad-ops-repo.sh` | from `ansible/secrets/ops-repo.yml` | test hostname |
+
+`clouds/oracle.sh` still sets `OPS_REPO_BUCKET=ops-repo`; the scripts capture a
+caller-provided value *before* sourcing it and re-apply it afterwards, so prod
+behavior is unchanged when nothing is overridden.
+
+## 1. Create the test bucket (terraform)
+
+```bash
+cd terraform/ops-repo-bucket
+ENVIRONMENT=ops-dev ORACLE_REGION=us-phoenix-1 OPS_REPO_BUCKET_NAME=ops-repo-test ./ops-repo-bucket.sh
+```
+
+Creates `ops-repo-test` in namespace `fr4eeztjonbe`, state at
+`tf-state-ops-dev/ops-repo-bucket/ops-repo-test/terraform.tfstate`.
+
+## 2. Seed the bucket layout
+
+The repo serves `root /mnt/ops-repo/repo`, and `update-ops-repo.sh` builds under
+`repo/debian` with mini-dinstall, reading `jitsi-debian-pkg.conf` from the mount
+root. Seed the same structure into `ops-repo-test`:
+
+```
+jitsi-debian-pkg.conf                  # mini-dinstall config (copy from prod bucket)
+repo/debian/unstable/mini-dinstall/incoming/   # incoming dir for new debs
+repo/debian/unstable/archive.key       # combined public key (added in step 4/5)
+```
+
+```bash
+# copy the prod mini-dinstall config as a starting point
+oci os object get -bn ops-repo --name jitsi-debian-pkg.conf --file /tmp/jitsi-debian-pkg.conf
+# ensure release_signscript in it points at the checked-out scripts/sign-release.sh
+oci os object put  -bn ops-repo-test --name jitsi-debian-pkg.conf --file /tmp/jitsi-debian-pkg.conf
+# seed a couple of sample .debs into the incoming dir (or let the reconfigure job copy them)
+```
+
+## 3. Produce the dual-key signing material
+
+Use the rotation job (JIT-15930, infra-customizations-private) pointed at the
+**ops-dev** Vault:
+
+```
+rotate-ops-repo-signing-key  DRY_RUN=true            # review new_keyid
+rotate-ops-repo-signing-key  DRY_RUN=false VAULT_ENVIRONMENT=ops-dev
+```
+
+Note the `new_keyid` from the output — that is the `NEW_KEYID` for step 4.
+
+Until the signing jobs read from Vault (JIT-15934), create **test** Jenkins file
+credentials from the combined material the rotation produced, so the reconfigure
+job can sign with both keys:
+
+- `ops-repo-secring-test`           ← combined `secring` (base64-decoded)
+- `ops-repo-pubring-test`           ← combined `pubring` (base64-decoded)
+- `ops-repo-secring-passphrase-test`← the (unchanged) passphrase
+
+## 4. Reconfigure (build + dual-sign) the test bucket
+
+Run the `reconfigure-ops-repo` job with:
+
+- `VIDEO_INFRA_BRANCH` = the JIT-15930 dual-sign branch (so `sign-release.sh`
+  emits the dual-signed `InRelease`)
+- `OPS_REPO_BUCKET` = `ops-repo-test`
+- `NEW_KEYID` = the fingerprint from step 3
+- `OPS_REPO_SECRING_CREDENTIAL_ID` = `ops-repo-secring-test`
+- `OPS_REPO_PUBRING_CREDENTIAL_ID` = `ops-repo-pubring-test`
+- `OPS_REPO_SECRING_PASSPHRASE_CREDENTIAL_ID` = `ops-repo-secring-passphrase-test`
+
+Then publish the combined public key to the bucket:
+
+```bash
+oci os object put -bn ops-repo-test --name debian/unstable/archive.key --file archive.key
+```
+
+## 5. Deploy the serving job in ops-dev
+
+```bash
+ENVIRONMENT=ops-dev ORACLE_REGION=us-phoenix-1 \
+  OPS_REPO_BUCKET=ops-repo-test \
+  JOB_NAME=ops-repo-test \
+  OPS_REPO_HOSTNAME=ops-repo-test.<ops-dev-zone> \
+  scripts/deploy-nomad-ops-repo.sh
+```
+
+Prerequisites in ops-dev: the `secret/default/ops-repo/s3` Vault secret (s3fs
+object-storage key), and a DNS/fabio route for `OPS_REPO_HOSTNAME` (the job
+advertises `int-urlprefix-<hostname>/`). The htpasswd user/pass come from
+`ansible/secrets/ops-repo.yml`.
+
+## 6. Verify on Debian Trixie
+
+```bash
+docker run --rm -it debian:trixie bash
+# install ca-certificates; drop the combined archive.key (dearmored) into
+# /etc/apt/keyrings/jitsi-archive-keyring.gpg
+echo 'deb [signed-by=/etc/apt/keyrings/jitsi-archive-keyring.gpg] \
+  https://<user>:<pass>@ops-repo-test.<ops-dev-zone>/debian unstable/' \
+  > /etc/apt/sources.list.d/jitsi.list
+apt-get update     # expect exit 0, no "not signed"
+apt-get install -y <a-test-package>
+```
+
+Also confirm an existing distro (e.g. Bookworm) still verifies via the legacy key.
+
+## 7. Teardown
+
+```bash
+nomad job stop -purge ops-repo-test                     # in ops-dev
+cd terraform/ops-repo-bucket
+ACTION=destroy ENVIRONMENT=ops-dev OPS_REPO_BUCKET_NAME=ops-repo-test ./ops-repo-bucket.sh
+# remove the test Jenkins credentials and the ops-dev Vault signing secret if desired
+```

--- a/jenkins/groovy/reconfigure-ops-repo/Jenkinsfile
+++ b/jenkins/groovy/reconfigure-ops-repo/Jenkinsfile
@@ -25,14 +25,15 @@ pipeline {
         stage ("ops repo processing") {
             steps {
                 script {
-                    echo 'ops repo rebuild'
+                    echo "ops repo rebuild (bucket=${env.OPS_REPO_BUCKET ?: 'ops-repo'})"
                     dir('infra-provisioning') {
-                      lock("ops-repo") {
+                      // Lock per-bucket so a test-bucket rebuild does not block the production one.
+                      lock("reconfigure-ops-repo-${env.OPS_REPO_BUCKET ?: 'ops-repo'}") {
                         withCredentials([
                             file(credentialsId: 'ops-repo-s3fs', variable: 'S3_PASSWORD_PATH'),
-                            file(credentialsId: 'ops-repo-secring', variable: 'OPS_REPO_SECRING_PATH'),
-                            file(credentialsId: 'ops-repo-pubring', variable: 'OPS_REPO_PUBRING_PATH'),
-                            file(credentialsId: 'ops-repo-secring-passphrase', variable: 'OPS_REPO_SECRING_PASSPHRASE_PATH')
+                            file(credentialsId: env.OPS_REPO_SECRING_CREDENTIAL_ID ?: 'ops-repo-secring', variable: 'OPS_REPO_SECRING_PATH'),
+                            file(credentialsId: env.OPS_REPO_PUBRING_CREDENTIAL_ID ?: 'ops-repo-pubring', variable: 'OPS_REPO_PUBRING_PATH'),
+                            file(credentialsId: env.OPS_REPO_SECRING_PASSPHRASE_CREDENTIAL_ID ?: 'ops-repo-secring-passphrase', variable: 'OPS_REPO_SECRING_PASSPHRASE_PATH')
                         ]) {
                           sshagent(credentials: ['ssh-jenkins-ci']) {
                             sh '''#!/bin/bash

--- a/jenkins/jobs/reconfigure-ops-repo.yaml
+++ b/jenkins/jobs/reconfigure-ops-repo.yaml
@@ -22,7 +22,32 @@
           default: git@github.com:jitsi/infra-customizations.git
           description: "Repo with customized configurations, defaults to 'git@github.com:jitsi/infra-customizations.git'."
           trim: true
- 
+      - string:
+          name: OPS_REPO_BUCKET
+          default: ops-repo
+          description: "Object storage bucket to rebuild. Use 'ops-repo-test' for end-to-end testing without touching production."
+          trim: true
+      - string:
+          name: NEW_KEYID
+          default: ""
+          description: "Modern signing key fingerprint for dual-signing the InRelease (Debian Trixie / APT 3.0). Empty = legacy single-key signing only. See JIT-15930."
+          trim: true
+      - string:
+          name: OPS_REPO_SECRING_CREDENTIAL_ID
+          default: ops-repo-secring
+          description: "Jenkins file credential for the secret keyring. Override (e.g. ops-repo-secring-test) to sign a test bucket with the combined dual-key keyring."
+          trim: true
+      - string:
+          name: OPS_REPO_PUBRING_CREDENTIAL_ID
+          default: ops-repo-pubring
+          description: "Jenkins file credential for the public keyring."
+          trim: true
+      - string:
+          name: OPS_REPO_SECRING_PASSPHRASE_CREDENTIAL_ID
+          default: ops-repo-secring-passphrase
+          description: "Jenkins file credential for the signing key passphrase."
+          trim: true
+
     project-type: pipeline
     sandbox: true
     pipeline-scm:

--- a/nomad/ops-repo.hcl
+++ b/nomad/ops-repo.hcl
@@ -34,7 +34,7 @@ variable "image_version" {
     default = "0.0.6"
 }
 
-job "ops-repo" {
+job "[JOB_NAME]" {
   datacenters = ["${var.dc}"]
 
   type = "service"

--- a/scripts/deploy-nomad-ops-repo.sh
+++ b/scripts/deploy-nomad-ops-repo.sh
@@ -7,10 +7,17 @@ fi
 
 LOCAL_PATH=$(dirname "${BASH_SOURCE[0]}")
 
+# Capture a caller-provided bucket before clouds/oracle.sh sets its default, so a
+# non-prod bucket (e.g. ops-repo-test) can be served for end-to-end testing.
+OPS_REPO_BUCKET_OVERRIDE="$OPS_REPO_BUCKET"
+
 [ -e "$LOCAL_PATH/../sites/$ENVIRONMENT/stack-env.sh" ] && . "$LOCAL_PATH/../sites/$ENVIRONMENT/stack-env.sh"
 
 [ -e "$LOCAL_PATH/../clouds/all.sh" ] && . "$LOCAL_PATH/../clouds/all.sh"
 [ -e "$LOCAL_PATH/../clouds/oracle.sh" ] && . "$LOCAL_PATH/../clouds/oracle.sh"
+
+[ -n "$OPS_REPO_BUCKET_OVERRIDE" ] && OPS_REPO_BUCKET="$OPS_REPO_BUCKET_OVERRIDE"
+[ -z "$OPS_REPO_BUCKET" ] && OPS_REPO_BUCKET="ops-repo"
 
 [ -z "$VAULT_PASSWORD_FILE" ] && VAULT_PASSWORD_FILE="$LOCAL_PATH/../.vault-password.txt"
 
@@ -32,6 +39,10 @@ export NOMAD_VAR_ops_repo_password="$(ansible-vault view $ENCRYPTED_OPS_REPO_CRE
 export NOMAD_VAR_ops_repo_hostname="$(ansible-vault view $ENCRYPTED_OPS_REPO_CREDENTIALS_FILE --vault-password $VAULT_PASSWORD_FILE | yq eval ".${OPS_REPO_HOSTNAME_VARIABLE}" -)"
 set -x
 
+# Allow overriding the served hostname (test instances use a distinct hostname so
+# they do not collide with the production ops-repo route).
+[ -n "$OPS_REPO_HOSTNAME" ] && export NOMAD_VAR_ops_repo_hostname="$OPS_REPO_HOSTNAME"
+
 
 [ -z "$LOCAL_REGION" ] && LOCAL_REGION="$OCI_LOCAL_REGION"
 [ -z "$LOCAL_REGION" ] && LOCAL_REGION="us-phoenix-1"
@@ -42,10 +53,14 @@ fi
 
 NOMAD_JOB_PATH="$LOCAL_PATH/../nomad"
 NOMAD_DC="$ENVIRONMENT-$ORACLE_REGION"
-JOB_NAME="ops-repo-$ORACLE_REGION"
+# Nomad job name. Defaults to "ops-repo" (the existing production name); test
+# instances set JOB_NAME (e.g. ops-repo-test) so they run alongside without
+# clobbering the production job.
+[ -z "$JOB_NAME" ] && JOB_NAME="ops-repo"
 
 export NOMAD_VAR_oracle_s3_namespace="$ORACLE_S3_NAMESPACE"
 export NOMAD_VAR_oracle_region="$ORACLE_REGION"
+export NOMAD_VAR_ops_bucket="$OPS_REPO_BUCKET"
 
 
 sed -e "s/\[JOB_NAME\]/$JOB_NAME/" "$NOMAD_JOB_PATH/ops-repo.hcl" | nomad job run -var="dc=$NOMAD_DC" -

--- a/scripts/update-ops-repo.sh
+++ b/scripts/update-ops-repo.sh
@@ -5,11 +5,17 @@ set -x
 # e.g. scripts
 LOCAL_PATH=$(dirname "${BASH_SOURCE[0]}")
 
+# Capture any caller-provided bucket before clouds/oracle.sh (which sets a
+# default unconditionally) so a non-prod bucket (e.g. ops-repo-test) can be
+# targeted for end-to-end testing without touching the production repo.
+OPS_REPO_BUCKET_OVERRIDE="$OPS_REPO_BUCKET"
+
 [ -e "$LOCAL_PATH/../clouds/all.sh" ] && . $LOCAL_PATH/../clouds/all.sh
 
 # pull in oracle namespace
 [ -e "$LOCAL_PATH/../clouds/oracle.sh" ] && . $LOCAL_PATH/../clouds/oracle.sh
 
+[ -n "$OPS_REPO_BUCKET_OVERRIDE" ] && OPS_REPO_BUCKET="$OPS_REPO_BUCKET_OVERRIDE"
 [ -z "$OPS_REPO_BUCKET" ] && OPS_REPO_BUCKET="ops-repo"
 [ -z "$S3FS_PASSWORD_PATH" ] && S3FS_PASSWORD_PATH="/etc/.passwd-s3fs"
 [ -z "$ORACLE_REGION" ] && ORACLE_REGION="us-phoenix-1"

--- a/terraform/ops-repo-bucket/ops-repo-bucket.sh
+++ b/terraform/ops-repo-bucket/ops-repo-bucket.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+set -x
+
+LOCAL_PATH=$(realpath "$(dirname "${BASH_SOURCE[0]}")")
+
+if [ -z "$ENVIRONMENT" ]; then
+  echo "No ENVIRONMENT found. Exiting..."
+  exit 203
+fi
+
+[ -e "$LOCAL_PATH/../../sites/$ENVIRONMENT/stack-env.sh" ] && . "$LOCAL_PATH/../../sites/$ENVIRONMENT/stack-env.sh"
+
+[ -z "$ORACLE_REGION" ] && ORACLE_REGION="us-phoenix-1"
+
+[ -e "$LOCAL_PATH/../../clouds/all.sh" ] && . "$LOCAL_PATH/../../clouds/all.sh"
+[ -e "$LOCAL_PATH/../../clouds/oracle.sh" ] && . "$LOCAL_PATH/../../clouds/oracle.sh"
+
+# Name of the bucket to manage; defaults to the ops-repo test bucket.
+[ -z "$OPS_REPO_BUCKET_NAME" ] && OPS_REPO_BUCKET_NAME="ops-repo-test"
+
+# do the needful with terraform
+[ -z "$S3_PROFILE" ] && S3_PROFILE="oracle"
+[ -z "$S3_STATE_BUCKET" ] && S3_STATE_BUCKET="tf-state-$ENVIRONMENT"
+[ -z "$S3_ENDPOINT" ] && S3_ENDPOINT="https://$ORACLE_S3_NAMESPACE.compat.objectstorage.$ORACLE_REGION.oraclecloud.com"
+[ -z "$S3_STATE_KEY" ] && S3_STATE_KEY="ops-repo-bucket/$OPS_REPO_BUCKET_NAME/terraform.tfstate"
+
+[ -z "$ACTION" ] && ACTION="apply"
+if [[ "$ACTION" == "apply" ]]; then
+  ACTION_POST_PARAMS="-auto-approve"
+fi
+if [[ "$ACTION" == "import" ]]; then
+  ACTION_POST_PARAMS="$1 $2"
+fi
+
+TERRAFORM_MAJOR_VERSION=$(terraform -v | head -1  | awk '{print $2}' | cut -d'.' -f1)
+TF_GLOBALS_CHDIR=
+if [[ "$TERRAFORM_MAJOR_VERSION" == "v1" ]]; then
+  TF_GLOBALS_CHDIR="-chdir=$LOCAL_PATH"
+  TF_POST_PARAMS=
+else
+  TF_POST_PARAMS="$LOCAL_PATH"
+fi
+
+# The —reconfigure option disregards any existing configuration, preventing migration of any existing state
+terraform $TF_GLOBALS_CHDIR init \
+  -backend-config="bucket=$S3_STATE_BUCKET" \
+  -backend-config="key=$S3_STATE_KEY" \
+  -backend-config="region=$ORACLE_REGION" \
+  -backend-config="profile=$S3_PROFILE" \
+  -backend-config="endpoint=$S3_ENDPOINT" \
+  -reconfigure \
+  $TF_POST_PARAMS
+
+terraform $TF_GLOBALS_CHDIR $ACTION \
+  -var="environment=$ENVIRONMENT" \
+  -var="oracle_region=$ORACLE_REGION" \
+  -var="tenancy_ocid=$TENANCY_OCID" \
+  -var="compartment_ocid=$COMPARTMENT_OCID" \
+  -var="tag_namespace=$TAG_NAMESPACE" \
+  -var="bucket_namespace=$ORACLE_S3_NAMESPACE" \
+  -var="bucket_name=$OPS_REPO_BUCKET_NAME" \
+  $ACTION_POST_PARAMS $TF_POST_PARAMS

--- a/terraform/ops-repo-bucket/ops-repo-bucket.tf
+++ b/terraform/ops-repo-bucket/ops-repo-bucket.tf
@@ -1,0 +1,51 @@
+variable "oracle_region" {}
+variable "tenancy_ocid" {}
+variable "compartment_ocid" {}
+variable "environment" {}
+variable "tag_namespace" {
+  default = "jitsi"
+}
+variable "bucket_namespace" {
+}
+variable "bucket_name" {
+  default = "ops-repo-test"
+}
+provider "oci" {
+  region       = var.oracle_region
+  tenancy_ocid = var.tenancy_ocid
+}
+
+
+terraform {
+  backend "s3" {
+    skip_region_validation      = true
+    skip_credentials_validation = true
+    skip_metadata_api_check     = true
+    force_path_style            = true
+  }
+  required_providers {
+    oci = {
+      source = "oracle/oci"
+    }
+  }
+}
+
+locals {
+  common_tags = {
+    "${var.tag_namespace}.environment" = var.environment
+    "${var.tag_namespace}.role"        = "ops-repo"
+  }
+}
+
+# Object storage bucket backing an ops-repo deployment. Defaults to the
+# ops-repo-test bucket used to validate the Debian Trixie dual-signing flow
+# end-to-end without touching the production ops-repo bucket. See JIT-15930.
+resource "oci_objectstorage_bucket" "bucket" {
+  #Required
+  compartment_id = var.compartment_ocid
+  name           = var.bucket_name
+  namespace      = var.bucket_namespace
+
+  #Optional
+  defined_tags = local.common_tags
+}


### PR DESCRIPTION
## Why

Before rolling the Debian Trixie dual-signing change ([#1101](https://github.com/jitsi/infra-provisioning/pull/1101) etc.) to the production `ops-repo`, we want a **full end-to-end test** — build → dual-sign → serve → `apt update` on Trixie — against a **separate bucket** so production is never at risk.

This parameterizes the existing tooling so an ops-dev `ops-repo-test` instance can be stood up alongside prod. **With no overrides, prod behavior is identical.**

## What

- **`terraform/ops-repo-bucket/`** — managed `oci_objectstorage_bucket` stack (bucket name is a var, default `ops-repo-test`), modeled on `terraform/tempo-bucket`. `terraform validate` passes; `fmt`-clean.
- **`scripts/update-ops-repo.sh` + `deploy-nomad-ops-repo.sh`** — capture a caller-provided `OPS_REPO_BUCKET` *before* `clouds/oracle.sh` sets its unconditional default, and re-apply it after (so the shared clouds file is untouched). Deploy also exports `NOMAD_VAR_ops_bucket` and honors `OPS_REPO_HOSTNAME` + `JOB_NAME` overrides.
- **`nomad/ops-repo.hcl`** — use the `[JOB_NAME]` placeholder the deploy script *already* substitutes (it was a no-op because the job name was hardcoded). Default stays `ops-repo`, so the **prod job name is unchanged**; test instances pass `JOB_NAME=ops-repo-test`. (Note: the hcl is now deployed via the script, not `nomad job run` directly.)
- **`reconfigure-ops-repo` job** — new params, all defaulting to prod values: `OPS_REPO_BUCKET`, `NEW_KEYID` (→ `sign-release.sh` dual-sign), and `OPS_REPO_{SECRING,PUBRING,SECRING_PASSPHRASE}_CREDENTIAL_ID`. Lock is now keyed per-bucket so a test rebuild can't block production.
- **`docs/ops-repo-test-env.md`** — full runbook: create bucket → seed layout → rotate signing key → reconfigure (on the dual-sign branch, with `NEW_KEYID`) → deploy in ops-dev → verify on `debian:trixie` → teardown.

## Safety / backward-compat

- Every override defaults to the production value; an un-parameterized run of `reconfigure-ops-repo` or `deploy-nomad-ops-repo.sh` behaves exactly as today (bucket `ops-repo`, job `ops-repo`, prod credentials, legacy single-sign).
- The bucket override is captured/re-applied locally in the two scripts — `clouds/oracle.sh` (a shared, symlinked file in infra-customizations-private) is **not** modified.

## Validation done here

- `terraform validate` + `fmt` on the new stack.
- `bash -n` + `shellcheck` on the changed scripts (remaining warnings are pre-existing patterns on untouched lines).

## Prereqs for the actual test (ops actions, in the runbook)

`secret/default/ops-repo/s3` in ops-dev Vault, a DNS/fabio route for the test hostname, the dual-key signing material (via the rotation job, JIT-15930 / [infra-customizations-private #1044](https://github.com/jitsi/infra-customizations-private/pull/1044)), and the JIT-15930 dual-sign branch selected for the reconfigure run.

Ref: JIT-15930