### PR TITLE
feat(cloudprober): probe each vault node directly via consul discovery

### DIFF
--- a/nomad/jitsi_packs/packs/jitsi_cloudprober/templates/_cloudprober_config.tpl
+++ b/nomad/jitsi_packs/packs/jitsi_cloudprober/templates/_cloudprober_config.tpl
@@ -324,6 +324,52 @@ probe {
     value: "infra"
   }
 }
+
+# probes each vault node directly, discovered from consul (service "vault"),
+# bypassing the load balancer. The LB-fronted "vault" probe above only ever
+# reaches the active node, so it stays green while a standby node is sealed
+# (silent loss of HA redundancy). "vault|any" includes nodes whose consul health
+# check is critical (e.g. sealed) so they are still probed. Healthy states are
+# 200 (active), 429 (standby) and 473 (perf-standby); a sealed node returns 503
+# and fails. Cert validation is disabled since nodes present the wildcard cert
+# on their own (non-matching) address. Nodes register themselves via the
+# consul-vault ansible role, so rotation needs no cloudprober redeploy.
+probe {
+  name: "vault_nodes"
+  type: HTTP
+  targets {
+    {{ $vault_node_count := 0 -}}
+    {{ range service "vault|any" -}}
+    {{ $vault_node_count = add $vault_node_count 1 -}}
+    endpoint {
+      name: "{{ .Node }}"
+      url: "https://{{ .Address }}:{{ .Port }}/v1/sys/health"
+    }
+    {{ end -}}
+    {{ if eq $vault_node_count 0 -}}
+    host_names: ""
+    {{- end }}
+  }
+  http_probe {
+    protocol: HTTPS
+    tls_config {
+      disable_cert_validation: true
+    }
+  }
+  validator {
+      name: "status_code_ok"
+      http_validator {
+          success_status_codes: "200-299,429,473"
+      }
+  }
+  interval_msec: 30000
+  timeout_msec: 10000
+  latency_unit: "ms"
+  additional_label {
+    key: "service"
+    value: "infra"
+  }
+}
 [[ end -]]
 [[ if var "enable_canary" . -]]
 # probes canary health and latency across datacenters


### PR DESCRIPTION
## Why

Follow-up to the 2026-07-09 ops-prod Vault outage. The existing `vault` cloudprober probe only hits the load-balanced endpoint. The LB routes to the active node and removes sealed backends from rotation, so a sealed **standby** is invisible to it — a standby had been silently sealed for ~6 months and no alert fired.

## What

Adds a `vault_nodes` probe (inside the existing `enable_vault` block) that:

- **Discovers every vault node from consul** via `{{ range service "vault|any" }}` — `|any` includes nodes whose consul health check is critical (e.g. sealed) so they are still probed.
- Hits each node's own `/v1/sys/health` directly (cert validation disabled since nodes present the wildcard cert on their own address).
- Treats `200/429/473` (active/standby/perf-standby) as healthy; a **sealed** node returns `503` and fails the probe.

Because targets come from consul at render time, **node rotation needs no cloudprober redeploy**.

## Depends on

- `infra-configuration`: new `consul-vault` role registers each node as consul service `vault` (+ seal watchdog).
- `infra-customizations-private`: wires the role into `configure-vault-local.yml` and adds the `Vault_Node_Sealed_Or_Down` alert on `probe="vault_nodes"`.

In a datacenter with no vault service the probe renders empty targets (`host_names: ""`) and is harmless.