### PR TITLE
fix(cdn): correct per-environment domain and cross-check CDN prefix (JIT-16013)

### DIFF
--- a/scripts/cleanup-cdn-r2-versions.sh
+++ b/scripts/cleanup-cdn-r2-versions.sh
@@ -115,11 +115,19 @@ echo "## scanning environments for in-use CDN versions:$ENVIRONMENTS"
 
 IN_USE_FOLDERS=""
 for ENV in $ENVIRONMENTS; do
-    DOMAIN=$(. $LOCAL_PATH/../sites/$ENV/stack-env.sh > /dev/null 2>&1; echo $DOMAIN)
+    # DOMAIN must be cleared inside the subshell: stack-env.sh only sets it
+    # when unset, so a value carried over from the previous environment would
+    # win and every shard query would hit the wrong domain
+    DOMAIN=$(DOMAIN=""; . $LOCAL_PATH/../sites/$ENV/stack-env.sh > /dev/null 2>&1; echo $DOMAIN)
     if [ -z "$DOMAIN" ]; then
         echo "## ERROR: no DOMAIN for environment $ENV, exiting without deleting anything"
         exit 1
     fi
+
+    # the prefix family this environment publishes to, used to sanity-check
+    # what the shards report back
+    EXPECTED_PREFIX=$(yq eval '.jitsi_meet_cdn_prefix' $LOCAL_PATH/../sites/$ENV/vars.yml | tail -1)
+    [[ "$EXPECTED_PREFIX" == "null" ]] && EXPECTED_PREFIX=""
 
     # shard.sh list honors SHARDS_FROM_CONSUL: default (false) enumerates via
     # shard.py (needs cloud credentials, the mode Jenkins jobs use); true asks
@@ -132,7 +140,11 @@ for ENV in $ENVIRONMENTS; do
         # absolute form (https://web-cdn.jitsi.net/<folder>/)
         FOLDER=$(echo "$BASE_HTML" | sed -e 's|.*web-cdn.jitsi.net/||' -e 's|.*/v1/_cdn/||' -e 's|/".*||')
         if [[ "$FOLDER" =~ $VERSION_FOLDER_REGEX ]]; then
-            ENV_FOLDERS="$ENV_FOLDERS $FOLDER"
+            if [[ "${BASH_REMATCH[1]}" == "$EXPECTED_PREFIX" ]]; then
+                ENV_FOLDERS="$ENV_FOLDERS $FOLDER"
+            else
+                echo "## WARNING: $ENV shard $SHARD reports CDN folder '$FOLDER' but $ENV publishes prefix '${EXPECTED_PREFIX:-<none>}'; ignoring it (check DOMAIN/shard routing)"
+            fi
         else
             echo "## WARNING: could not extract CDN version from $ENV shard $SHARD (got '$FOLDER')"
         fi


### PR DESCRIPTION
JIT-16013: https://agile.8x8.com/browse/JIT-16013

Follow-up to #1120. The first dry run showed prod-8x8 and stage-8x8 reporting `meetjitsi_9330.6429` as in use, even though they publish to the `meet8x8com_` family — which was then skipped as having "no in-use versions". No deletions happened (dry run + the family skip fail-safe), but detection was wrong.

## Root cause

The in-use scan assigned `DOMAIN` in the parent shell each loop iteration, and `sites/*/stack-env.sh` guards with `[ -z "$DOMAIN" ] && export DOMAIN=...` — so after the first environment (beta-meet-jit-si) ran, every subsequent environment inherited `beta.meet.jit.si` and curled its shards' `base.html` from the wrong domain.

## Fixes

- **Clear `DOMAIN` inside the sourcing subshell** so each environment resolves its own domain.
- **Cross-check each shard-reported folder against the environment's configured `jitsi_meet_cdn_prefix`** from `sites/<env>/vars.yml` (defense in depth, as requested): a mismatching folder is ignored with a warning naming both prefixes, and an environment whose shards all mismatch ends up with zero in-use versions and trips the existing refuse-to-clean abort — so a repeat of this failure mode now halts the run loudly instead of silently misclassifying.

## Testing

- `bash -n` clean
- simulated two stack-env.sh files with the `[ -z "$DOMAIN" ]` guard: old pattern reproduces the leak (`prod -> beta.meet.jit.si`), fixed pattern resolves each correctly
- prefix cross-check exercised for accept/reject: misrouted `meetjitsi_*` rejected under `meet8x8com_` and under empty-prefix environments; correct branded and bare versions accepted

Expected dry-run output after this fix: prod-8x8/stage-8x8 report `meet8x8com_*` versions and the `meet8x8com_` family gets a real retention plan instead of being skipped.
