### PR TITLE
feat: attribute VM release components to source repos + per-component deploy gates for core

### DIFF
--- a/jenkins/groovy/create-release-jibri/Jenkinsfile
+++ b/jenkins/groovy/create-release-jibri/Jenkinsfile
@@ -96,6 +96,11 @@ pipeline {				//indicate the job is written in Declarative Pipeline
                       version:       env.JIBRI_VERSION,
                       artifactType:  'vm',
                       environment:   env.ENVIRONMENT,
+                      // The jibri VM is built from jitsi/jibri, not the
+                      // infra-provisioning workspace this job runs in. Point the
+                      // primary component's git at the real source so it is not
+                      // mis-attributed to infra-provisioning.
+                      git: [repository: 'https://github.com/jitsi/jibri', commit: jibriGitHash, branch: '', pr: ''],
                       // Standard governance job parameters (see
                       // the governance provider's JOB_PARAMETERS.md).
                       // Undefined params resolve to null -> init applies its defaults.

--- a/jenkins/groovy/release-core/Jenkinsfile
+++ b/jenkins/groovy/release-core/Jenkinsfile
@@ -1,6 +1,7 @@
 def utils
 def governance
 def artConfig
+def coreComponents
 import groovy.json.JsonOutput
 
 // splits incoming clouds into a list
@@ -280,7 +281,7 @@ pipeline {
             steps {
                 script {
                     dir('infra-provisioning') {
-                        def coreComponents = collectCoreComponents(env.SIGNAL_VERSION, env.JVB_VERSION)
+                        coreComponents = collectCoreComponents(env.SIGNAL_VERSION, env.JVB_VERSION)
                         governance = utils.LoadGovernanceHooks()
                         artConfig = governance.init([
                             serviceName:   'core',
@@ -330,8 +331,12 @@ pipeline {
                 stage('Governance') {
                     steps {
                         script {
+                            // Aggregate release gate (umbrella for all components),
+                            // then a focused pre-deploy gate per source component
+                            // (jicofo, jitsi-meet, jvb...), each attributed to its
+                            // own repo. Components without a git commit are skipped.
                             governance.preRelease(artConfig)
-                            governance.preDeploy(artConfig)
+                            governance.preDeployComponents(artConfig, coreComponents)
                         }
                     }
                 }
@@ -484,7 +489,7 @@ pipeline {
         always {
             script {
                 if (governance != null) {
-                    governance.postHooks(artConfig, currentBuild.result == 'SUCCESS')
+                    governance.postHooksComponents(artConfig, coreComponents, currentBuild.result == 'SUCCESS')
                 }
             }
         }

--- a/jenkins/groovy/release-jigasi/Jenkinsfile
+++ b/jenkins/groovy/release-jigasi/Jenkinsfile
@@ -104,6 +104,10 @@ pipeline {				//indicate the job is written in Declarative Pipeline
                             version:       env.JIGASI_VERSION,
                             artifactType:  'vm',
                             environment:   env.ENVIRONMENT,
+                            // The jigasi VM is built from jitsi/jigasi, not the
+                            // infra-provisioning workspace this job runs in. Point
+                            // the primary component's git at the real source.
+                            git: [repository: 'https://github.com/jitsi/jigasi', commit: jigasiHash, branch: '', pr: ''],
                             // Standard governance job parameters (see
                             // the governance provider's JOB_PARAMETERS.md).
                             // Undefined params resolve to null -> init applies its defaults.

--- a/jenkins/groovy/release-jvb/Jenkinsfile
+++ b/jenkins/groovy/release-jvb/Jenkinsfile
@@ -191,6 +191,10 @@ pipeline {
                         version:       env.JVB_VERSION,
                         artifactType:  'vm',
                         environment:   env.ENVIRONMENT,
+                        // The jvb VM is built from jitsi/jitsi-videobridge, not the
+                        // infra-provisioning workspace this job runs in. Point the
+                        // primary component's git at the real source.
+                        git: [repository: 'https://github.com/jitsi/jitsi-videobridge', commit: jvbHash, branch: '', pr: ''],
                         // Standard governance job parameters (see
                         // the governance provider's JOB_PARAMETERS.md).
                         // Undefined params resolve to null -> init applies its defaults.

--- a/jenkins/groovy/release-sip-jibri/Jenkinsfile
+++ b/jenkins/groovy/release-sip-jibri/Jenkinsfile
@@ -124,6 +124,10 @@ pipeline {				//indicate the job is written in Declarative Pipeline
                             version:       env.JIBRI_VERSION,
                             artifactType:  'vm',
                             environment:   env.ENVIRONMENT,
+                            // The sip-jibri VM is built from jitsi/jibri, not the
+                            // infra-provisioning workspace this job runs in. Point
+                            // the primary component's git at the real source.
+                            git: [repository: 'https://github.com/jitsi/jibri', commit: jibriHash, branch: '', pr: ''],
                             // Standard governance job parameters (see
                             // the governance provider's JOB_PARAMETERS.md).
                             // Undefined params resolve to null -> init applies its defaults.


### PR DESCRIPTION
## Two related changes

### 1. Attribute VM release components to their real source repos
The governance primary component's git was derived from the Jenkins workspace (`infra-provisioning`), mis-attributing VM releases built from their own repos. Each now passes the source git via the new `git` governance option:

| Job | serviceName | source repo |
|-----|-------------|-------------|
| create-release-jibri | jibri | jitsi/jibri |
| release-jigasi | jigasi | jitsi/jigasi |
| release-jvb | jvb | jitsi/jitsi-videobridge |
| release-sip-jibri | sip-jibri | jitsi/jibri |

### 2. Per-component deploy gates for `release-core`
`core` deploys several independently-sourced services (jicofo, jitsi-meet, jvb...). It now sends a focused **pre-deploy/post-deploy gate per component** — each attributed to its own repo — via the new `preDeployComponents`/`postHooksComponents` API, while the **release gate stays aggregate** (umbrella listing all components). Components without a git commit (prosody) are skipped.

Non-source jobs (haproxy, coturn, nomad-*) are unaffected.

## Dependencies
- jitsi/jenkins-govern8-integration#4 (governance library consumes `artConfig.git`)
- infra-customizations-private#1054 (governance hooks: `opts.git` + per-component API)

## Test plan
- [ ] jibri/jigasi/jvb/sip-jibri: primary component shows its real source repo + commit
- [ ] core: one aggregate release gate + a pre-deploy/post-deploy per component (jicofo/jitsi-meet/jvb), prosody skipped
- [ ] Jobs without a `git` override still resolve the workspace repo