### PR TITLE
feat(jitsi-meet-web): wire jitsi_meet_enable_audio_translation

### DIFF
--- a/nomad/jitsi_packs/packs/jitsi_meet_web/templates/_custom-config.js.tpl
+++ b/nomad/jitsi_packs/packs/jitsi_meet_web/templates/_custom-config.js.tpl
@@ -43,6 +43,12 @@ config.videoQuality.vp9.useSimulcast=true;
 config.audioQuality.enableOpusDtx=[[ or (env "CONFIG_jitsi_meet_enable_dtx") "false" ]];
 config.audioQuality.enableAdvancedAudioSettings=[[ or (env "CONFIG_jitsi_meet_enable_advanced_audio_settings") "false" ]];
 
+[[ if eq (env "CONFIG_jitsi_meet_enable_audio_translation") "true" -]]
+config.audioTranslation = {
+    enabled: true
+};
+[[- end ]]
+
 [[ if eq (env "CONFIG_jitsi_meet_hidden_from_recorder_feature") "true" -]]
 config.hiddenFromRecorderFeatureEnabled=true;
 [[- end ]]


### PR DESCRIPTION
## Summary

Emits `config.audioTranslation = { enabled: true };` in the Nomad web pack's custom config when `CONFIG_jitsi_meet_enable_audio_translation` is `"true"` (exported automatically by yamltoenv from the site's `vars.yml`). Default is off — sites without the var see no change.

## Companion changes

- infra-configuration: https://github.com/jitsi/infra-configuration/pull/933
- infra-customizations-private: https://github.com/jitsi/infra-customizations-private/pull/1060

## Test plan

- `_custom-config.js.tpl`: rendered `config.js` contains the `audioTranslation` assignment only when `CONFIG_jitsi_meet_enable_audio_translation=true`; omitted otherwise.
