### PR TITLE
feat: Provision live audio translation on the nomad backend

### DIFF
--- a/nomad/jitsi_packs/packs/jitsi_meet_backend/templates/jitsi_meet_backend.nomad.tpl
+++ b/nomad/jitsi_packs/packs/jitsi_meet_backend/templates/jitsi_meet_backend.nomad.tpl
@@ -555,6 +555,9 @@ EOF
         ENABLE_AV_MODERATION="1"
         ENABLE_BREAKOUT_ROOMS="1"
         ENABLE_AUTH="1"
+[[- if eq (env "CONFIG_prosody_meet_audio_translation_enabled") "true" ]]
+        ENABLE_AUDIO_TRANSLATION="1"
+[[- end ]]
 [[- if eq (env "CONFIG_prosody_enable_guest_auth") "true" ]]
         ENABLE_GUESTS="true"
 [[- end ]]
@@ -947,6 +950,11 @@ EOF
         # jicofo rtcstats push vars
         JICOFO_ADDRESS = "http://127.0.0.1:8888"
         JICOFO_VISITORS_REQUIRE_MUC_CONFIG = "[[ env "CONFIG_jicofo_require_muc_config_flag" ]]"
+[[- if env "CONFIG_jicofo_translation_url_template" ]]
+        JICOFO_TRANSLATION_URL_TEMPLATE = "[[ env "CONFIG_jicofo_translation_url_template" ]]"
+        JICOFO_TRANSLATION_CF_ACCESS_CLIENT_ID = "[[ env "CONFIG_jicofo_translation_cf_access_client_id" ]]"
+        JICOFO_TRANSLATION_CF_ACCESS_CLIENT_SECRET = "[[ env "CONFIG_jicofo_translation_cf_access_client_secret" ]]"
+[[- end ]]
         RTCSTATS_SERVER="[[ env "CONFIG_jicofo_rtcstats_push_rtcstats_server" ]]"
         INTERVAL=10000
         # rtcstats-push tails this file and pushes jicofo log lines alongside the

--- a/scripts/deploy-nomad-shard-backend.sh
+++ b/scripts/deploy-nomad-shard-backend.sh
@@ -143,6 +143,11 @@ export CONFIG_turnrelay_password="$(ansible-vault view $ENCRYPTED_COTURN_CREDENT
 # TODO: use the separate _jvb and _visitor secrets for the different accounts.
 export CONFIG_jicofo_auth_password="$(ansible-vault view $ENCRYPTED_JICOFO_CREDENTIALS_FILE --vault-password $VAULT_PASSWORD_FILE | yq eval ".${JICOFO_XMPP_PASSWORD_VARIABLE}" -)"
 
+# Live-translation opus-transcriber-proxy CF-Access credentials (reused from transcription). Optional: empty when unset,
+# in which case jicofo signals the translation connect without http-headers.
+export CONFIG_jicofo_translation_cf_access_client_id="$(ansible-vault view $ENCRYPTED_JICOFO_CREDENTIALS_FILE --vault-password $VAULT_PASSWORD_FILE | yq eval '.secrets_jicofo_opus_transcriber_client_id // ""' -)"
+export CONFIG_jicofo_translation_cf_access_client_secret="$(ansible-vault view $ENCRYPTED_JICOFO_CREDENTIALS_FILE --vault-password $VAULT_PASSWORD_FILE | yq eval '.secrets_jicofo_opus_transcriber_secret // ""' -)"
+
 export CONFIG_asap_jwt_kid="$(ansible-vault view $ENCRYPTED_ASAP_KEYS_FILE --vault-password $VAULT_PASSWORD_FILE | yq eval ".${ASAP_KEY_VARIABLE}.id" -)"
 
 export CONFIG_aws_access_key_id="$(ansible-vault view $ENCRYPTED_PROSODY_EGRESS_AWS_FILE --vault-password $VAULT_PASSWORD_FILE | yq eval ".prosody_egress_aws_access_key_id_by_type.$ENVIRONMENT_TYPE" -)"


### PR DESCRIPTION
Wires the live audio translation feature into the nomad jitsi_meet_backend job (cloud shards), matching the ansible provisioning (infra-configuration#932) and the docker-jitsi-meet image support.

- **prosody**: `ENABLE_AUDIO_TRANSLATION=1` when `prosody_meet_audio_translation_enabled` is set (enables the `audiotranslation` component).
- **jicofo**: `JICOFO_TRANSLATION_URL_TEMPLATE` from `jicofo_translation_url_template`, plus `JICOFO_TRANSLATION_CF_ACCESS_CLIENT_ID/SECRET` http-header credentials.
- **deploy-nomad-shard-backend.sh**: exports the CF-Access credentials from the jicofo secrets file (reused from transcription); empty when unset, in which case jicofo signals the connect without http-headers.

The url-template and enable flag flow automatically from site vars via the bulk CONFIG_ export. Requires the docker-jitsi-meet image with audio_translation support (separate PR) and per-environment enablement in site vars.