### PR TITLE
feat(cdn): job to clean up old R2 CDN build folders (JIT-16013)

### DIFF
--- a/jenkins/groovy/cleanup-cdn-versions/Jenkinsfile
+++ b/jenkins/groovy/cleanup-cdn-versions/Jenkinsfile
@@ -1,0 +1,45 @@
+def utils
+
+pipeline {
+    agent any
+    options {
+        ansiColor('xterm')
+        timestamps()
+        buildDiscarder(logRotator(numToKeepStr: '30', artifactNumToKeepStr: '30'))
+    }
+    stages {
+        stage('Prepare/Checkout') {
+            steps {
+                script {
+                    // load utility function
+                    def rootDir = pwd()
+                    utils = load "${rootDir}/jenkins/groovy/Utils.groovy"
+                    // checkout repos (overlays infra-customizations, so sites/ is present)
+                    utils.SetupRepos(env.VIDEO_INFRA_BRANCH)
+
+                    // setup OCI credentials (shard.sh list enumerates via shard.py)
+                    utils.SetupOCI()
+                }
+            }
+        }
+        stage('cleanup CDN versions') {
+            steps {
+                script {
+                    withCredentials([
+                            string(credentialsId: 'jenkins-aws-secret', variable: 'AWS_SECRET_ACCESS_KEY'),
+                            string(credentialsId: 'jenkins-aws-id', variable: 'AWS_ACCESS_KEY_ID')
+                    ]) {
+                        dir('infra-provisioning') {
+                            utils.SetupAnsible()
+                            sh '''#!/bin/bash
+                            if [[ "$DRY_RUN" == "false" ]]; then
+                                export CDN_CLEANUP_CONFIRM="true"
+                            fi
+                            scripts/cleanup-cdn-r2-versions.sh'''
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/jenkins/jobs/cleanup-cdn-versions.yaml
+++ b/jenkins/jobs/cleanup-cdn-versions.yaml
@@ -1,0 +1,51 @@
+- job:
+    name: cleanup-cdn-versions
+    display-name: cleanup cdn versions
+    concurrent: false
+    # once dry-run output has been validated, enable a weekly report run:
+    # triggers:
+    #   - timed: 'H 4 * * 1'
+    parameters:
+      - string:
+          name: VIDEO_INFRA_BRANCH
+          default: main
+          description: "Controls checkout branch for infra repos, defaults to 'main'."
+          trim: true
+      - bool:
+          name: DRY_RUN
+          default: true
+          description: "If true, only report the CDN folders that would be deleted; uncheck to actually purge them from R2."
+      - string:
+          name: CDN_KEEP_ROLLBACK
+          default: "5"
+          description: "How many versions older than the oldest in-use version to keep per prefix family, as rollback targets."
+          trim: true
+      - string:
+          name: ENVIRONMENTS
+          description: "Space-separated environments to scan for in-use CDN versions; leave empty to auto-discover every site with jitsi_meet_cdn_cloudflare_enabled. CAUTION: prefix families are shared across environments, so scanning a subset risks deleting versions another environment still uses."
+          trim: true
+      - string:
+          name: CDN_CLEANUP_ALLOW_EMPTY
+          description: "Space-separated environments allowed to have no in-use CDN versions (e.g. environments with no shards up); any other empty environment aborts the cleanup."
+          trim: true
+      - string:
+          name: INFRA_CUSTOMIZATIONS_REPO
+          default: git@github.com:jitsi/infra-customizations.git
+          description: "Repo with customized configurations, defaults to 'git@github.com:jitsi/infra-customizations.git'."
+          trim: true
+
+    project-type: pipeline
+    sandbox: true
+    pipeline-scm:
+      scm:
+        - git:
+            url: git@github.com:jitsi/infra-provisioning.git
+            credentials-id: "video-infra"
+            branches:
+              - "origin/${{VIDEO_INFRA_BRANCH}}"
+            browser: githubweb
+            browser-url: https://github.com/jitsi/infra-provisioning
+            submodule:
+              recursive: true
+      script-path: jenkins/groovy/cleanup-cdn-versions/Jenkinsfile
+      lightweight-checkout: true

--- a/scripts/cleanup-cdn-r2-versions.sh
+++ b/scripts/cleanup-cdn-r2-versions.sh
@@ -1,0 +1,246 @@
+#!/bin/bash
+
+# cleanup-cdn-r2-versions.sh
+#
+# Prunes old build folders from the Cloudflare R2 CDN bucket (v1/_cdn/*),
+# which accumulates one folder per published branding build
+# (see publish-branding-cdn.sh, e.g. v1/_cdn/meet8x8com_4570.1272).
+#
+# Retention policy, applied independently per version-prefix family
+# (meet8x8com_, meetjitsi_, ...):
+#   - a version is IN USE if any signal shard in any scanned environment
+#     serves a base.html that points at it
+#   - keep every in-use version
+#   - keep every version newer than the oldest in-use version (they may
+#     still be promoted later)
+#   - keep the newest $CDN_KEEP_ROLLBACK (default 5) versions older than
+#     the oldest in-use version, as rollback targets that outlive their
+#     original releases
+#   - delete everything older than those
+#   - a prefix family with no in-use version found anywhere is skipped
+#     entirely (fail safe: we cannot tell "unused" from "not scanned")
+#   - folders that do not look like build versions (auth-static/, ...) are
+#     never touched
+#
+# DRY RUN by default: prints what would be deleted. Pass --delete (or set
+# CDN_CLEANUP_CONFIRM=true) to actually purge.
+#
+# The scanned environments default to every sites/*/vars.yml with
+# jitsi_meet_cdn_cloudflare_enabled: true. Because prefix families are
+# shared across environments (e.g. meet8x8com_ serves prod-8x8, stage-8x8
+# and jitsi-net), overriding ENVIRONMENTS to a subset risks deleting a
+# version another environment still uses — only do that if you know the
+# prefix families do not overlap.
+
+set -e
+
+LOCAL_PATH=$(dirname "${BASH_SOURCE[0]}")
+
+CONFIG_VARS_PATH="$LOCAL_PATH/../config/vars.yml"
+
+DELETE_MODE="false"
+[[ "$1" == "--delete" ]] && DELETE_MODE="true"
+[[ "$CDN_CLEANUP_CONFIRM" == "true" ]] && DELETE_MODE="true"
+
+[ -z "$CDN_KEEP_ROLLBACK" ] && CDN_KEEP_ROLLBACK=5
+[ -z "$CDN_R2_BUCKET" ] && CDN_R2_BUCKET="$(yq '.cdn_r2_bucket' < $CONFIG_VARS_PATH)"
+[ -z "$CDN_R2_ROOT" ] && CDN_R2_ROOT="v1/_cdn"
+
+if [ -z "$CDN_R2_BUCKET" ] || [ "$CDN_R2_BUCKET" == "null" ]; then
+    echo "No CDN_R2_BUCKET found, exiting..."
+    exit 1
+fi
+
+if [ -z "$ANSIBLE_SSH_USER" ]; then
+    ANSIBLE_SSH_USER=$(whoami)
+fi
+
+# rclone remote for the R2 bucket, same credentials as publish-branding-cdn.sh
+[ -z "$RCLONE_CONFIG_PATH" ] && RCLONE_CONFIG_PATH="$HOME/.config/rclone/rclone.conf"
+CREATED_RCLONE_CONFIG="false"
+if [ ! -e "$RCLONE_CONFIG_PATH" ]; then
+    R2_SECRETS_PATH="$LOCAL_PATH/../ansible/secrets/r2-bucket.yml"
+    [ -z "$VAULT_PASSWORD_FILE" ] && VAULT_PASSWORD_FILE="$LOCAL_PATH/../.vault-password.txt"
+    R2_ACCESS_KEY_ID="$(ansible-vault view $R2_SECRETS_PATH --vault-password $VAULT_PASSWORD_FILE | yq eval ".r2_access_key_id" -)"
+    R2_SECRET_ACCESS_KEY="$(ansible-vault view $R2_SECRETS_PATH --vault-password $VAULT_PASSWORD_FILE | yq eval ".r2_secret_access_key" -)"
+    R2_ENDPOINT_URL="$(ansible-vault view $R2_SECRETS_PATH --vault-password $VAULT_PASSWORD_FILE | yq eval ".r2_endpoint_url" -)"
+    mkdir -p "$(dirname $RCLONE_CONFIG_PATH)"
+    cat > "$RCLONE_CONFIG_PATH" <<EOF
+[default]
+type = s3
+provider = Cloudflare
+access_key_id = $R2_ACCESS_KEY_ID
+secret_access_key = $R2_SECRET_ACCESS_KEY
+endpoint = $R2_ENDPOINT_URL
+bucket_acl = private
+no_check_bucket = true
+EOF
+    CREATED_RCLONE_CONFIG="true"
+fi
+
+function cleanup_rclone_config() {
+    [[ "$CREATED_RCLONE_CONFIG" == "true" ]] && rm -f "$RCLONE_CONFIG_PATH"
+}
+trap cleanup_rclone_config EXIT
+
+# version folders look like <prefix><meet>.<branding> (meet8x8com_4570.1272)
+# or a bare meet version (4679); anything else (auth-static, ...) is untouchable
+VERSION_FOLDER_REGEX='^([A-Za-z0-9]+_)?[0-9]+(\.[0-9]+)?$'
+
+# sortable fixed-width key from "<meet>[.<branding>]"
+function version_key() {
+    local major="${1%%.*}"
+    local minor="${1#*.}"
+    [[ "$minor" == "$1" ]] && minor=0
+    printf "%012d.%012d" "$major" "$minor"
+}
+
+# --- 1. find in-use versions across environments ---------------------------
+
+if [ -z "$ENVIRONMENTS" ]; then
+    for SITE_VARS in $LOCAL_PATH/../sites/*/vars.yml; do
+        CDN_CLOUDFLARE_FLAG=$(yq eval '.jitsi_meet_cdn_cloudflare_enabled' $SITE_VARS | tail -1)
+        if [[ "$CDN_CLOUDFLARE_FLAG" == "true" ]]; then
+            ENVIRONMENTS="$ENVIRONMENTS $(basename $(dirname $SITE_VARS))"
+        fi
+    done
+fi
+
+if [ -z "$ENVIRONMENTS" ]; then
+    echo "No ENVIRONMENTS with jitsi_meet_cdn_cloudflare_enabled found, exiting..."
+    exit 1
+fi
+
+echo "## scanning environments for in-use CDN versions:$ENVIRONMENTS"
+
+IN_USE_FOLDERS=""
+for ENV in $ENVIRONMENTS; do
+    DOMAIN=$(. $LOCAL_PATH/../sites/$ENV/stack-env.sh > /dev/null 2>&1; echo $DOMAIN)
+    if [ -z "$DOMAIN" ]; then
+        echo "## ERROR: no DOMAIN for environment $ENV, exiting without deleting anything"
+        exit 1
+    fi
+
+    # shard.sh list honors SHARDS_FROM_CONSUL: default (false) enumerates via
+    # shard.py (needs cloud credentials, the mode Jenkins jobs use); true asks
+    # consul directly
+    SHARDS=$(RELEASE_NUMBER="" ENVIRONMENT="$ENV" $LOCAL_PATH/shard.sh list $ANSIBLE_SSH_USER)
+    ENV_FOLDERS=""
+    for SHARD in $SHARDS; do
+        BASE_HTML=$(curl --silent --insecure --max-time 10 "https://$DOMAIN/$SHARD/base.html" || true)
+        # base href is either host-relative (/v1/_cdn/<folder>/) or the legacy
+        # absolute form (https://web-cdn.jitsi.net/<folder>/)
+        FOLDER=$(echo "$BASE_HTML" | sed -e 's|.*web-cdn.jitsi.net/||' -e 's|.*/v1/_cdn/||' -e 's|/".*||')
+        if [[ "$FOLDER" =~ $VERSION_FOLDER_REGEX ]]; then
+            ENV_FOLDERS="$ENV_FOLDERS $FOLDER"
+        else
+            echo "## WARNING: could not extract CDN version from $ENV shard $SHARD (got '$FOLDER')"
+        fi
+    done
+
+    ENV_FOLDERS=$(echo $ENV_FOLDERS | tr ' ' '\n' | sort -u)
+    if [ -z "$ENV_FOLDERS" ]; then
+        if [[ " $CDN_CLEANUP_ALLOW_EMPTY " == *" $ENV "* ]]; then
+            echo "## WARNING: no in-use CDN versions found for $ENV, allowed by CDN_CLEANUP_ALLOW_EMPTY"
+        else
+            echo "## ERROR: no in-use CDN versions found for $ENV; refusing to clean up anything."
+            echo "## if $ENV legitimately has no shards, add it to CDN_CLEANUP_ALLOW_EMPTY"
+            exit 1
+        fi
+    else
+        echo "## $ENV in use: "$ENV_FOLDERS
+        IN_USE_FOLDERS="$IN_USE_FOLDERS $ENV_FOLDERS"
+    fi
+done
+
+IN_USE_FOLDERS=$(echo $IN_USE_FOLDERS | tr ' ' '\n' | sort -u)
+
+# --- 2. list version folders in the bucket ---------------------------------
+
+ALL_FOLDERS=$(rclone lsf --dirs-only "default:$CDN_R2_BUCKET/$CDN_R2_ROOT/" | sed 's|/$||')
+
+CANDIDATE_FOLDERS=""
+PREFIXES=""
+for FOLDER in $ALL_FOLDERS; do
+    if [[ "$FOLDER" =~ $VERSION_FOLDER_REGEX ]]; then
+        CANDIDATE_FOLDERS="$CANDIDATE_FOLDERS $FOLDER"
+        PREFIX="${BASH_REMATCH[1]}"
+        PREFIXES="$PREFIXES ${PREFIX:-<none>}"
+    else
+        echo "## skipping non-version folder: $FOLDER"
+    fi
+done
+PREFIXES=$(echo $PREFIXES | tr ' ' '\n' | sort -u)
+
+# --- 3. apply retention per prefix family -----------------------------------
+
+DELETE_LIST=""
+for PREFIX in $PREFIXES; do
+    [[ "$PREFIX" == "<none>" ]] && PREFIX=""
+
+    # this family's folders in the bucket, oldest first
+    FAMILY=""
+    for FOLDER in $CANDIDATE_FOLDERS; do
+        [[ "$FOLDER" =~ $VERSION_FOLDER_REGEX ]] || continue
+        [[ "${BASH_REMATCH[1]}" == "$PREFIX" ]] || continue
+        FAMILY="$FAMILY $(version_key ${FOLDER#$PREFIX})|$FOLDER"
+    done
+    FAMILY=$(echo $FAMILY | tr ' ' '\n' | sort)
+
+    # oldest in-use version in this family
+    OLDEST_IN_USE_KEY=""
+    for FOLDER in $IN_USE_FOLDERS; do
+        [[ "$FOLDER" =~ $VERSION_FOLDER_REGEX ]] || continue
+        [[ "${BASH_REMATCH[1]}" == "$PREFIX" ]] || continue
+        KEY=$(version_key ${FOLDER#$PREFIX})
+        if [ -z "$OLDEST_IN_USE_KEY" ] || [[ "$KEY" < "$OLDEST_IN_USE_KEY" ]]; then
+            OLDEST_IN_USE_KEY="$KEY"
+        fi
+    done
+
+    if [ -z "$OLDEST_IN_USE_KEY" ]; then
+        echo "## prefix '${PREFIX:-<none>}': no in-use versions found in any scanned environment, skipping family"
+        continue
+    fi
+
+    # everything below the oldest in-use version, oldest first; keep the
+    # newest CDN_KEEP_ROLLBACK of them as rollback targets, delete the rest
+    OLDER=""
+    for ENTRY in $FAMILY; do
+        KEY="${ENTRY%%|*}"
+        [[ "$KEY" < "$OLDEST_IN_USE_KEY" ]] && OLDER="$OLDER $ENTRY"
+    done
+    OLDER_COUNT=$(echo $OLDER | wc -w | tr -d ' ')
+    DELETE_COUNT=$((OLDER_COUNT - CDN_KEEP_ROLLBACK))
+    [ "$DELETE_COUNT" -lt 0 ] && DELETE_COUNT=0
+
+    echo "## prefix '${PREFIX:-<none>}': $(echo $FAMILY | wc -w | tr -d ' ') folders, $OLDER_COUNT older than oldest in-use, keeping $CDN_KEEP_ROLLBACK rollback versions, deleting $DELETE_COUNT"
+
+    if [ "$DELETE_COUNT" -gt 0 ]; then
+        FAMILY_DELETES=$(echo $OLDER | tr ' ' '\n' | head -n $DELETE_COUNT | cut -d'|' -f2)
+        DELETE_LIST="$DELETE_LIST $FAMILY_DELETES"
+    fi
+done
+
+# --- 4. delete (or report) ---------------------------------------------------
+
+DELETE_LIST=$(echo $DELETE_LIST | tr ' ' '\n' | sort)
+if [ -z "$DELETE_LIST" ]; then
+    echo "## nothing to delete"
+    exit 0
+fi
+
+echo "## folders to delete from $CDN_R2_BUCKET/$CDN_R2_ROOT:"
+echo "$DELETE_LIST"
+
+if [[ "$DELETE_MODE" != "true" ]]; then
+    echo "## DRY RUN: no deletions performed; re-run with --delete to purge"
+    exit 0
+fi
+
+for FOLDER in $DELETE_LIST; do
+    echo "## purging $CDN_R2_BUCKET/$CDN_R2_ROOT/$FOLDER"
+    rclone purge "default:$CDN_R2_BUCKET/$CDN_R2_ROOT/$FOLDER"
+done
+
+echo "## CDN R2 cleanup complete"


### PR DESCRIPTION
JIT-16013: https://agile.8x8.com/browse/JIT-16013

## Problem

The Cloudflare R2 CDN bucket (`jitsi-cdn-bucket`, path `v1/_cdn/`) accumulates one folder per published branding build (e.g. `meet8x8com_4570.1272`) via `publish-branding-cdn.sh`, and nothing ever deletes them, so storage grows without bound.

## Approach

New `scripts/cleanup-cdn-r2-versions.sh` applies a retention policy independently per version-prefix family (`meet8x8com_`, `meetjitsi_`, ...):

- a version is **in use** if any signal shard in any scanned environment serves a `base.html` pointing at it (fetched over HTTP, same trick as `validate-shard.sh`; shards enumerated via `shard.sh list`)
- keep every in-use version
- keep every version **newer** than the oldest in-use version (they may still be promoted later)
- keep the newest `CDN_KEEP_ROLLBACK` (default 5) versions **older** than the oldest in-use version, as rollback targets that outlive their releases
- delete everything older than those

Fail-safe by design:

- **dry-run by default** — deletes only with `--delete` / `CDN_CLEANUP_CONFIRM=true`
- aborts if any environment reports zero in-use versions (can't tell "no shards" from "consul/cloud unreachable"); per-environment override via `CDN_CLEANUP_ALLOW_EMPTY`
- skips any prefix family with no in-use version found anywhere
- only touches folders matching `<prefix><digits>.<digits>` — `auth-static/` and anything unexpected survive
- scans **all** environments with `jitsi_meet_cdn_cloudflare_enabled: true` by default, since prefix families are shared across environments (`meet8x8com_` serves prod-8x8/stage-8x8/jitsi-net, `meetjitsi_` serves meet-jit-si/beta/torture-test)

R2 access reuses the vaulted `r2-bucket.yml` rclone credentials from `publish-branding-cdn.sh`.

## Jenkins job

`cleanup-cdn-versions` (yaml + Jenkinsfile, modeled on `publish-branding-cdn`): `DRY_RUN` defaults to **true**, `concurrent: false`, weekly `timed` trigger included but commented out until dry-run output has been validated.

## Testing

- `bash -n` and shellcheck clean (benign warnings only), job YAML parses
- retention logic exercised against a simulated folder set (shared-prefix families, bare-version folders, `auth-static`): deletes only below the rollback window, keeps in-use/newer, skips families with no in-use versions

Suggested first step after merge: run the job with defaults (dry run) to see how much has accumulated per prefix family.

## Follow-up

The legacy S3 origin bucket (`jitsi-cdn-origin-20181106`) accumulates both plain-meet and branding builds; the same policy could be ported there once the R2 behavior is validated.
