### PR TITLE
feat(autoscaler): gate group rotation scale-down on new-instance health

### DIFF
--- a/jenkins/groovy/release-jvb/Jenkinsfile
+++ b/jenkins/groovy/release-jvb/Jenkinsfile
@@ -84,7 +84,9 @@ def upgradeJVBPool(shard_environment,cloud_name,cloud_provider,shard,release_num
         [$class: 'StringParameterValue', name: 'SHAPE', value: shape],
         [$class: 'StringParameterValue', name: 'OCPUS', value: ocpus],
         [$class: 'StringParameterValue', name: 'MEMORY_IN_GBS', value: memory_in_gbs],
-        [$class: 'StringParameterValue', name: 'VIDEO_INFRA_BRANCH', value: video_infra_branch]
+        [$class: 'StringParameterValue', name: 'VIDEO_INFRA_BRANCH', value: video_infra_branch],
+        [$class: 'StringParameterValue', name: 'SKIP_HEALTH_CHECK', value: env.SKIP_HEALTH_CHECK ?: ''],
+        [$class: 'StringParameterValue', name: 'HEALTH_CHECK_TIMEOUT', value: env.HEALTH_CHECK_TIMEOUT ?: '']
     ]
 
     return createShard

--- a/jenkins/jobs/release-jvb.yaml
+++ b/jenkins/jobs/release-jvb.yaml
@@ -46,6 +46,14 @@
           description: "Override JVB memory"
           trim: true
       - string:
+          name: SKIP_HEALTH_CHECK
+          description: "Set to true to skip the new-instance health gate and use the legacy fixed wait before scale down"
+          trim: true
+      - string:
+          name: HEALTH_CHECK_TIMEOUT
+          description: "Seconds to wait for new JVBs to report healthy before failing each pool rotation, defaults to 900"
+          trim: true
+      - string:
           name: INFRA_CONFIGURATION_REPO
           default: git@github.com:jitsi/infra-configuration.git
           description: "Repo for configuration code (ansible etc), defaults to 'git@github.com:jitsi/infra-configuration.git'."

--- a/jenkins/jobs/rotate-autoscaler-group.yaml
+++ b/jenkins/jobs/rotate-autoscaler-group.yaml
@@ -27,7 +27,15 @@
           trim: true
       - string:
           name: ROTATE_SLEEP_SECONDS
-          description: "Seconds to sleep after instance launch, before scaling down group"
+          description: "Seconds to sleep after instance launch, before scaling down group (only used with SKIP_HEALTH_CHECK=true)"
+          trim: true
+      - string:
+          name: SKIP_HEALTH_CHECK
+          description: "Set to true to skip the new-instance health gate and use the legacy fixed wait before scale down"
+          trim: true
+      - string:
+          name: HEALTH_CHECK_TIMEOUT
+          description: "Seconds to wait for new instances to report healthy before failing the rotation, defaults to 900"
           trim: true
       - string:
           name: SKIP_SCALE_DOWN

--- a/jenkins/jobs/upgrade-jvb-pool.yaml
+++ b/jenkins/jobs/upgrade-jvb-pool.yaml
@@ -62,6 +62,14 @@
           description: "Set to true to only update instance configuration, skip rotation"
           trim: true
       - string:
+          name: SKIP_HEALTH_CHECK
+          description: "Set to true to skip the new-instance health gate and use the legacy fixed wait before scale down"
+          trim: true
+      - string:
+          name: HEALTH_CHECK_TIMEOUT
+          description: "Seconds to wait for new JVBs to report healthy before failing the rotation, defaults to 900"
+          trim: true
+      - string:
           name: INFRA_CONFIGURATION_REPO
           default: git@github.com:jitsi/infra-configuration.git
           description: "Repo for configuration code (ansible etc), defaults to 'git@github.com:jitsi/infra-configuration.git'."

--- a/scripts/check-group-rotation-health.sh
+++ b/scripts/check-group-rotation-health.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
 # polls the autoscaler group report until at least EXPECTED_COUNT newly-launched
 # instances report a healthy application status, i.e. the sidecar is successfully
-# polling the local application for stats (scaleStatus SIDECAR_RUNNING or IN USE).
-# used by create-or-rotate-custom-jvb-oracle.sh to gate the scale-down of old
-# instances on the health of their replacements.
+# polling the local application for stats. used by the rotation scripts to gate
+# the scale-down of old instances on the health of their replacements.
 #
 # new instances are identified by not appearing in PRE_ROTATION_INSTANCE_IDS
 # (space-separated instance ids captured before launch) and, when
 # EXPECTED_VERSION is set, by the sidecar-reported application version.
+#
+# healthy scaleStatus values depend on the group type: jibri-family groups
+# report a busy status (IDLE/BUSY), all other types report stats-derived
+# statuses (SIDECAR_RUNNING/IN USE). set GROUP_TYPE to pick the right set,
+# or override HEALTHY_STATUSES directly.
 
 if [ -z "$GROUP_NAME" ]; then
   echo "No GROUP_NAME provided or found. Exiting.. "
@@ -38,7 +42,16 @@ if [ -z "$AUTOSCALER_URL" ]; then
 fi
 
 # scaleStatus values indicating the application is up and reporting stats
-[ -z "$HEALTHY_STATUSES" ] && HEALTHY_STATUSES="SIDECAR_RUNNING,IN USE"
+if [ -z "$HEALTHY_STATUSES" ]; then
+  case "$GROUP_TYPE" in
+    jibri|sip-jibri|availability)
+      HEALTHY_STATUSES="IDLE,BUSY"
+      ;;
+    *)
+      HEALTHY_STATUSES="SIDECAR_RUNNING,IN USE"
+      ;;
+  esac
+fi
 
 # no version assertion possible when rotating to 'latest'
 [ "$EXPECTED_VERSION" == "latest" ] && EXPECTED_VERSION=""

