### PR TITLE
fix: pass release envelope to post-enable (GA) so /gate/release validates

### DIFF
--- a/jenkins/groovy/release-core/Jenkinsfile
+++ b/jenkins/groovy/release-core/Jenkinsfile
@@ -347,6 +347,7 @@ pipeline {
                                 def createdAt = sh(returnStdout: true, script: 'date -u +"%Y-%m-%dT%H:%M:%SZ"').trim()
                                 def details = [
                                     releaseNumber: env.BUILD_ID,
+                                    releaseId    : env.RELEASE_ID,
                                     environment  : env.ENVIRONMENT,
                                     rp           : governance.getRpTicket() ?: '',
                                     signalVersion: env.SIGNAL_VERSION,

--- a/jenkins/groovy/set-release-ga/Jenkinsfile
+++ b/jenkins/groovy/set-release-ga/Jenkinsfile
@@ -188,7 +188,12 @@ ENVIRONMENT=${env.ENVIRONMENT} RELEASE_NUMBER=${env.RELEASE_NUMBER} scripts/cons
                                 verbose:      params.GOVERNANCE_VERBOSE,
                             ])
                             // effectiveAt defaults to now (the GA moment) inside the hook.
+                            // releaseId/name/environment/components form the release
+                            // envelope /gate/release validates; reuse the original
+                            // release's id so the enable ties back to that release.
                             governance.postEnable([
+                                releaseId:  details.releaseId ?: "${env.RELEASE_NUMBER}_core",
+                                name:       "Core release ${env.RELEASE_NUMBER}",
                                 key:        'core',
                                 label:      "Core release ${env.RELEASE_NUMBER} (${env.ENVIRONMENT})",
                                 components: components,


### PR DESCRIPTION
## Problem
GA promotion's post-enable POST to `/gate/release` was rejected with a 400 — the endpoint validates the release envelope (`releaseId`, `context.name`, `context.environment`, `context.components`) for every phase, and the call didn't supply them.

## Fix
- `release-core` stores the original `releaseId` (env.RELEASE_ID) in the consul release-details record.
- `set-release-ga` passes `releaseId` (from the stored record, fallback `<release>_core`) and a `name` to `postEnable`, so the enable references the original release and satisfies validation. Components already come from the stored record (real per-service versions).

## Dependencies
- jitsi/jenkins-govern8-integration#6 (library hook emits envelope)
- infra-customizations-private#1056 (postEnable defaults/forwards envelope)

## Test plan
- [ ] release-core writes releaseId into releases/<env>/<release>/details
- [ ] set-release-ga GA promotion (incl. beta/no-RP) sends a post-enable that passes /gate/release validation