### PR TITLE
chore(docker): venv for ops image python tooling instead of --break-system-packages

### DIFF
--- a/docker/ops-agent/Dockerfile
+++ b/docker/ops-agent/Dockerfile
@@ -19,8 +19,17 @@ USER root
 RUN apt-get update && apt-get -y install procps dnsutils \
   jq python3-pip python3-venv rsync wget curl gpg unzip zip git python-is-python3 maven xvfb imagemagick s3cmd s3fs mini-dinstall \
   sudo devscripts dpkg-dev amazon-ecr-credential-helper netcat-openbsd rclone
-RUN pip install --break-system-packages -r /home/jenkins/requirements.txt \
-  && pip install --break-system-packages jenkins-job-builder
+# Install python tooling (ansible, oci-cli, awscli, jenkins-job-builder, ...) into an
+# isolated virtualenv instead of the system interpreter (PEP 668 / --break-system-packages).
+# --system-site-packages keeps access to apt-provided python modules.
+ENV VIRTUAL_ENV=/opt/jenkins/venv
+RUN python3 -m venv --system-site-packages "$VIRTUAL_ENV" && \
+    "$VIRTUAL_ENV/bin/pip" install --no-cache-dir --upgrade pip wheel "setuptools<81" && \
+    "$VIRTUAL_ENV/bin/pip" install --no-cache-dir -r /home/jenkins/requirements.txt jenkins-job-builder && \
+    chown -R jenkins:jenkins /opt/jenkins
+# Activate the venv for every shell/build on this agent (inherited by `docker exec` from
+# the attach connector) so the tools above are on PATH without each job activating it.
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 RUN echo "%jenkins ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/jenkins
 RUN wget -O- https://apt.releases.hashicorp.com/gpg | \

--- a/docker/ops-jenkins/Dockerfile
+++ b/docker/ops-jenkins/Dockerfile
@@ -12,10 +12,19 @@ COPY ./requirements.txt /home/jenkins/requirements.txt
 COPY ./plugins.txt /home/jenkins/plugins.txt
 
 USER root
+# Install ansible / jenkins-job-builder into an isolated virtualenv rather than the
+# system interpreter (PEP 668 / --break-system-packages). --system-site-packages keeps
+# access to apt-provided python modules while layering our pip packages on top.
+ENV VIRTUAL_ENV=/opt/jenkins/venv
 RUN apt-get update && \
-    apt-get -y install procps dnsutils jq python3-pip wget curl gpg unzip zip git python-is-python3 maven xvfb imagemagick sudo && \
-    pip install --break-system-packages -r /home/jenkins/requirements.txt && \
-    pip install --break-system-packages jenkins-job-builder
+    apt-get -y install procps dnsutils jq python3-pip python3-venv wget curl gpg unzip zip git python-is-python3 maven xvfb imagemagick sudo && \
+    python3 -m venv --system-site-packages "$VIRTUAL_ENV" && \
+    "$VIRTUAL_ENV/bin/pip" install --no-cache-dir --upgrade pip wheel "setuptools<81" && \
+    "$VIRTUAL_ENV/bin/pip" install --no-cache-dir -r /home/jenkins/requirements.txt jenkins-job-builder && \
+    chown -R jenkins:jenkins /opt/jenkins
+# Activate the venv for every shell/build on this controller (the "jenkins-local" node)
+# so ansible / jenkins-jobs resolve to the venv before any local-node job runs.
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN echo "%jenkins ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/jenkins
 
 RUN wget -O-  https://download.docker.com/linux/debian/gpg | \


### PR DESCRIPTION
## What

Replace `pip install --break-system-packages` in the **ops-jenkins** and **ops-agent** Docker images with an isolated Python virtualenv at `/opt/jenkins/venv`.

- `python3 -m venv --system-site-packages /opt/jenkins/venv` — keeps apt-provided python modules visible while layering our pip packages on top
- install `requirements.txt` + `jenkins-job-builder` (ops-agent also: `oci-cli`, `awscli`, `ansible`, etc.) into the venv
- `chown` to `jenkins`, then `ENV PATH="$VIRTUAL_ENV/bin:$PATH"` to activate it image-wide
- pin `setuptools<81` so `pkg_resources` stays available (removed in setuptools 81), which `jenkins-job-builder`'s stevedore entry points require

## Why no job changes are needed

The venv is activated via `ENV PATH`, which is inherited by every build:
- **ops-jenkins** (`jenkins-local` controller): Jenkins `sh` steps inherit the container env
- **ops-agent**: Jenkins connects via the attach connector (`docker exec`), which also inherits the image env

So all `agent any` jobs and the pinned `jenkins-local` reconfigure-users job get `ansible` / `jenkins-jobs` / `oci` / `aws` on `PATH` automatically — no Jenkinsfile or job-YAML edits.

## Testing

Built both images single-arch (arm64) locally and verified in a non-login shell (what Jenkins `sh` and `docker exec` use):

| Check | ops-jenkins | ops-agent |
|---|---|---|
| `PATH` starts with `/opt/jenkins/venv/bin` | ✅ | ✅ |
| `ansible` / `ansible-playbook` → venv | ✅ 2.16.19 | ✅ 11.1.0 |
| `jenkins-jobs` → venv | ✅ 6.5.0 | ✅ 6.5.0 |
| `oci` / `aws` → venv | — | ✅ 3.89.0 / 1.45.37 |
| `terraform` / `nomad` / `node` still system | n/a | ✅ unaffected |
| `import pkg_resources` works | ✅ | ✅ |

> Note: a **login** shell (`bash -l`) re-sources `/etc/profile` and resets `PATH`, but Jenkins does not use login shells for build steps, so this does not affect builds.