### PR TITLE
fix(jicofo,jvb): extract rtcstats-push in-container (Nomad 4096-file limit)

### DIFF
--- a/nomad/jitsi_packs/packs/jitsi_meet_backend/templates/jitsi_meet_backend.nomad.tpl
+++ b/nomad/jitsi_packs/packs/jitsi_meet_backend/templates/jitsi_meet_backend.nomad.tpl
@@ -892,7 +892,6 @@ EOF
           "local/rtcstats-push-dep:/etc/s6-overlay/s6-rc.d/60-jicofo-rtcstats-push/dependencies.d/jicofo",
           "local/rtcstats-push-contents:/etc/s6-overlay/s6-rc.d/user/contents.d/60-jicofo-rtcstats-push",
           "local/jicofo-rtcstats-push-script:/etc/s6-overlay/scripts/jicofo-rtcstats-push",
-          "local/jicofo-rtcstats-push:/opt/jicofo-rtcstats-push",
           # Periodic in-place truncation of JICOFO_LOG_FILE. Safe now that the
           # image tees with -a (append) -- docker-jitsi-meet#2268 -- so writes go
           # to EOF and an in-place truncate actually shrinks the file without
@@ -963,13 +962,18 @@ EOF
         VISITORS_XMPP_AUTH_DOMAIN="auth.[[ env "CONFIG_domain" ]]"
       }
 
-      # Unzip the rtcstats-push node app on the Nomad client. The container now
-      # runs rootless on a read-only root fs, so it can no longer apt-get/unzip
-      # at runtime. Nomad auto-extracts the .zip into the destination directory,
-      # which we bind-mount read-only at /opt/jicofo-rtcstats-push.
+      # Download the rtcstats-push zip as-is (no Nomad-side decompression): the
+      # archive bundles node_modules (~7772 files) and exceeds go-getter's default
+      # decompression_file_count_limit (4096). The service body extracts it inside
+      # the container with `jar` (ships in base-java's JDK) -- no runtime apt/unzip,
+      # works on the rootless image.
       artifact {
         source      = "https://github.com/jitsi/jicofo-rtcstats-push/releases/download/release-0.0.1/jicofo-rtcstats-push.zip"
-        destination = "local/jicofo-rtcstats-push"
+        mode        = "file"
+        destination = "local/jicofo-rtcstats-push.zip"
+        options {
+          archive = false
+        }
       }
 
       # --- rtcstats-push as an s6-overlay v3 longrun service ---
@@ -1013,14 +1017,20 @@ EOF
         perms = "644"
       }
 
-      # service body. nodejs ships in base-java; the app is bind-mounted at
-      # /opt/jicofo-rtcstats-push. with-contenv imports the container env
-      # (JICOFO_ADDRESS, RTCSTATS_SERVER, INTERVAL, ...).
+      # service body. Extracts the rtcstats-push zip into a writable dir with `jar`
+      # (JDK, base-java) on first start, then runs it. nodejs ships in base-java;
+      # with-contenv imports the container env (JICOFO_ADDRESS, RTCSTATS_SERVER,
+      # INTERVAL, ...).
       template {
         data = <<EOF
 #!/command/with-contenv bash
 
-exec node /opt/jicofo-rtcstats-push/app.js
+RTCSTATS_DIR=/tmp/jicofo-rtcstats-push
+if [ ! -f "$RTCSTATS_DIR/app.js" ]; then
+  mkdir -p "$RTCSTATS_DIR"
+  cd "$RTCSTATS_DIR" && jar xf /local/jicofo-rtcstats-push.zip
+fi
+exec node "$RTCSTATS_DIR/app.js"
 EOF
         destination = "local/jicofo-rtcstats-push-script"
         perms = "755"

--- a/nomad/jitsi_packs/packs/jitsi_meet_jvb/templates/jitsi_meet_jvb.nomad.tpl
+++ b/nomad/jitsi_packs/packs/jitsi_meet_jvb/templates/jitsi_meet_jvb.nomad.tpl
@@ -180,7 +180,6 @@ EOF
           "local/rtcstats-push-dep:/etc/s6-overlay/s6-rc.d/60-jvb-rtcstats-push/dependencies.d/jvb",
           "local/rtcstats-push-contents:/etc/s6-overlay/s6-rc.d/user/contents.d/60-jvb-rtcstats-push",
           "local/jvb-rtcstats-push-script:/etc/s6-overlay/scripts/jvb-rtcstats-push",
-          "local/jvb-rtcstats-push:/opt/jvb-rtcstats-push",
           # log-truncate sidecar (v3 longrun); safe because the image tees with -a
           "local/log-truncate-type:/etc/s6-overlay/s6-rc.d/62-jvb-log-truncate/type",
           "local/log-truncate-run:/etc/s6-overlay/s6-rc.d/62-jvb-log-truncate/run",
@@ -240,11 +239,18 @@ EOF
 #        CHROMIUM_FLAGS="--start-maximized,--kiosk,--enabled,--autoplay-policy=no-user-gesture-required,--use-fake-ui-for-media-stream,--enable-logging,--v=1"
       }
 