--- a/scripts/check-jvb-rotation-health-oracle.sh
+++ b/scripts/check-jvb-rotation-health-oracle.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+# polls the autoscaler group report until at least EXPECTED_COUNT newly-launched
+# instances report a healthy application status, i.e. the sidecar is successfully
+# polling the local application for stats (scaleStatus SIDECAR_RUNNING or IN USE).
+# used by create-or-rotate-custom-jvb-oracle.sh to gate the scale-down of old
+# instances on the health of their replacements.
+#
+# new instances are identified by not appearing in PRE_ROTATION_INSTANCE_IDS
+# (space-separated instance ids captured before launch) and, when
+# EXPECTED_VERSION is set, by the sidecar-reported application version.
+
+if [ -z "$GROUP_NAME" ]; then
+  echo "No GROUP_NAME provided or found. Exiting.. "
+  exit 213
+fi
+
+if [ -z "$EXPECTED_COUNT" ]; then
+  echo "No EXPECTED_COUNT found.  Exiting..."
+  exit 220
+fi
+
+if [ -z "$TOKEN" ]; then
+  if [ -z "$JWT_ENV_FILE" ]; then
+    if [ -z "$SIDECAR_ENV_VARIABLES" ]; then
+      echo "No SIDECAR_ENV_VARIABLES provided or found. Exiting.. "
+      exit 211
+    fi
+
+    JWT_ENV_FILE="/etc/jitsi/autoscaler-sidecar/$SIDECAR_ENV_VARIABLES"
+  fi
+
+  TOKEN=$(JWT_ENV_FILE=$JWT_ENV_FILE /opt/jitsi/jitsi-autoscaler-sidecar/scripts/jwt.sh)
+fi
+
+if [ -z "$AUTOSCALER_URL" ]; then
+  echo "No AUTOSCALER_URL provided or found. Exiting.. "
+  exit 212
+fi
+
+# scaleStatus values indicating the application is up and reporting stats
+[ -z "$HEALTHY_STATUSES" ] && HEALTHY_STATUSES="SIDECAR_RUNNING,IN USE"
+
+# no version assertion possible when rotating to 'latest'
+[ "$EXPECTED_VERSION" == "latest" ] && EXPECTED_VERSION=""
+
+if [ -z "$PRE_ROTATION_INSTANCE_IDS" ] && [ -z "$EXPECTED_VERSION" ]; then
+  echo "Neither PRE_ROTATION_INSTANCE_IDS nor EXPECTED_VERSION provided, cannot identify new instances. Exiting.."
+  exit 221
+fi
+
+[ -z "$HEALTH_CHECK_TIMEOUT" ] && HEALTH_CHECK_TIMEOUT=900
+[ -z "$HEALTH_CHECK_INTERVAL" ] && HEALTH_CHECK_INTERVAL=60
+
+WAIT_TOTAL_SECONDS=0
+while true; do
+  instanceGroupGetResponse=$(curl -s -w "\n %{http_code}" -X GET \
+    "$AUTOSCALER_URL"/groups/"$GROUP_NAME"/report \
+    -H "Authorization: Bearer $TOKEN")
+
+  GROUP_REPORT_STATUS_CODE=$(tail -n1 <<<"$instanceGroupGetResponse" | sed 's/[^0-9]*//g') # get the last line
+  GROUP_REPORT_VALUE=$(sed '$ d' <<<"$instanceGroupGetResponse")                           # get all but the last line which contains the status code
+
+  if [ "$GROUP_REPORT_STATUS_CODE" == 200 ]; then
+    NEW_INSTANCES=$(echo "$GROUP_REPORT_VALUE" | jq --arg pre "$PRE_ROTATION_INSTANCE_IDS" --arg version "$EXPECTED_VERSION" \
+      '[.groupReport.instances[]
+        | select((.isShuttingDown != true) and ((.shutdownComplete == null) or (.shutdownComplete == false)))
+        | select(.instanceId as $id | ($pre | split(" ")) | index($id) | not)
+        | select(($version == "") or (.version == $version))]')
+    NEW_COUNT=$(echo "$NEW_INSTANCES" | jq -r 'length')
+    HEALTHY_COUNT=$(echo "$NEW_INSTANCES" | jq -r --arg statuses "$HEALTHY_STATUSES" \
+      '[.[] | select(.scaleStatus as $s | ($statuses | split(",")) | index($s))] | length')
+    [ -z "$HEALTHY_COUNT" ] && HEALTHY_COUNT=0
+
+    if [ "$HEALTHY_COUNT" -ge "$EXPECTED_COUNT" ]; then
+      echo "Health check passed for group $GROUP_NAME: $HEALTHY_COUNT healthy new instances of $NEW_COUNT new total, expected $EXPECTED_COUNT"
+      exit 0
+    fi
+
+    echo "Group $GROUP_NAME has $HEALTHY_COUNT healthy new instances of $NEW_COUNT new total, waiting for $EXPECTED_COUNT"
+  else
+    echo "Failed to get group $GROUP_NAME report, status is $GROUP_REPORT_STATUS_CODE"
+  fi
+
+  if [ $WAIT_TOTAL_SECONDS -lt $HEALTH_CHECK_TIMEOUT ]; then
+    echo "Sleeping $HEALTH_CHECK_INTERVAL..."
+    sleep $HEALTH_CHECK_INTERVAL
+    WAIT_TOTAL_SECONDS=$(( WAIT_TOTAL_SECONDS + HEALTH_CHECK_INTERVAL ))
+  else
+    echo "Error. Reached maximum wait time of $WAIT_TOTAL_SECONDS seconds with only ${HEALTHY_COUNT:-0} of $EXPECTED_COUNT expected healthy new instances in group $GROUP_NAME"
+    if [ -n "$NEW_INSTANCES" ]; then
+      echo "Unhealthy new instances in group $GROUP_NAME:"
+      echo "$NEW_INSTANCES" | jq --arg statuses "$HEALTHY_STATUSES" \
+        '[.[] | select(.scaleStatus as $s | ($statuses | split(",")) | index($s) | not) | {instanceId, displayName, scaleStatus, cloudStatus, version, privateIp}]'
+    fi
+    exit 210
+  fi
+done

--- a/scripts/create-or-rotate-custom-jigasi-oracle.sh
+++ b/scripts/create-or-rotate-custom-jigasi-oracle.sh
@@ -127,7 +127,11 @@ fi
 
 
 
-[ -z "$JIGASI_PROTECTED_TTL_SEC" ] && JIGASI_PROTECTED_TTL_SEC=900
+[ -z "$SKIP_HEALTH_CHECK" ] && SKIP_HEALTH_CHECK="false"
+[ -z "$HEALTH_CHECK_TIMEOUT" ] && HEALTH_CHECK_TIMEOUT=900
+# scale-down protection must outlive the health gate, or the autoscaler may
+# reap the new instances while we are still waiting on their health
+[ -z "$JIGASI_PROTECTED_TTL_SEC" ] && JIGASI_PROTECTED_TTL_SEC=$((HEALTH_CHECK_TIMEOUT + 900))
 METADATA_PATH="$LOCAL_PATH/../terraform/create-jigasi-instance-configuration/user-data/postinstall-runner-oracle.sh"
 METADATA_LIB_PATH="$LOCAL_PATH/../terraform/lib"
 [ -z "$USER_PUBLIC_KEY_PATH" ] && USER_PUBLIC_KEY_PATH=~/.ssh/id_ed25519.pub
