### PR TITLE
feat(jvb): internal scheduled-scaling for release JVB pools at GA

### DIFF
--- a/jenkins/groovy/set-release-ga/Jenkinsfile
+++ b/jenkins/groovy/set-release-ga/Jenkinsfile
@@ -33,12 +33,19 @@ else
             echo "## found jvb scaling groups for \${REGION}: \${JVB_GROUPS}"
         fi
         for GROUP in \$JVB_GROUPS; do
-            if [[ "\$GROUP" =~ "JVB" ]] && [[ "\$GROUP" =~ "${release_number}" ]] && ([[ "\$GROUP" =~ "-local-" ]] || [[ "\$GROUP" =~ "-global-" ]]); then
-                echo "## adding to scheduler: \${GROUP}"
-                ENABLE_SCHEDULER=true ORACLE_REGION=\${REGION} GROUP_NAME=\${GROUP} TYPE=JVB scripts/custom-autoscaler-update-scaling-activities.sh
-            else
-                echo "## removing from scheduler: \${GROUP}"
-                ENABLE_SCHEDULER=false ORACLE_REGION=\${REGION} GROUP_NAME=\${GROUP} TYPE=JVB scripts/custom-autoscaler-update-scaling-activities.sh
+            # Only the release-facing local/global JVB pools carry a schedule.
+            if [[ "\$GROUP" =~ "JVB" ]] && ([[ "\$GROUP" =~ "-local-" ]] || [[ "\$GROUP" =~ "-global-" ]]); then
+                # Flip only the internal scheduling (scheduledScaling.enabled) flag on the
+                # group's embedded schedule: on for the GA release, off for groups leaving GA.
+                # enableScheduler is deprecated and no longer touched here.
+                if [[ "\$GROUP" =~ "${release_number}" ]]; then
+                    echo "## enabling internal scheduling: \${GROUP}"
+                    # exit 231 == group has no embedded schedule yet (legacy); a benign skip, not a failure.
+                    ACTION=enable ORACLE_REGION=\${REGION} GROUP_NAME=\${GROUP} TYPE=JVB scripts/custom-autoscaler-update-scheduled-scaling.sh || [ \$? -eq 231 ]
+                else
+                    echo "## disabling internal scheduling: \${GROUP}"
+                    ACTION=disable ORACLE_REGION=\${REGION} GROUP_NAME=\${GROUP} TYPE=JVB scripts/custom-autoscaler-update-scheduled-scaling.sh
+                fi
             fi
         done
     done

--- a/scripts/create-jvb-pool.sh
+++ b/scripts/create-jvb-pool.sh
@@ -230,6 +230,17 @@ fi
 [ -z "$AUTOSCALER_TYPE" ] && AUTOSCALER_TYPE="JVB"
 
 export TYPE="$AUTOSCALER_TYPE"
+
+# check for a regional per-pool-mode JVB scheduled scaling ("internal scheduling")
+# config and embed it in the group at creation if present (enabled is forced off
+# until the release goes GA). Keyed by region then pool mode (local/global/remote/…),
+# so e.g. remote pools stay unscheduled simply by omitting them from the file.
+JVB_SCHEDULE_FILE="./sites/$ENVIRONMENT/jvb-schedule-by-region"
+if [ -f "$JVB_SCHEDULE_FILE" ]; then
+  JVB_SCHEDULE_CONFIG=$(jq -c --arg r "$ORACLE_REGION" --arg m "$JVB_POOL_MODE" '.[$r][$m] // empty' "$JVB_SCHEDULE_FILE" 2>/dev/null)
+  [ -n "$JVB_SCHEDULE_CONFIG" ] && export SCHEDULED_SCALING_CONFIG="$JVB_SCHEDULE_CONFIG"
+fi
+
 export INSTANCE_CONFIGURATION_ID=$INSTANCE_CONFIGURATION_ID
 export TAG_RELEASE_NUMBER=$INSTANCE_CONFIG_RELEASE_NUMBER
 export GROUP_NAME="${JVB_POOL_NAME}-${GROUP_NAME_SUFFIX}"

--- a/scripts/custom-autoscaler-create-group.sh
+++ b/scripts/custom-autoscaler-create-group.sh
@@ -184,6 +184,35 @@ elif [ "$getGroupHttpCode" == 200 ]; then
   fi
 fi
 
