### PR TITLE
fix(reconfigure-ops-repo): share bucket-scoped ops-repo lock with build-branding-debs (JIT-15930)

### DIFF
--- a/jenkins/groovy/reconfigure-ops-repo/Jenkinsfile
+++ b/jenkins/groovy/reconfigure-ops-repo/Jenkinsfile
@@ -27,8 +27,10 @@ pipeline {
                 script {
                     echo "ops repo rebuild (bucket=${env.OPS_REPO_BUCKET ?: 'ops-repo'})"
                     dir('infra-provisioning') {
-                      // Lock per-bucket so a test-bucket rebuild does not block the production one.
-                      lock("reconfigure-ops-repo-${env.OPS_REPO_BUCKET ?: 'ops-repo'}") {
+                      // Bucket-scoped lock shared with build-branding-debs so the two jobs
+                      // never mutate the same ops-repo bucket concurrently, while different
+                      // buckets (e.g. ops-repo-test) stay independent. See JIT-15930.
+                      lock("ops-repo-bucket-${env.OPS_REPO_BUCKET ?: 'ops-repo'}") {
                         withCredentials([
                             file(credentialsId: 'ops-repo-s3fs', variable: 'S3_PASSWORD_PATH'),
                             file(credentialsId: env.OPS_REPO_SECRING_CREDENTIAL_ID ?: 'ops-repo-secring', variable: 'OPS_REPO_SECRING_PATH'),


### PR DESCRIPTION
## Why

#1103 changed this job's lock from `lock("ops-repo")` to `lock("reconfigure-ops-repo-${OPS_REPO_BUCKET}")`. That broke mutual exclusion with **build-branding-debs** (which holds `lock("ops-repo")`): the two jobs could then run **concurrently against the prod `ops-repo` bucket**, both mounting it via s3fs and running mini-dinstall — risking a corrupt/half-signed index.

## What

Use a shared, bucket-scoped lock name `ops-repo-bucket-${OPS_REPO_BUCKET}` (default `ops-repo-bucket-ops-repo`). build-branding-debs is updated to the same name in jitsi/infra-customizations-private#1047. Result:
- prod runs of either job serialize on `ops-repo-bucket-ops-repo`, and
- non-prod buckets (e.g. `ops-repo-test`) keep their own lock, so test rebuilds don't block prod.

Companion to #1047. Ref: JIT-15930