@@ -252,6 +256,7 @@ elif [ "$getGroupHttpCode" == 200 ]; then
   echo "Group $GROUP_NAME was found in the autoScaler"
   EXISTING_INSTANCE_CONFIGURATION_ID=$(echo "$instanceGroupDetails" | jq -r ."instanceGroup.instanceConfigurationId")
   EXISTING_MAXIMUM=$(echo "$instanceGroupDetails" | jq -r ."instanceGroup.scalingOptions.maxDesired")
+  GROUP_TYPE=$(echo "$instanceGroupDetails" | jq -r ."instanceGroup.type")
   if [ -z "$EXISTING_INSTANCE_CONFIGURATION_ID" ] || [ "$EXISTING_INSTANCE_CONFIGURATION_ID" == "null" ]; then
     echo "No Instance Configuration was found on the group details $GROUP_NAME. Exiting.."
     exit 206
@@ -289,6 +294,13 @@ elif [ "$getGroupHttpCode" == 200 ]; then
     $LOCAL_PATH/oracle_custom_images.py --tag_production --image_id $JIGASI_IMAGE_OCID --region $ORACLE_REGION
   fi
   
+  # snapshot the instances present before launching, so the health gate below
+  # can tell the new instances apart from the ones they are replacing
+  PRE_ROTATION_INSTANCE_IDS=$(curl -s -X GET \
+    "$AUTOSCALER_URL"/groups/"$GROUP_NAME"/report \
+    -H "Authorization: Bearer $TOKEN" | jq -r '[.groupReport.instances[]?.instanceId] | join(" ")')
+  echo "Instances present before rotation: $PRE_ROTATION_INSTANCE_IDS"
+
   echo "Will launch $PROTECTED_INSTANCES_COUNT protected instances (new max $NEW_MAXIMUM_DESIRED) in group $GROUP_NAME"
   instanceGroupLaunchResponse=$(curl -s -w "\n %{http_code}" -X POST \
     "$AUTOSCALER_URL"/groups/"$GROUP_NAME"/actions/launch-protected \
@@ -303,16 +315,39 @@ elif [ "$getGroupHttpCode" == 200 ]; then
   launchGroupHttpCode=$(tail -n1 <<<"$instanceGroupLaunchResponse" | sed 's/[^0-9]*//g')
   if [ "$launchGroupHttpCode" == 200 ]; then
     echo "Successfully launched $PROTECTED_INSTANCES_COUNT instances in group $GROUP_NAME"
-
-    echo "Will delete the old Instance Configuration for group $GROUP_NAME"
-    oci compute-management instance-configuration delete --instance-configuration-id "$EXISTING_INSTANCE_CONFIGURATION_ID" --region "$ORACLE_REGION" --force
   else
     echo "Error launching $PROTECTED_INSTANCES_COUNT instances in group $GROUP_NAME. AutoScaler response status code is $launchGroupHttpCode"
     exit 208
   fi
 
-  #Wait as much as it will take to provision the new instances, before scaling down the existing ones
-  sleep 600
+  if [[ "$SKIP_HEALTH_CHECK" == "true" ]]; then
+    #Wait as much as it will take to provision the new instances, before scaling down the existing ones
+    sleep 600
+  else
+    # wait until the new instances report healthy application stats via the
+    # sidecar before scaling down the old ones; on failure leave the old
+    # instances serving and restore the previous instance configuration
+    export GROUP_NAME AUTOSCALER_URL TOKEN PRE_ROTATION_INSTANCE_IDS GROUP_TYPE HEALTH_CHECK_TIMEOUT
+    EXPECTED_COUNT=$PROTECTED_INSTANCES_COUNT EXPECTED_VERSION="$JIGASI_VERSION" \
+      $LOCAL_PATH/check-group-rotation-health.sh
+    if [ $? -gt 0 ]; then
+      echo "Health check FAILED for new instances in group $GROUP_NAME, skipping scale down; old instances are left running"
+      echo "Restoring previous instance configuration $EXISTING_INSTANCE_CONFIGURATION_ID on group $GROUP_NAME"
+      restoreConfigResponse=$(curl -s -w "\n %{http_code}" -X PUT \
+        "$AUTOSCALER_URL"/groups/"$GROUP_NAME"/instance-configuration \
+        -H 'Content-Type: application/json' \
+        -H "Authorization: Bearer $TOKEN" \
+        -d '{"instanceConfigurationId": '\""$EXISTING_INSTANCE_CONFIGURATION_ID"'"}')
+      restoreConfigHttpCode=$(tail -n1 <<<"$restoreConfigResponse" | sed 's/[^0-9]*//g')
+      if [ "$restoreConfigHttpCode" == 200 ]; then
+        echo "Successfully restored previous instance configuration on group $GROUP_NAME"
+      else
+        echo "Error restoring previous instance configuration on group $GROUP_NAME. AutoScaler response status code is $restoreConfigHttpCode"
+      fi
+      echo "The unhealthy protected instances will lose scale-down protection after $JIGASI_PROTECTED_TTL_SEC seconds and require manual cleanup"
+      exit 223
+    fi
+  fi
 
   echo "Will scale down the group $GROUP_NAME and keep only the $PROTECTED_INSTANCES_COUNT protected instances with maximum $EXISTING_MAXIMUM"
   instanceGroupScaleDownResponse=$(curl -s -w "\n %{http_code}" -X PUT \
@@ -326,6 +361,11 @@ elif [ "$getGroupHttpCode" == 200 ]; then
   scaleDownGroupHttpCode=$(tail -n1 <<<"$instanceGroupScaleDownResponse" | sed 's/[^0-9]*//g')
   if [ "$scaleDownGroupHttpCode" == 200 ]; then
     echo "Successfully scaled down to $PROTECTED_INSTANCES_COUNT instances in group $GROUP_NAME"
+
+    # only delete the old instance configuration once the rotation has
+    # completed successfully, so a failed rotation can still roll back to it
+    echo "Will delete the old Instance Configuration for group $GROUP_NAME"
+    oci compute-management instance-configuration delete --instance-configuration-id "$EXISTING_INSTANCE_CONFIGURATION_ID" --region "$ORACLE_REGION" --force
   else
     echo "Error scaling down to $PROTECTED_INSTANCES_COUNT instances in group $GROUP_NAME. AutoScaler response status code is $scaleDownGroupHttpCode"
     exit 209

--- a/scripts/create-or-rotate-custom-jvb-oracle.sh
+++ b/scripts/create-or-rotate-custom-jvb-oracle.sh
@@ -156,7 +156,11 @@ fi
 [ -z "$TS" ] && TS=$(date +%s)
 [ -z "$INSTANCE_CONFIG_NAME" ] && export INSTANCE_CONFIG_NAME="${SHARD}-JVBInstanceConfig-${TS}"
 
-[ -z "$JVB_PROTECTED_TTL_SEC" ] && JVB_PROTECTED_TTL_SEC=900
+[ -z "$SKIP_HEALTH_CHECK" ] && SKIP_HEALTH_CHECK="false"
+[ -z "$HEALTH_CHECK_TIMEOUT" ] && HEALTH_CHECK_TIMEOUT=900
+# scale-down protection must outlive the health gate, or the autoscaler may
+# reap the new instances while we are still waiting on their health
+[ -z "$JVB_PROTECTED_TTL_SEC" ] && JVB_PROTECTED_TTL_SEC=$((HEALTH_CHECK_TIMEOUT + 900))
 METADATA_PATH="$LOCAL_PATH/../terraform/create-jvb-instance-configuration/user-data/postinstall-runner-oracle.sh"
 METADATA_LIB_PATH="$LOCAL_PATH/../terraform/lib"
 [ -z "$USER_PUBLIC_KEY_PATH" ] && USER_PUBLIC_KEY_PATH=~/.ssh/id_ed25519.pub
@@ -268,6 +272,13 @@ elif [ "$getGroupHttpCode" == 200 ]; then
     export AUTOSCALER_URL="https://${ENVIRONMENT}-${ORACLE_REGION}-autoscaler.${TOP_LEVEL_DNS_ZONE_NAME}"
   fi
 
+  # snapshot the instances present before launching, so the health gate below
+  # can tell the new instances apart from the ones they are replacing
+  PRE_ROTATION_INSTANCE_IDS=$(curl -s -X GET \
+    "$AUTOSCALER_URL"/groups/"$GROUP_NAME"/report \
+    -H "Authorization: Bearer $TOKEN" | jq -r '[.groupReport.instances[]?.instanceId] | join(" ")')
+  echo "Instances present before rotation: $PRE_ROTATION_INSTANCE_IDS"
+
   echo "Will launch $PROTECTED_INSTANCES_COUNT protected instances (new max $NEW_MAXIMUM_DESIRED) in group $GROUP_NAME"
   instanceGroupLaunchResponse=$(curl -s -w "\n %{http_code}" -X POST \
     "$AUTOSCALER_URL"/groups/"$GROUP_NAME"/actions/launch-protected \
@@ -293,8 +304,36 @@ elif [ "$getGroupHttpCode" == 200 ]; then
 
 # check flag for skipping scale down step
   if [[ "$SKIP_SCALE_DOWN" != "true" ]]; then
-    #Wait as much as it will take to provision the new instances, before scaling down the existing ones
-    sleep 480
+    if [[ "$SKIP_HEALTH_CHECK" == "true" ]]; then
+      #Wait as much as it will take to provision the new instances, before scaling down the existing ones
+      sleep 480
+    else
+      # wait until the new instances report healthy application stats via the
+      # sidecar before scaling down the old ones; on failure leave the old
+      # instances serving and restore the previous instance configuration
+      export GROUP_NAME AUTOSCALER_URL TOKEN PRE_ROTATION_INSTANCE_IDS HEALTH_CHECK_TIMEOUT
+      EXPECTED_COUNT=$PROTECTED_INSTANCES_COUNT EXPECTED_VERSION="$JVB_VERSION" \
+        $LOCAL_PATH/check-jvb-rotation-health-oracle.sh
+      if [ $? -gt 0 ]; then
+        echo "Health check FAILED for new instances in group $GROUP_NAME, skipping scale down; old instances are left running"
+        if [ "$NEW_INSTANCE_CONFIGURATION_ID" != "$EXISTING_INSTANCE_CONFIGURATION_ID" ]; then
+          echo "Restoring previous instance configuration $EXISTING_INSTANCE_CONFIGURATION_ID on group $GROUP_NAME"
+          restoreConfigResponse=$(curl -s -w "\n %{http_code}" -X PUT \
+            "$AUTOSCALER_URL"/groups/"$GROUP_NAME"/instance-configuration \
+            -H 'Content-Type: application/json' \
+            -H "Authorization: Bearer $TOKEN" \
+            -d '{"instanceConfigurationId": '\""$EXISTING_INSTANCE_CONFIGURATION_ID"'"}')
+          restoreConfigHttpCode=$(tail -n1 <<<"$restoreConfigResponse" | sed 's/[^0-9]*//g')
+          if [ "$restoreConfigHttpCode" == 200 ]; then
+            echo "Successfully restored previous instance configuration on group $GROUP_NAME"
+          else
+            echo "Error restoring previous instance configuration on group $GROUP_NAME. AutoScaler response status code is $restoreConfigHttpCode"
+          fi
+        fi
+        echo "The unhealthy protected instances will lose scale-down protection after $JVB_PROTECTED_TTL_SEC seconds and require manual cleanup"
+        exit 223
+      fi
+    fi
 
     echo "Will scale down the group $GROUP_NAME and keep only the $PROTECTED_INSTANCES_COUNT protected instances with maximum $EXISTING_MAXIMUM"
     instanceGroupScaleDownResponse=$(curl -s -w "\n %{http_code}" -X PUT \

--- a/scripts/create-or-rotate-custom-jvb-oracle.sh
+++ b/scripts/create-or-rotate-custom-jvb-oracle.sh
@@ -313,7 +313,7 @@ elif [ "$getGroupHttpCode" == 200 ]; then
       # instances serving and restore the previous instance configuration
       export GROUP_NAME AUTOSCALER_URL TOKEN PRE_ROTATION_INSTANCE_IDS HEALTH_CHECK_TIMEOUT
       EXPECTED_COUNT=$PROTECTED_INSTANCES_COUNT EXPECTED_VERSION="$JVB_VERSION" \
-        $LOCAL_PATH/check-jvb-rotation-health-oracle.sh
+        $LOCAL_PATH/check-group-rotation-health.sh
       if [ $? -gt 0 ]; then
         echo "Health check FAILED for new instances in group $GROUP_NAME, skipping scale down; old instances are left running"
         if [ "$NEW_INSTANCE_CONFIGURATION_ID" != "$EXISTING_INSTANCE_CONFIGURATION_ID" ]; then

--- a/scripts/create-or-rotate-jibri-nomad.sh
+++ b/scripts/create-or-rotate-jibri-nomad.sh
@@ -51,7 +51,11 @@ fi
 
 [ -z "$TOKEN" ] && TOKEN=$(JWT_ENV_FILE=$JWT_ENV_FILE /opt/jitsi/jitsi-autoscaler-sidecar/scripts/jwt.sh)
 
-[ -z "$JIBRI_PROTECTED_TTL_SEC" ] && JIBRI_PROTECTED_TTL_SEC=900
+[ -z "$SKIP_HEALTH_CHECK" ] && SKIP_HEALTH_CHECK="false"
+[ -z "$HEALTH_CHECK_TIMEOUT" ] && HEALTH_CHECK_TIMEOUT=900
+# scale-down protection must outlive the health gate, or the autoscaler may
+# reap the new instances while we are still waiting on their health
+[ -z "$JIBRI_PROTECTED_TTL_SEC" ] && JIBRI_PROTECTED_TTL_SEC=$((HEALTH_CHECK_TIMEOUT + 900))
 
 # ensure nomad job is defined
 
@@ -179,6 +183,7 @@ elif [ "$getGroupHttpCode" == 200 ]; then
   fi
 
   NEW_INSTANCE_CONFIGURATION_ID="$EXISTING_INSTANCE_CONFIGURATION_ID"
+  GROUP_TYPE=$(echo "$instanceGroupDetails" | jq -r ."instanceGroup.type")
 
   [ -z "$PROTECTED_INSTANCES_COUNT" ] && PROTECTED_INSTANCES_COUNT=$(echo "$instanceGroupDetails" | jq -r ."instanceGroup.scalingOptions.minDesired")
   if [ -z "$PROTECTED_INSTANCES_COUNT" ]; then
@@ -188,6 +193,13 @@ elif [ "$getGroupHttpCode" == 200 ]; then
 
   NEW_MAXIMUM_DESIRED=$((EXISTING_MAXIMUM + PROTECTED_INSTANCES_COUNT))
   echo "Creating new Instance Configuration for group $GROUP_NAME based on the existing one"
+
+  # snapshot the instances present before launching, so the health gate below
+  # can tell the new instances apart from the ones they are replacing
+  PRE_ROTATION_INSTANCE_IDS=$(curl -s -X GET \
+    "$AUTOSCALER_URL"/groups/"$GROUP_NAME"/report \
+    -H "Authorization: Bearer $TOKEN" | jq -r '[.groupReport.instances[]?.instanceId] | join(" ")')
+  echo "Instances present before rotation: $PRE_ROTATION_INSTANCE_IDS"
 
   echo "Will launch $PROTECTED_INSTANCES_COUNT protected instances (new max $NEW_MAXIMUM_DESIRED) in group $GROUP_NAME"
   instanceGroupLaunchResponse=$(curl -s -w "\n %{http_code}" -X POST \
@@ -209,8 +221,21 @@ elif [ "$getGroupHttpCode" == 200 ]; then
     exit 208
   fi
 
-  #Wait as much as it will take to provision the new instances, before scaling down the existing ones
-  sleep 90
+  if [[ "$SKIP_HEALTH_CHECK" == "true" ]]; then
+    #Wait as much as it will take to provision the new instances, before scaling down the existing ones
+    sleep 90
+  else
+    # wait until the new instances report healthy application stats via the
+    # sidecar before scaling down the old ones; on failure leave the old
+    # instances serving (rotation reuses the existing instance configuration)
+    export GROUP_NAME AUTOSCALER_URL TOKEN PRE_ROTATION_INSTANCE_IDS GROUP_TYPE HEALTH_CHECK_TIMEOUT
+    EXPECTED_COUNT=$PROTECTED_INSTANCES_COUNT $LOCAL_PATH/check-group-rotation-health.sh
+    if [ $? -gt 0 ]; then
+      echo "Health check FAILED for new instances in group $GROUP_NAME, skipping scale down; old instances are left running"
+      echo "The unhealthy protected instances will lose scale-down protection after $JIBRI_PROTECTED_TTL_SEC seconds and require manual cleanup"
+      exit 225
+    fi
+  fi
 
   echo "Will scale down the group $GROUP_NAME and keep only the $PROTECTED_INSTANCES_COUNT protected instances with maximum $EXISTING_MAXIMUM"
   instanceGroupScaleDownResponse=$(curl -s -w "\n %{http_code}" -X PUT \

--- a/scripts/create-or-rotate-jibri-oracle.sh
+++ b/scripts/create-or-rotate-jibri-oracle.sh
@@ -206,7 +206,11 @@ fi
 
 [ -z "$TOKEN" ] && TOKEN=$(JWT_ENV_FILE=$JWT_ENV_FILE /opt/jitsi/jitsi-autoscaler-sidecar/scripts/jwt.sh)
 
-[ -z "$JIBRI_PROTECTED_TTL_SEC" ] && JIBRI_PROTECTED_TTL_SEC=900
+[ -z "$SKIP_HEALTH_CHECK" ] && SKIP_HEALTH_CHECK="false"
+[ -z "$HEALTH_CHECK_TIMEOUT" ] && HEALTH_CHECK_TIMEOUT=900
+# scale-down protection must outlive the health gate, or the autoscaler may
+# reap the new instances while we are still waiting on their health
+[ -z "$JIBRI_PROTECTED_TTL_SEC" ] && JIBRI_PROTECTED_TTL_SEC=$((HEALTH_CHECK_TIMEOUT + 900))
 
 METADATA_PATH="$LOCAL_PATH/../terraform/jibri-instance-configuration/user-data/postinstall-runner-oracle.sh"
 METADATA_LIB_PATH="$LOCAL_PATH/../terraform/lib"
@@ -358,6 +362,7 @@ elif [ "$getGroupHttpCode" == 200 ]; then
   echo "Group $GROUP_NAME was found in the autoScaler"
   EXISTING_INSTANCE_CONFIGURATION_ID=$(echo "$instanceGroupDetails" | jq -r ."instanceGroup.instanceConfigurationId")
   EXISTING_MAXIMUM=$(echo "$instanceGroupDetails" | jq -r ."instanceGroup.scalingOptions.maxDesired")
+  GROUP_TYPE=$(echo "$instanceGroupDetails" | jq -r ."instanceGroup.type")
   if [ -z "$EXISTING_INSTANCE_CONFIGURATION_ID" ] || [ "$EXISTING_INSTANCE_CONFIGURATION_ID" == "null" ]; then
     echo "No Instance Configuration was found on the group details $GROUP_NAME. Exiting.."
     exit 206
@@ -402,6 +407,13 @@ elif [ "$getGroupHttpCode" == 200 ]; then
     $LOCAL_PATH/oracle_custom_images.py --tag_production --image_id $JIBRI_IMAGE_OCID --region $ORACLE_REGION
   fi
 
+  # snapshot the instances present before launching, so the health gate below
+  # can tell the new instances apart from the ones they are replacing
+  PRE_ROTATION_INSTANCE_IDS=$(curl -s -X GET \
+    "$AUTOSCALER_URL"/groups/"$GROUP_NAME"/report \
+    -H "Authorization: Bearer $TOKEN" | jq -r '[.groupReport.instances[]?.instanceId] | join(" ")')
+  echo "Instances present before rotation: $PRE_ROTATION_INSTANCE_IDS"
+
   echo "Will launch $PROTECTED_INSTANCES_COUNT protected instances (new max $NEW_MAXIMUM_DESIRED) in group $GROUP_NAME"
   instanceGroupLaunchResponse=$(curl -s -w "\n %{http_code}" -X POST \
     "$AUTOSCALER_URL"/groups/"$GROUP_NAME"/actions/launch-protected \
@@ -416,16 +428,39 @@ elif [ "$getGroupHttpCode" == 200 ]; then
   launchGroupHttpCode=$(tail -n1 <<<"$instanceGroupLaunchResponse" | sed 's/[^0-9]*//g')
   if [ "$launchGroupHttpCode" == 200 ]; then
     echo "Successfully launched $PROTECTED_INSTANCES_COUNT instances in group $GROUP_NAME"
-
-    echo "Will delete the old Instance Configuration for group $GROUP_NAME"
-    oci compute-management instance-configuration delete --instance-configuration-id "$EXISTING_INSTANCE_CONFIGURATION_ID" --region "$ORACLE_REGION" --force
   else
     echo "Error launching $PROTECTED_INSTANCES_COUNT instances in group $GROUP_NAME. AutoScaler response status code is $launchGroupHttpCode"
     exit 208
   fi
 
-  #Wait as much as it will take to provision the new instances, before scaling down the existing ones
-  sleep 600
+  if [[ "$SKIP_HEALTH_CHECK" == "true" ]]; then
+    #Wait as much as it will take to provision the new instances, before scaling down the existing ones
+    sleep 600
+  else
+    # wait until the new instances report a healthy status via the sidecar
+    # before scaling down the old ones; on failure leave the old instances
+    # serving and restore the previous instance configuration
+    export GROUP_NAME AUTOSCALER_URL TOKEN PRE_ROTATION_INSTANCE_IDS GROUP_TYPE HEALTH_CHECK_TIMEOUT
+    EXPECTED_COUNT=$PROTECTED_INSTANCES_COUNT EXPECTED_VERSION="$JIBRI_VERSION" \
+      $LOCAL_PATH/check-group-rotation-health.sh
+    if [ $? -gt 0 ]; then
+      echo "Health check FAILED for new instances in group $GROUP_NAME, skipping scale down; old instances are left running"
+      echo "Restoring previous instance configuration $EXISTING_INSTANCE_CONFIGURATION_ID on group $GROUP_NAME"
+      restoreConfigResponse=$(curl -s -w "\n %{http_code}" -X PUT \
+        "$AUTOSCALER_URL"/groups/"$GROUP_NAME"/instance-configuration \
+        -H 'Content-Type: application/json' \
+        -H "Authorization: Bearer $TOKEN" \
+        -d '{"instanceConfigurationId": '\""$EXISTING_INSTANCE_CONFIGURATION_ID"'"}')
+      restoreConfigHttpCode=$(tail -n1 <<<"$restoreConfigResponse" | sed 's/[^0-9]*//g')
+      if [ "$restoreConfigHttpCode" == 200 ]; then
+        echo "Successfully restored previous instance configuration on group $GROUP_NAME"
+      else
+        echo "Error restoring previous instance configuration on group $GROUP_NAME. AutoScaler response status code is $restoreConfigHttpCode"
+      fi
+      echo "The unhealthy protected instances will lose scale-down protection after $JIBRI_PROTECTED_TTL_SEC seconds and require manual cleanup"
+      exit 223
+    fi
+  fi
 
   echo "Will scale down the group $GROUP_NAME and keep only the $PROTECTED_INSTANCES_COUNT protected instances with maximum $EXISTING_MAXIMUM"
   instanceGroupScaleDownResponse=$(curl -s -w "\n %{http_code}" -X PUT \
@@ -439,6 +474,11 @@ elif [ "$getGroupHttpCode" == 200 ]; then
   scaleDownGroupHttpCode=$(tail -n1 <<<"$instanceGroupScaleDownResponse" | sed 's/[^0-9]*//g')
   if [ "$scaleDownGroupHttpCode" == 200 ]; then
     echo "Successfully scaled down to $PROTECTED_INSTANCES_COUNT instances in group $GROUP_NAME"
+
+    # only delete the old instance configuration once the rotation has
+    # completed successfully, so a failed rotation can still roll back to it
+    echo "Will delete the old Instance Configuration for group $GROUP_NAME"
+    oci compute-management instance-configuration delete --instance-configuration-id "$EXISTING_INSTANCE_CONFIGURATION_ID" --region "$ORACLE_REGION" --force
   else
     echo "Error scaling down to $PROTECTED_INSTANCES_COUNT instances in group $GROUP_NAME. AutoScaler response status code is $scaleDownGroupHttpCode"
     exit 209

--- a/scripts/create-or-rotate-transcriber-nomad.sh
+++ b/scripts/create-or-rotate-transcriber-nomad.sh
@@ -47,7 +47,11 @@ fi
 
 [ -z "$TOKEN" ] && TOKEN=$(JWT_ENV_FILE=$JWT_ENV_FILE /opt/jitsi/jitsi-autoscaler-sidecar/scripts/jwt.sh)
 
-[ -z "$TRANSCRIBER_PROTECTED_TTL_SEC" ] && TRANSCRIBER_PROTECTED_TTL_SEC=900
+[ -z "$SKIP_HEALTH_CHECK" ] && SKIP_HEALTH_CHECK="false"
+[ -z "$HEALTH_CHECK_TIMEOUT" ] && HEALTH_CHECK_TIMEOUT=900
+# scale-down protection must outlive the health gate, or the autoscaler may
+# reap the new instances while we are still waiting on their health
+[ -z "$TRANSCRIBER_PROTECTED_TTL_SEC" ] && TRANSCRIBER_PROTECTED_TTL_SEC=$((HEALTH_CHECK_TIMEOUT + 900))
 
 # ensure nomad job is defined
 
@@ -165,6 +169,7 @@ elif [ "$getGroupHttpCode" == 200 ]; then
   fi
 
   NEW_INSTANCE_CONFIGURATION_ID="$EXISTING_INSTANCE_CONFIGURATION_ID"
+  GROUP_TYPE=$(echo "$instanceGroupDetails" | jq -r ."instanceGroup.type")
 
   [ -z "$PROTECTED_INSTANCES_COUNT" ] && PROTECTED_INSTANCES_COUNT=$(echo "$instanceGroupDetails" | jq -r ."instanceGroup.scalingOptions.minDesired")
   if [ -z "$PROTECTED_INSTANCES_COUNT" ]; then
@@ -174,6 +179,13 @@ elif [ "$getGroupHttpCode" == 200 ]; then
 
   NEW_MAXIMUM_DESIRED=$((EXISTING_MAXIMUM + PROTECTED_INSTANCES_COUNT))
   echo "Creating new Instance Configuration for group $GROUP_NAME based on the existing one"
+
+  # snapshot the instances present before launching, so the health gate below
+  # can tell the new instances apart from the ones they are replacing
+  PRE_ROTATION_INSTANCE_IDS=$(curl -s -X GET \
+    "$AUTOSCALER_URL"/groups/"$GROUP_NAME"/report \
+    -H "Authorization: Bearer $TOKEN" | jq -r '[.groupReport.instances[]?.instanceId] | join(" ")')
+  echo "Instances present before rotation: $PRE_ROTATION_INSTANCE_IDS"
 
   echo "Will launch $PROTECTED_INSTANCES_COUNT protected instances (new max $NEW_MAXIMUM_DESIRED) in group $GROUP_NAME"
   instanceGroupLaunchResponse=$(curl -s -w "\n %{http_code}" -X POST \
@@ -195,8 +207,21 @@ elif [ "$getGroupHttpCode" == 200 ]; then
     exit 208
   fi
 
-  #Wait as much as it will take to provision the new instances, before scaling down the existing ones
-  sleep 90
+  if [[ "$SKIP_HEALTH_CHECK" == "true" ]]; then
+    #Wait as much as it will take to provision the new instances, before scaling down the existing ones
+    sleep 90
+  else
+    # wait until the new instances report healthy application stats via the
+    # sidecar before scaling down the old ones; on failure leave the old
+    # instances serving (rotation reuses the existing instance configuration)
+    export GROUP_NAME AUTOSCALER_URL TOKEN PRE_ROTATION_INSTANCE_IDS GROUP_TYPE HEALTH_CHECK_TIMEOUT
+    EXPECTED_COUNT=$PROTECTED_INSTANCES_COUNT $LOCAL_PATH/check-group-rotation-health.sh
+    if [ $? -gt 0 ]; then
+      echo "Health check FAILED for new instances in group $GROUP_NAME, skipping scale down; old instances are left running"
+      echo "The unhealthy protected instances will lose scale-down protection after $TRANSCRIBER_PROTECTED_TTL_SEC seconds and require manual cleanup"
+      exit 225
+    fi
+  fi
 
   echo "Will scale down the group $GROUP_NAME and keep only the $PROTECTED_INSTANCES_COUNT protected instances with maximum $EXISTING_MAXIMUM"
   instanceGroupScaleDownResponse=$(curl -s -w "\n %{http_code}" -X PUT \

--- a/scripts/custom-autoscaler-launch-protected.sh
+++ b/scripts/custom-autoscaler-launch-protected.sh
@@ -22,7 +22,10 @@ if [ -z "$ORACLE_REGION" ]; then
   RET=203
 fi
 
-[ -z "$PROTECTED_TTL_SEC" ] && PROTECTED_TTL_SEC=900
+[ -z "$HEALTH_CHECK_TIMEOUT" ] && HEALTH_CHECK_TIMEOUT=900
+# scale-down protection must outlive the rotation health gate, or the
+# autoscaler may reap the new instances while we are still waiting on them
+[ -z "$PROTECTED_TTL_SEC" ] && PROTECTED_TTL_SEC=$((HEALTH_CHECK_TIMEOUT + 900))
 
 ORACLE_CLOUD_NAME="$ORACLE_REGION-$ENVIRONMENT-oracle"
 [ -e "$LOCAL_PATH/../clouds/${ORACLE_CLOUD_NAME}.sh" ] && . $LOCAL_PATH/../clouds/"${ORACLE_CLOUD_NAME}".sh
@@ -77,6 +80,8 @@ fi
 
 export EXISTING_MAXIMUM=$(echo "$INSTANCE_GROUP_DETAILS" | jq -r ."instanceGroup.scalingOptions.maxDesired")
 export EXISTING_DESIRED=$(echo "$INSTANCE_GROUP_DETAILS" | jq -r ."instanceGroup.scalingOptions.desiredCount")
+export EXISTING_INSTANCE_CONFIGURATION_ID=$(echo "$INSTANCE_GROUP_DETAILS" | jq -r ."instanceGroup.instanceConfigurationId")
+export GROUP_TYPE=$(echo "$INSTANCE_GROUP_DETAILS" | jq -r ."instanceGroup.type")
 [ -z "$PROTECTED_INSTANCES_COUNT" ] && export PROTECTED_INSTANCES_COUNT=$EXISTING_DESIRED
 if [ -z "$PROTECTED_INSTANCES_COUNT" ]; then
     echo "Something went wrong, could not extract PROTECTED_INSTANCES_COUNT from instanceGroup.scalingOptions.desiredCount";
@@ -99,6 +104,13 @@ if [ -n "$NEW_MAXIMUM_DESIRED" ]; then
     BODY=$BODY'"maxDesired": '$NEW_MAXIMUM_DESIRED','
 fi
 BODY=$BODY'"count": '"$PROTECTED_INSTANCES_COUNT"',"protectedTTLSec": '$PROTECTED_TTL_SEC'}'
+
+# snapshot the instances present before launching, so the rotation health gate
+# can tell the new instances apart from the ones they are replacing
+export PRE_ROTATION_INSTANCE_IDS=$(curl -s -X GET \
+  "$AUTOSCALER_URL"/groups/"$GROUP_NAME"/report \
+  -H "Authorization: Bearer $TOKEN" | jq -r '[.groupReport.instances[]?.instanceId] | join(" ")')
+echo "Instances present before rotation: $PRE_ROTATION_INSTANCE_IDS"
 
 echo "Will launch $PROTECTED_INSTANCES_COUNT protected instances (new max $NEW_MAXIMUM_DESIRED) in group $GROUP_NAME: $BODY"
 instanceGroupLaunchResponse=$(curl -s -w "\n %{http_code}" -X POST \

--- a/scripts/custom-autoscaler-rotate-group.sh
+++ b/scripts/custom-autoscaler-rotate-group.sh
@@ -17,8 +17,35 @@ if [[ "$RET" != "0" ]]; then
 fi
 
 if [[ "$SKIP_SCALE_DOWN" != "true" ]]; then
-    # now wait until launched instances are ready
-    sleep $ROTATE_SLEEP_SECONDS
+    if [[ "$SKIP_HEALTH_CHECK" == "true" ]]; then
+        # now wait until launched instances are ready
+        sleep $ROTATE_SLEEP_SECONDS
+    else
+        # wait until the new instances report healthy application stats via
+        # the sidecar before scaling down the old ones; on failure leave the
+        # old instances serving and restore the previous instance configuration
+        export GROUP_NAME AUTOSCALER_URL TOKEN PRE_ROTATION_INSTANCE_IDS GROUP_TYPE HEALTH_CHECK_TIMEOUT
+        EXPECTED_COUNT=$PROTECTED_INSTANCES_COUNT $LOCAL_PATH/check-group-rotation-health.sh
+        if [ $? -gt 0 ]; then
+            echo "Health check FAILED for new instances in group $GROUP_NAME, skipping scale down; old instances are left running"
+            if [ -n "$NEW_INSTANCE_CONFIGURATION_ID" ] && [ "$NEW_INSTANCE_CONFIGURATION_ID" != "$EXISTING_INSTANCE_CONFIGURATION_ID" ]; then
+                echo "Restoring previous instance configuration $EXISTING_INSTANCE_CONFIGURATION_ID on group $GROUP_NAME"
+                restoreConfigResponse=$(curl -s -w "\n %{http_code}" -X PUT \
+                    "$AUTOSCALER_URL"/groups/"$GROUP_NAME"/instance-configuration \
+                    -H 'Content-Type: application/json' \
+                    -H "Authorization: Bearer $TOKEN" \
+                    -d '{"instanceConfigurationId": '\""$EXISTING_INSTANCE_CONFIGURATION_ID"'"}')
+                restoreConfigHttpCode=$(tail -n1 <<<"$restoreConfigResponse" | sed 's/[^0-9]*//g')
+                if [ "$restoreConfigHttpCode" == 200 ]; then
+                    echo "Successfully restored previous instance configuration on group $GROUP_NAME"
+                else
+                    echo "Error restoring previous instance configuration on group $GROUP_NAME. AutoScaler response status code is $restoreConfigHttpCode"
+                fi
+            fi
+            echo "The unhealthy protected instances will lose scale-down protection after $PROTECTED_TTL_SEC seconds and require manual cleanup"
+            exit 223
+        fi
+    fi
 
     # now scale down to the previous desired value
     if [ -n "$NEW_MAXIMUM_DESIRED" ]; then


### PR DESCRIPTION
## Problem

Every autoscaler group rotation path launches new protected instances, sleeps a fixed interval (480s JVB, 600s jigasi/jibri/generic, 90s nomad pools), then scales down the old instances — with no verification that the replacements actually came up. When a bad build/image ships (as with the recent JVB release on 6869), whole pools rotate to broken instances.

## Change

**New script `scripts/check-group-rotation-health.sh`** — polls the autoscaler `GET /groups/:name/report` until at least `EXPECTED_COUNT` *new* instances report a healthy application status:

- New = instance id not in the pre-launch snapshot, and (when a concrete version is expected) sidecar-reported `version` matches. For deb-installed apps the sidecar reports the dpkg version minus deb revision, so this also proves the healthy instances run the new build.
- Healthy is group-type aware (`GROUP_TYPE`, or `HEALTHY_STATUSES` override): jibri-family groups (`jibri`/`sip-jibri`/`availability`) are healthy at `IDLE`/`BUSY`; all other types (JVB/jigasi/nomad/whisper/…) at `SIDECAR_RUNNING`/`IN USE` — i.e. the sidecar is successfully pulling stats from the application. An instance whose app never starts stays `PROVISIONING`/`ONLINE` and never passes.
- Configurable via `HEALTH_CHECK_TIMEOUT` (default 900s) / `HEALTH_CHECK_INTERVAL` (default 60s).

**Wired into every rotation path**, replacing the blind sleep:

| path | previously | on gate failure |
|---|---|---|
| `create-or-rotate-custom-jvb-oracle.sh` | sleep 480 | no scale-down, restore previous instance configuration, exit 223 |
| `custom-autoscaler-rotate-group.sh` (generic, via `custom-autoscaler-launch-protected.sh`) | sleep 600 | no scale-down, restore previous instance configuration if one was rotated, exit 223 |
| `create-or-rotate-custom-jigasi-oracle.sh` | sleep 600 | no scale-down, restore previous instance configuration, exit 223 |
| `create-or-rotate-jibri-oracle.sh` | sleep 600 | no scale-down, restore previous instance configuration, exit 223 |
| `create-or-rotate-transcriber-nomad.sh` | sleep 90 | no scale-down, exit 225 (config unchanged by rotation) |
| `create-or-rotate-jibri-nomad.sh` | sleep 90 | no scale-down, exit 225 (config unchanged by rotation) |

Supporting changes:

- **jigasi/jibri oracle**: the OCI delete of the old instance configuration moves from right-after-launch to after-successful-scale-down — previously the rollback target was destroyed before the new instances had ever served.
- **`custom-autoscaler-launch-protected.sh`**: exports the pre-launch instance-id snapshot, `EXISTING_INSTANCE_CONFIGURATION_ID`, and `GROUP_TYPE` for the gate; instance-configuration restore uses the autoscaler's `PUT /groups/:name/instance-configuration`.
- **Protected TTLs** (`*_PROTECTED_TTL_SEC`) default to `HEALTH_CHECK_TIMEOUT + 900` everywhere so scale-down protection outlives the gate window.
- **`SKIP_HEALTH_CHECK=true`** restores the legacy fixed sleep in every path. Params exposed on `release-jvb`, `upgrade-jvb-pool`, and `rotate-autoscaler-group`; other callers can pass them as env.

## Testing

- `bash -n` on all 8 modified/new scripts.
- Gate script run end-to-end against a mock autoscaler report server:
  - JVB-type pass (healthy new = expected, with version assertion) → exit 0; also exercised the retry path on unreachable autoscaler
  - fail case → exit 210 after timeout with a per-instance report of the unhealthy new instances (id, scaleStatus, cloudStatus, version, privateIp)
  - jibri-type: `IDLE` counts healthy, `SIDECAR_RUNNING` correctly does not
- jq selection logic verified for pre-id + version filtering, pre-id-only, version-only, and exclusion of shutting-down instances.
- Status semantics confirmed against jitsi-autoscaler `group_report.ts`; version semantics against the `autoscaler-sidecar` ansible role.

Follow-up (not in this PR): wave/canary pool ordering in release-jvb.