### PR TITLE
fix: Key the translation CF-Access secret lookup by environment

### DIFF
--- a/scripts/deploy-nomad-shard-backend.sh
+++ b/scripts/deploy-nomad-shard-backend.sh
@@ -143,10 +143,11 @@ export CONFIG_turnrelay_password="$(ansible-vault view $ENCRYPTED_COTURN_CREDENT
 # TODO: use the separate _jvb and _visitor secrets for the different accounts.
 export CONFIG_jicofo_auth_password="$(ansible-vault view $ENCRYPTED_JICOFO_CREDENTIALS_FILE --vault-password $VAULT_PASSWORD_FILE | yq eval ".${JICOFO_XMPP_PASSWORD_VARIABLE}" -)"
 
-# Live-translation opus-transcriber-proxy CF-Access credentials (reused from transcription). Optional: empty when unset,
-# in which case jicofo signals the translation connect without http-headers.
-export CONFIG_jicofo_translation_cf_access_client_id="$(ansible-vault view $ENCRYPTED_JICOFO_CREDENTIALS_FILE --vault-password $VAULT_PASSWORD_FILE | yq eval '.secrets_jicofo_opus_transcriber_client_id // ""' -)"
-export CONFIG_jicofo_translation_cf_access_client_secret="$(ansible-vault view $ENCRYPTED_JICOFO_CREDENTIALS_FILE --vault-password $VAULT_PASSWORD_FILE | yq eval '.secrets_jicofo_opus_transcriber_secret // ""' -)"
+# Live-translation opus-transcriber-proxy CF-Access credentials (reused from transcription; same service token as the
+# translate worker's Zero Trust Access policy). Keyed per-environment since this vault file is shared across shards.
+# Optional: empty when unset, in which case jicofo signals the translation connect without http-headers.
+export CONFIG_jicofo_translation_cf_access_client_id="$(ansible-vault view $ENCRYPTED_JICOFO_CREDENTIALS_FILE --vault-password $VAULT_PASSWORD_FILE | yq eval ".secrets_jicofo_opus_transcriber_client_id_by_environment.\"$ENVIRONMENT\" // \"\"" -)"
+export CONFIG_jicofo_translation_cf_access_client_secret="$(ansible-vault view $ENCRYPTED_JICOFO_CREDENTIALS_FILE --vault-password $VAULT_PASSWORD_FILE | yq eval ".secrets_jicofo_opus_transcriber_secret_by_environment.\"$ENVIRONMENT\" // \"\"" -)"
 
 export CONFIG_asap_jwt_kid="$(ansible-vault view $ENCRYPTED_ASAP_KEYS_FILE --vault-password $VAULT_PASSWORD_FILE | yq eval ".${ASAP_KEY_VARIABLE}.id" -)"
 


### PR DESCRIPTION
Follow-up to #1118 (merged): the opus-transcriber-proxy CF-Access credentials for live translation live under a `_by_environment` map in the shared jicofo vault file (`secrets_jicofo_opus_transcriber_client_id_by_environment.<env>` / `..._secret_by_environment.<env>`), matching how `JICOFO_XMPP_PASSWORD_VARIABLE` reads `secrets_jicofo_focus_by_environment` a few lines above, and how the translate worker's Zero Trust Access policy reads the same credential.

#1118 read a flat top-level key instead, which would resolve to null/empty for every environment. Fixes the lookup to use the per-environment key.