+# Optional scheduled scaling ("internal scheduling") config. When a schedule is
+# supplied via SCHEDULED_SCALING_CONFIG (region/type schedule read from
+# sites/*/jvb-schedule-by-region by the caller), embed it in the group so the
+# schedule travels with the group from creation. New groups are created with the
+# schedule disabled; it is flipped on when the release goes GA (see
+# set-release-ga). enableScheduler is deprecated and intentionally not managed here.
+SCHEDULED_SCALING_BODY=""
+if [ "$getGroupHttpCode" == 200 ]; then
+  EXISTING_SCHEDULED_SCALING=$(echo "$instanceGroupDetails" | jq -c '.instanceGroup.scheduledScaling // empty' 2>/dev/null)
+  EXISTING_SS_ENABLED=$(echo "$instanceGroupDetails" | jq -r '.instanceGroup.scheduledScaling.enabled // empty' 2>/dev/null)
+fi
+if [ -n "$SCHEDULED_SCALING_CONFIG" ]; then
+  if ! echo "$SCHEDULED_SCALING_CONFIG" | jq . > /dev/null 2>&1; then
+    echo "SCHEDULED_SCALING_CONFIG is not valid JSON. Exiting.. "
+    exit 231
+  fi
+  # Preserve the live enabled flag on existing groups so re-running create/rotate
+  # never flips a GA group's schedule off; default brand-new groups to disabled.
+  if [ -n "$EXISTING_SS_ENABLED" ]; then
+    SCHEDULED_SCALING_BODY=$(echo "$SCHEDULED_SCALING_CONFIG" | jq -c --argjson e "$EXISTING_SS_ENABLED" '.enabled=$e')
+  else
+    SCHEDULED_SCALING_BODY=$(echo "$SCHEDULED_SCALING_CONFIG" | jq -c '.enabled=false')
+  fi
+elif [ -n "$EXISTING_SCHEDULED_SCALING" ]; then
+  # No schedule supplied but the group already has one: preserve it as-is so the
+  # full-object upsert does not wipe it.
+  SCHEDULED_SCALING_BODY="$EXISTING_SCHEDULED_SCALING"
+fi
+
 REQUEST_BODY='{
             "name": "'"$GROUP_NAME"'",
             "type": "'$TYPE'",
@@ -214,6 +243,10 @@ REQUEST_BODY='{
             },
             "cloud": "'$CLOUD_PROVIDER'"
 }'
