### PR TITLE
fix(web): include nginx site-confs from /run path so the :8000 server loads (beta 502)

### DIFF
--- a/nomad/jitsi_packs/packs/jitsi_meet_web/templates/jitsi_meet_web.nomad.tpl
+++ b/nomad/jitsi_packs/packs/jitsi_meet_web/templates/jitsi_meet_web.nomad.tpl
@@ -328,7 +328,12 @@ http {
 	##
 	# Virtual Host Configs
 	##
-	include /config/nginx/site-confs/*;
+	# The rootless web image renders its server configs (the listen-8000 default
+	# server + meet.conf) into /run/web/config/nginx/site-confs/, and copies
+	# /config/. there too (so our mounted status.conf lands alongside). Including
+	# the old /config path only picked up status.conf (888) and never the
+	# listen-8000 server -> nothing on 8000 -> shard nginx ECONNREFUSED -> 502.
+	include /run/web/config/nginx/site-confs/*;
 }
 
 daemon off;


### PR DESCRIPTION
## Second half of the beta 502 fix

After the port-mapping fix (#1106, http/https -> 8000/8443), the site **still** 502'd: web-release-6880 came up but the shard nginx upstream still got ECONNREFUSED, and the web container logged zero requests.

### Root cause
Our overriding `nginx.conf` (mounted to `/defaults/nginx.conf`) included virtual hosts from `/config/nginx/site-confs/*`. The **rootless web image renders its server configs into `/run/web/config/nginx/site-confs/`** — the `listen 8000` default server and `meet.conf` live there. So nginx only loaded the single file we mount into `/config` (`status.conf`, listen 888) and **never loaded the listen-8000 server** → nothing on 8000 → `no live upstreams` → 502.

The 888 status server still came up, so the consul check (`/nginx_status` on 888) passed and `jitsi-meet-web` registered **healthy** — masking the dead site port.

### Fix
```
include /run/web/config/nginx/site-confs/*;   # was /config/nginx/site-confs/*
```
The image copies `/config/.` → `/run/web/config`, so our mounted `status.conf` is still picked up there.

**Deploy:** needs the web release re-rendered/redeployed (release 6880 web, or a new beta release) for the shards (which route to `release-6880.jitsi-meet-web`) to reach a working backend.

Refs JIT-15926

🤖 Generated with [Claude Code](https://claude.com/claude-code)