### PR TITLE
fix: store component artifact type for post-enable envelope

### DIFF
--- a/jenkins/groovy/release-core/Jenkinsfile
+++ b/jenkins/groovy/release-core/Jenkinsfile
@@ -354,7 +354,7 @@ pipeline {
                                     jvbVersion   : env.JVB_VERSION,
                                     branch       : env.RELEASE_BRANCH ?: git_branch,
                                     requestedBy  : env.BUILD_USER_ID ?: 'jenkins',
-                                    components   : coreComponents.collect { [name: it.name, version: it.artifact?.version] },
+                                    components   : coreComponents.collect { [name: it.name, type: it.artifact?.type, version: it.artifact?.version] },
                                     createdAt    : createdAt,
                                 ]
                                 dir('infra-provisioning') {

--- a/jenkins/groovy/set-release-ga/Jenkinsfile
+++ b/jenkins/groovy/set-release-ga/Jenkinsfile
@@ -170,7 +170,7 @@ ENVIRONMENT=${env.ENVIRONMENT} RELEASE_NUMBER=${env.RELEASE_NUMBER} scripts/cons
                             // Components: stored per-service versions, else a single core fallback.
                             def components = (details.components instanceof List && details.components) \
                                 ? details.components \
-                                : [[name: 'core', version: env.RELEASE_NUMBER]]
+                                : [[name: 'core', type: 'vm', version: env.RELEASE_NUMBER]]
                             echo "Post-enable RP ticket: ${rpTicket ?: '(none)'}, components: ${components}"
 
                             governance = utils.LoadGovernanceHooks()


### PR DESCRIPTION
## Problem
GA promotion's post-enable 400s with `context.components[N].artifact: Component artifact is required` — `/gate/release` requires an `artifact{type,version}` per component, and the release-details record only stored `{name, version}`.

## Fix
- `release-core`: store each component's artifact `type` in the details record (`{name, type, version}`) — jicofo/jitsi-meet/jvb=`git`, prosody=`deb`.
- `set-release-ga`: give the core fallback component a `vm` type.

The library hook (jitsi/jenkins-govern8-integration#7) builds `artifact{type,version}` from these and defaults `type` to `git` for details records written before this change.

## Dependencies
- jitsi/jenkins-govern8-integration#7 (hook emits the artifact object)

## Test plan
- [ ] new release-core run stores component types in releases/<env>/<release>/details
- [ ] set-release-ga post-enable passes /gate/release validation with accurate component artifact types