+
+if [ -n "$SCHEDULED_SCALING_BODY" ]; then
+  REQUEST_BODY=$(echo "$REQUEST_BODY" | jq -c --argjson ss "$SCHEDULED_SCALING_BODY" '. += {"scheduledScaling": $ss}')
+fi
 
 echo "Creating group named $GROUP_NAME"
 instanceGroupCreateResponse=$(curl -s -w "\n %{http_code}" -X PUT \

--- a/scripts/custom-autoscaler-update-scheduled-scaling.sh
+++ b/scripts/custom-autoscaler-update-scheduled-scaling.sh
@@ -56,6 +56,17 @@ fi
 
 [ -z "$ACTION" ] && ACTION="put"
 
+# GET the group's current scheduled scaling config, following the same
+# local-autoscaler fallback as custom-autoscaler-update-scaling-activities.sh so
+# nomad/local-autoscaler JVB groups resolve correctly.
+function getScheduledScaling() {
+  getResponse=$(curl -s -w "\n %{http_code}" -X GET \
+    "$AUTOSCALER_URL"/groups/"$GROUP_NAME"/scheduled-scaling \
+    -H "Authorization: Bearer $TOKEN")
+  getHttpCode=$(tail -n1 <<<"$getResponse" | sed 's/[^0-9]*//g')
+  getBody=$(sed '$ d' <<<"$getResponse")
+}
+
 if [ "$ACTION" == "delete" ]; then
   echo "Deleting scheduled scaling config for group $GROUP_NAME"
 
@@ -100,7 +111,57 @@ elif [ "$ACTION" == "put" ]; then
     echo "Error updating scheduled scaling config for group $GROUP_NAME. AutoScaler response status code is $httpCode"
     exit 208
   fi
+elif [ "$ACTION" == "enable" ] || [ "$ACTION" == "disable" ]; then
+  # Flip only the enabled flag on the group's existing (embedded) schedule,
+  # preserving its periods/timezone. Used at set-release-ga to turn internal
+  # scheduling on for the GA release and off for groups leaving GA, without
+  # re-supplying the schedule. enableScheduler is deprecated and left untouched;
+  # the autoscaler drops it to false on its own when enabled=true.
+  if [ "$ACTION" == "enable" ]; then TARGET_ENABLED=true; else TARGET_ENABLED=false; fi
+
+  getScheduledScaling
+  if { [ "$getHttpCode" == 404 ] || [ "$getHttpCode" == 000 ]; } && [ -n "$ENVIRONMENT" ] && [ -n "$ORACLE_REGION" ]; then
+    echo "Group $GROUP_NAME not found at $AUTOSCALER_URL. Trying local autoscaler"
+    export AUTOSCALER_URL="https://${ENVIRONMENT}-${ORACLE_REGION}-autoscaler.${TOP_LEVEL_DNS_ZONE_NAME}"
+    getScheduledScaling
+  fi
+
+  if [ "$getHttpCode" != 200 ]; then
+    echo "Error fetching scheduled scaling config for group $GROUP_NAME. AutoScaler response status code is $getHttpCode"
+    exit 208
+  fi
+
+  CURRENT_CONFIG=$(echo "$getBody" | jq -c '.scheduledScaling // empty' 2>/dev/null)
+  if [ -z "$CURRENT_CONFIG" ]; then
+    if [ "$ACTION" == "enable" ]; then
+      # No embedded schedule (e.g. a legacy group created before schedules were
+      # baked in at creation). Nothing to enable; skip rather than fail the release.
+      echo "No scheduled scaling config present for group $GROUP_NAME; cannot enable. Skipping."
+      exit 231
+    else
+      echo "No scheduled scaling config present for group $GROUP_NAME; nothing to disable."
+      exit 0
+    fi
+  fi
+
+  NEW_CONFIG=$(echo "$CURRENT_CONFIG" | jq -c --argjson e "$TARGET_ENABLED" '.enabled=$e')
+
+  echo "Setting scheduled scaling enabled=$TARGET_ENABLED for group $GROUP_NAME"
+  response=$(curl -s -w "\n %{http_code}" -X PUT \
+    "$AUTOSCALER_URL"/groups/"$GROUP_NAME"/scheduled-scaling \
+    -H 'Content-Type: application/json' \
+    -H "Authorization: Bearer $TOKEN" \
+    -d "$NEW_CONFIG")
+
+  httpCode=$(tail -n1 <<<"$response" | sed 's/[^0-9]*//g')
+
+  if [ "$httpCode" == 200 ]; then
+    echo "Successfully set scheduled scaling enabled=$TARGET_ENABLED for group $GROUP_NAME"
+  else
+    echo "Error updating scheduled scaling config for group $GROUP_NAME. AutoScaler response status code is $httpCode"
+    exit 208
+  fi
 else
-  echo "Unknown ACTION '$ACTION'. Must be 'put' or 'delete'. Exiting.. "
+  echo "Unknown ACTION '$ACTION'. Must be 'put', 'delete', 'enable', or 'disable'. Exiting.. "
   exit 221
 fi


### PR DESCRIPTION
## What
Switches release JVB pools from the deprecated `enableScheduler` (external scheduling) to the autoscaler's **internal `scheduledScaling`**. The schedule is baked into each group at creation (disabled) and flipped on when the release goes GA.

## Changes
- **custom-autoscaler-create-group.sh** — embed a `scheduledScaling` block from `SCHEDULED_SCALING_CONFIG` at creation. New groups get `enabled:false`; on rotate the live `enabled` flag is preserved so a GA group's schedule is never wiped.
- **create-jvb-pool.sh** — read `sites/<env>/jvb-schedule-by-region`, keyed by region + pool mode (local/global/remote/…), and pass it through. Remote pools stay unscheduled simply by omitting them from the file.
- **custom-autoscaler-update-scheduled-scaling.sh** — new `enable`/`disable` actions that GET the embedded schedule, flip only `.enabled`, and PUT it back (with local-autoscaler fallback). Exit 231 = no schedule to enable (benign skip for legacy groups).
- **set-release-ga** — enable internal scheduling for the GA release's local/global JVB pools, disable it for pools leaving GA; `enableScheduler` no longer touched. Since `releases/<env>/live` is single-valued and only set by this job, any release leaving GA is disabled in the same run.

## Notes
- `enableScheduler` is being deprecated/removed separately; this PR just stops relying on it.
- Companion config PR (schedule files): jitsi/infra-customizations-private#jvb-schedule-by-region