-      # Unzip the rtcstats-push node app on the Nomad client (rootless, read-only
-      # root means no runtime apt-get/unzip). Bind-mounted at /opt/jvb-rtcstats-push.
+      # Download the rtcstats-push zip as-is (no Nomad-side decompression): the
+      # archive bundles node_modules and exceeds go-getter's default
+      # decompression_file_count_limit (4096). The service body extracts it inside
+      # the container with `jar` (ships in base-java's JDK) -- no runtime apt/unzip,
+      # works on the rootless image.
       artifact {
         source      = "https://github.com/jitsi/jvb-rtcstats-push/releases/download/0.0.3/jvb-rtcstats-push.zip"
-        destination = "local/jvb-rtcstats-push"
+        mode        = "file"
+        destination = "local/jvb-rtcstats-push.zip"
+        options {
+          archive = false
+        }
       }
 
       template {
@@ -342,7 +348,12 @@ EOF
         data = <<EOF
 #!/command/with-contenv bash
 
-exec node /opt/jvb-rtcstats-push/app.js
+RTCSTATS_DIR=/tmp/jvb-rtcstats-push
+if [ ! -f "$RTCSTATS_DIR/app.js" ]; then
+  mkdir -p "$RTCSTATS_DIR"
+  cd "$RTCSTATS_DIR" && jar xf /local/jvb-rtcstats-push.zip
+fi
+exec node "$RTCSTATS_DIR/app.js"
 EOF
         destination = "local/jvb-rtcstats-push-script"
         perms = "755"


### PR DESCRIPTION
## Problem

The s6-overlay v3 migration (#1100) switched the rtcstats-push artifact to **Nomad-side decompression**. But the release zips bundle `node_modules` (~7772 files for jicofo), which exceeds go-getter's default `decompression_file_count_limit` (4096), so the download fails:

```
failed to download artifact "https://github.com/jitsi/jicofo-rtcstats-push/releases/download/release-0.0.1/jicofo-rtcstats-push.zip": getter subprocess failed: exit status 1: failed to download artifact: zip archive contains too many files: 7772 > 4096
```

### Collateral: the "prosody" symptom
jicofo, jvb-prosody, prosody and web all share the **`signal`** group. When jicofo's artifact download fails, the whole alloc fails, so prosody (which had started cleanly) is torn down with a graceful s6 shutdown — which looks like a separate prosody bug but is just collateral. This fix resolves that too.

## Fix

Download the zip as a **plain file** again (`mode = "file"`, `archive = false` → no Nomad decompression, no file-count limit) and extract it **inside the container** with `jar xf` (the JDK ships in `base-java`) into `/tmp` on first service start:

```bash
RTCSTATS_DIR=/tmp/jicofo-rtcstats-push
if [ ! -f "$RTCSTATS_DIR/app.js" ]; then
  mkdir -p "$RTCSTATS_DIR"
  cd "$RTCSTATS_DIR" && jar xf /local/jicofo-rtcstats-push.zip
fi
exec node "$RTCSTATS_DIR/app.js"
```

No runtime `apt`/`unzip` and no `/usr` write, so it works on the rootless image. Applied to **jicofo and jvb** (same pattern). The `/opt/...-rtcstats-push` bind-mount of the (previously Nomad-extracted) dir is removed.

### Alternative considered
`decompression_file_count_limit` can be raised, but it's a **Nomad client-agent** setting (not per-job) — a broader node-config change touching every job's security posture. In-container extraction keeps the fix contained to these jobs.

Refs JIT-15926

🤖 Generated with [Claude Code](https://claude.com/claude-code)
