### PR TITLE
fix(web): map http/https to rootless ports 8000/8443 (fixes beta 502)

### DIFF
--- a/nomad/jitsi_packs/packs/jitsi_meet_web/templates/jitsi_meet_web.nomad.tpl
+++ b/nomad/jitsi_packs/packs/jitsi_meet_web/templates/jitsi_meet_web.nomad.tpl
@@ -67,11 +67,15 @@ job [[ template "job_name" . ]] {
     }
 
     network {
+      # The rootless jitsi web image listens on unprivileged ports 8000/8443
+      # (uid 1000), not 80/443. Mapping to 80/443 left nothing listening on the
+      # http backend port, so the shard nginx upstream got ECONNREFUSED ("no live
+      # upstreams" -> 502) even though the nginx-status health check (888) passed.
       port "http" {
-        to = 80
+        to = 8000
       }
       port "https" {
-        to = 443
+        to = 8443
       }
       port "nginx-status" {
         to = 888


### PR DESCRIPTION
## Site-down fix (beta 502)

beta.meet.jit.si returns 502 from Cloudflare. Root cause: the rootless jitsi web image listens on **unprivileged ports 8000 (http) / 8443 (https)** as uid 1000, but the web pack mapped the container target to **80/443**. Nothing listens on the http backend port, so the shard nginx upstream (`release-N.jitsi-meet-web`) gets **ECONNREFUSED on every instance** → `no live upstreams` → 502, which HAProxy returns to clients.

**Masked by the health check:** the consul check probes `nginx-status` (port 888, served by our mounted `status.conf`), which was up — so `jitsi-meet-web` registered **healthy** while its actual HTTP port was dead.

## Fix
Map `http -> 8000` and `https -> 8443` to match the image. `nginx-status` (888) unchanged.

Confirmed against the image defaults (`web/rootfs/defaults/default`: `listen 8000` / `listen 8443`). Verified via Loki that the shard nginx upstreams were refusing connections on the old port across all three regions (uk-london-1, us-phoenix-1, us-ashburn-1).

Refs JIT-15926

🤖 Generated with [Claude Code](https://claude.com/claude-code)