### PR TITLE
JIT-16115: alert on opus-transcriber-proxy backend errors

### DIFF
--- a/jenkins/jobs/provision-nomad-opus-synthetic.yaml
+++ b/jenkins/jobs/provision-nomad-opus-synthetic.yaml
@@ -1,0 +1,59 @@
+- job:
+    name: provision-nomad-opus-synthetic
+    display-name: provision nomad opus-synthetic
+    description: "registers the opus-transcriber-proxy transcription synthetic periodic job in nomad in an oracle region in an environment"
+    concurrent: true
+    parameters:
+      - string:
+          name: VIDEO_INFRA_BRANCH
+          default: main
+          description: "Controls checkout branch for infra repos, defaults to 'main'."
+          trim: true
+      - string:
+          name: ENVIRONMENT
+          description: "Environment to provision in (also the environment whose endpoint and CF token are used)"
+          trim: true
+      - string:
+          name: ORACLE_REGION
+          description: "Region to provision in"
+          trim: true
+      - string:
+          name: JOB_TYPE
+          default: opus-synthetic
+          description: "Nomad job type to provision, defaults to 'opus-synthetic' do not change"
+          trim: true
+      - string:
+          name: OPUS_SYNTHETIC_IMAGE
+          description: "Overrides the opus-transcriber-proxy image (defaults to jitsi/opus-transcriber-proxy:latest)"
+          trim: true
+      - string:
+          name: OPUS_SYNTHETIC_INTERVAL_SECONDS
+          default: "300"
+          description: "How often the running synthetic replays the test, in seconds. prod-8x8: 300 (5m); stage-8x8: 7200 (2h)."
+          trim: true
+      - string:
+          name: INFRA_CONFIGURATION_REPO
+          default: git@github.com:jitsi/infra-configuration.git
+          description: "Repo for configuration code (ansible etc), defaults to 'git@github.com:jitsi/infra-configuration.git'."
+          trim: true
+      - string:
+          name: INFRA_CUSTOMIZATIONS_REPO
+          default: git@github.com:jitsi/infra-customizations-private.git
+          description: "Repo with customized configurations, defaults to 'git@github.com:jitsi/infra-customizations-private.git'."
+          trim: true
+
+    project-type: pipeline
+    sandbox: true
+    pipeline-scm:
+      scm:
+        - git:
+            url: git@github.com:jitsi/infra-provisioning.git
+            credentials-id: "video-infra"
+            branches:
+              - "origin/${{VIDEO_INFRA_BRANCH}}"
+            browser: githubweb
+            browser-url: https://github.com/jitsi/infra-provisioning
+            submodule:
+              recursive: true
+      script-path: jenkins/groovy/provision-nomad-job/Jenkinsfile
+      lightweight-checkout: true

--- a/nomad/jitsi_packs/packs/jitsi_opus_synthetic/metadata.hcl
+++ b/nomad/jitsi_packs/packs/jitsi_opus_synthetic/metadata.hcl
@@ -1,0 +1,8 @@
+app {
+  url = ""
+}
+pack {
+  name        = "opus_synthetic"
+  description = "Monitors the opus-transcriber-proxy /transcribe endpoint (image in monitor mode)"
+  version     = ""
+}

--- a/nomad/jitsi_packs/packs/jitsi_opus_synthetic/outputs.tpl
+++ b/nomad/jitsi_packs/packs/jitsi_opus_synthetic/outputs.tpl
@@ -1,0 +1,1 @@
+Deployed the opus_synthetic pack: a periodic replay test of the opus-transcriber-proxy /transcribe endpoint.

--- a/nomad/jitsi_packs/packs/jitsi_opus_synthetic/templates/_helpers.tpl
+++ b/nomad/jitsi_packs/packs/jitsi_opus_synthetic/templates/_helpers.tpl
@@ -1,0 +1,13 @@
+[[/* Template helpers used by jitsi_opus_synthetic.nomad.tpl. */]]
+
+[[/* job_name: the job_name var, falling back to the pack name. */]]
+[[- define "job_name" -]]
+[[ coalesce (var "job_name" .) (meta "pack.name" .) | quote ]]
+[[- end -]]
+
+[[/* region: emit a region line only when the region var is set. */]]
+[[ define "region" -]]
+[[- if var "region" . -]]
+  region = "[[ var "region" . ]]"
+[[- end -]]
+[[- end -]]

--- a/nomad/jitsi_packs/packs/jitsi_opus_synthetic/templates/jitsi_opus_synthetic.nomad.tpl
+++ b/nomad/jitsi_packs/packs/jitsi_opus_synthetic/templates/jitsi_opus_synthetic.nomad.tpl
@@ -1,0 +1,95 @@
+job [[ template "job_name" . ]] {
+  [[ template "region" . ]]
+  datacenters = [[ var "datacenters" . | toStringList ]]
+  type = "service"
+
+  update {
+    max_parallel     = 1
+    health_check     = "checks"
+    min_healthy_time = "15s"
+    healthy_deadline = "3m"
+    auto_revert      = true
+  }
+
+  reschedule {
+    delay          = "30s"
+    delay_function  = "exponential"
+    max_delay      = "1h"
+    unlimited      = true
+  }
+
+  // docker driver requires linux
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
+  group "synthetic" {
+    constraint {
+      attribute = "${meta.pool_type}"
+      value     = "[[ var "pool_type" . ]]"
+    }
+
+    count = 1
+
+    restart {
+      attempts = 3
+      interval = "5m"
+      delay    = "25s"
+      mode     = "delay"
+    }
+
+    network {
+      port "http" {
+        to = [[ var "metrics_port" . ]]
+      }
+    }
+
+    task "opus-synthetic" {
+      driver = "docker"
+
+      // The opus-transcriber-proxy image run in monitor mode: it exposes /metrics with an
+      // opus_transcriber_proxy_monitor_healthy flag and internally replays the sample dump
+      // against the target /transcribe URL every interval, reporting unhealthy only after two
+      // consecutive failed attempts. The default image CMD is the proxy; this overrides it.
+      config {
+        image   = "[[ var "image" . ]]"
+        command = "node"
+        args    = ["dist/bundle/monitor.js"]
+        ports   = ["http"]
+      }
+
+      service {
+        name = "opus-synthetic"
+        port = "http"
+        // Liveness only (process up) — a failing transcription must not restart the task.
+        check {
+          name     = "alive"
+          type     = "http"
+          path     = "/health"
+          interval = "15s"
+          timeout  = "3s"
+        }
+      }
+
+      env {
+        MONITOR_PORT                = "[[ var "metrics_port" . ]]"
+        MONITOR_URL                 = "[[ var "ws_url_template" . ]]"
+        MONITOR_INTERVAL_SECONDS    = "[[ var "interval_seconds" . ]]"
+        MONITOR_RETRY_DELAY_SECONDS = "[[ var "retry_delay_seconds" . ]]"
+        MONITOR_CONNECT_TIMEOUT     = "[[ var "connect_timeout" . ]]"
+        MONITOR_MIN_FINALS          = "[[ var "assert_min_finals" . ]]"
+        MONITOR_SAMPLE              = "[[ var "sample_dump" . ]]"
+        // The image's monitor mode takes headers as a generic JSON object; the CF Access service
+        // token is passed here (it is what gates the endpoint) without the image knowing anything
+        // CF-specific.
+        MONITOR_HEADERS = "{\"CF-Access-Client-Id\":\"[[ var "cf_access_client_id" . ]]\",\"CF-Access-Client-Secret\":\"[[ var "cf_access_client_secret" . ]]\"}"
+      }
+
+      resources {
+        cpu    = 500
+        memory = 256
+      }
+    }
+  }
+}

--- a/nomad/jitsi_packs/packs/jitsi_opus_synthetic/variables.hcl
+++ b/nomad/jitsi_packs/packs/jitsi_opus_synthetic/variables.hcl
@@ -1,0 +1,81 @@
+variable "job_name" {
+  description = "The name to use as the job name which overrides using the pack name"
+  type        = string
+  default     = ""
+}
+
+variable "region" {
+  description = "The region where the job should be placed"
+  type        = string
+  default     = ""
+}
+
+variable "datacenters" {
+  description = "A list of datacenters in the region which are eligible for task placement"
+  type        = list(string)
+  default     = ["dc1"]
+}
+
+variable "pool_type" {
+  description = "The type of pool to deploy to"
+  type        = string
+  default     = "general"
+}
+
+variable "image" {
+  description = "The opus-transcriber-proxy docker image (run in monitor mode via a command override)"
+  type        = string
+}
+
+variable "metrics_port" {
+  description = "Container port the synthetic metrics server listens on (mapped to a dynamic host port and scraped by Prometheus via Consul)"
+  type        = number
+  default     = 8080
+}
+
+variable "interval_seconds" {
+  description = "How often the synthetic replays the sample against the endpoint"
+  type        = string
+  default     = "300"
+}
+
+variable "retry_delay_seconds" {
+  description = "Seconds to wait before the single retry after a failed first attempt (the run reports failure only if both attempts fail)"
+  type        = string
+  default     = "20"
+}
+
+variable "ws_url_template" {
+  description = "The wss:// /transcribe endpoint. The literal token __SESSION_ID__ is replaced at runtime with a fresh synthetic-<random> sessionId so successive runs never clash."
+  type        = string
+}
+
+variable "sample_dump" {
+  description = "Path (inside the image) to the JSONL Opus dump to replay"
+  type        = string
+  default     = "resources/sample.jsonl"
+}
+
+variable "connect_timeout" {
+  description = "Seconds to wait for the websocket to connect before failing"
+  type        = string
+  default     = "15"
+}
+
+variable "assert_min_finals" {
+  description = "Minimum number of final transcripts required for the run to pass"
+  type        = string
+  default     = "1"
+}
+
+variable "cf_access_client_id" {
+  description = "Cloudflare Access service-token client id (CF-Access-Client-Id header)"
+  type        = string
+  default     = ""
+}
+
+variable "cf_access_client_secret" {
+  description = "Cloudflare Access service-token client secret (CF-Access-Client-Secret header)"
+  type        = string
+  default     = ""
+}

--- a/nomad/prometheus.hcl
+++ b/nomad/prometheus.hcl
@@ -195,6 +195,16 @@ ${var.custom_relabels}
       - target_label: service
         replacement: 'cloudprober'
 ${var.custom_relabels}
+  - job_name: 'opus-synthetic'
+    scrape_interval: 30s
+    metrics_path: /metrics
+    consul_sd_configs:
+    - server: '{{ env "NOMAD_IP_prometheus_ui" }}:8500'
+      services: ['opus-synthetic']
+    metric_relabel_configs:
+      - target_label: service
+        replacement: 'jitsi'
+${var.custom_relabels}
   - job_name: 'prometheus'
     scrape_interval: 5s
     static_configs:
@@ -508,6 +518,44 @@ groups:
         region and should be investigated immediately.
       dashboard_url: ${var.grafana_url}
       alert_url: https://${var.prometheus_hostname}/alerts?search=probe_site_unhealthy
+  - alert: Opus_Transcribe_Synthetic_Failed
+    # The opus-synthetic service (opus-transcriber-proxy in monitor mode) exposes
+    # opus_transcriber_proxy_monitor_healthy as a persistent gauge (1 healthy, 0 unhealthy); it is
+    # 0 once the replay against /transcribe has failed on two consecutive attempts (an attempt plus
+    # one retry, done in the service) and stays 0 until a check succeeds. min() collapses the single
+    # service instance to one alert. Absent where the synthetic is not deployed (no data -> never
+    # fires); pages only where alertmanager paging is enabled.
+    expr: min(opus_transcriber_proxy_monitor_healthy) < 1
+    for: 2m
+    labels:
+      service: jitsi
+      severity: severe
+      page: true
+    annotations:
+      summary: the opus-transcriber-proxy transcription synthetic is failing in ${var.dc}
+      description: >-
+        The opus-transcriber-proxy /transcribe synthetic in ${var.dc} failed on two consecutive
+        attempts, so live transcription is likely broken. The opus-synthetic Nomad service
+        replays a sample audio dump against the /transcribe endpoint on an interval (retrying
+        once on failure); check its allocation logs for the replay output.
+      dashboard_url: ${var.grafana_url}
+      alert_url: https://${var.prometheus_hostname}/alerts?search=opus_transcribe_synthetic_failed
+  - alert: Opus_Transcribe_Synthetic_Down
+    # The synthetic service itself is not being scraped (crashed, unscheduled, or unhealthy), so
+    # transcription health is unknown. Warn only (does not page) since it is not itself an outage;
+    # only fires where the synthetic is expected to run, i.e. its Prometheus target exists.
+    expr: max(up{job="opus-synthetic"}) < 1
+    for: 15m
+    labels:
+      service: jitsi
+      severity: warn
+    annotations:
+      summary: the opus-transcriber-proxy transcription synthetic is down in ${var.dc}
+      description: >-
+        The opus-synthetic service in ${var.dc} has not been scrapeable for 15m, so the
+        transcription synthetic is not reporting. Check the opus-synthetic Nomad job.
+      dashboard_url: ${var.grafana_url}
+      alert_url: https://${var.prometheus_hostname}/alerts?search=opus_transcribe_synthetic_down
   - alert: Probe_Ingress_Region_Unhealthy
     expr: cloudprober_haproxy_region_check_passed < 1
     for: 5m

--- a/nomad/prometheus.hcl
+++ b/nomad/prometheus.hcl
@@ -556,6 +556,46 @@ groups:
         transcription synthetic is not reporting. Check the opus-synthetic Nomad job.
       dashboard_url: ${var.grafana_url}
       alert_url: https://${var.prometheus_hostname}/alerts?search=opus_transcribe_synthetic_down
+  - alert: OTP_Backend_Errors
+    # opus-transcriber-proxy (a Cloudflare Container) pushes otp_* metrics through
+    # alloy-cloudflare into this region's prometheus, so this only has data in the 8x8
+    # deployment environments (absent elsewhere -> never fires). The counter is registered
+    # lazily by the service: the series does not exist until the first backend error ever
+    # occurs, and the first increment after series creation may be missed since increase()
+    # needs two samples.
+    expr: sum by (env, job) (increase(otp_backend_errors_total[5m])) > 0
+    for: 2m
+    labels:
+      service: jitsi
+      severity: warn
+    annotations:
+      summary: opus-transcriber-proxy backend errors in {{ $labels.env }} via ${var.dc}
+      description: >-
+        The opus-transcriber-proxy ({{ $labels.env }}) reported backend errors in the last
+        5 minutes (currently {{ $value | printf "%.0f" }} over 5m), ingested via
+        alloy-cloudflare in ${var.dc}. The proxy failed talking to its transcription
+        backend; check the opus-transcriber-proxy Cloudflare Container logs.
+      dashboard_url: ${var.grafana_url}
+      alert_url: https://${var.prometheus_hostname}/alerts?search=otp_backend_errors
+  - alert: OTP_Backend_Errors_Sustained
+    # Same signal held for 15m: backend errors are ongoing rather than a blip. Severe but
+    # does not page - Opus_Transcribe_Synthetic_Failed above pages when transcription is
+    # actually broken end-to-end.
+    expr: sum by (env, job) (increase(otp_backend_errors_total[5m])) > 0
+    for: 15m
+    labels:
+      service: jitsi
+      severity: severe
+    annotations:
+      summary: sustained opus-transcriber-proxy backend errors in {{ $labels.env }} via ${var.dc}
+      description: >-
+        The opus-transcriber-proxy ({{ $labels.env }}) has reported backend errors
+        continuously for 15+ minutes (most recently {{ $value | printf "%.0f" }} over 5m),
+        ingested via alloy-cloudflare in ${var.dc}. The transcription backend is likely
+        unhealthy; check the opus-transcriber-proxy Cloudflare Container logs and the
+        backend service health.
+      dashboard_url: ${var.grafana_url}
+      alert_url: https://${var.prometheus_hostname}/alerts?search=otp_backend_errors
   - alert: Probe_Ingress_Region_Unhealthy
     expr: cloudprober_haproxy_region_check_passed < 1
     for: 5m

--- a/scripts/deploy-nomad-opus-synthetic.sh
+++ b/scripts/deploy-nomad-opus-synthetic.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+
+# Registers the opus-transcriber-proxy transcription synthetic as a Nomad periodic job in
+# one region of one environment. The job runs every 5 minutes, replays a sample Opus dump
+# against that environment's public /transcribe endpoint, and emits a pass/fail gauge to the
+# node-local telegraf; a Prometheus rule pages when it fails on two consecutive runs.
+#
+# ENVIRONMENT is both the cluster to deploy into and the environment whose endpoint/token are
+# used (cloudprober-style), e.g. ENVIRONMENT=prod-8x8 ORACLE_REGION=us-phoenix-1.
+
+if [ -z "$ENVIRONMENT" ]; then
+    echo "No ENVIRONMENT set, exiting"
+    exit 2
+fi
+
+LOCAL_PATH=$(dirname "${BASH_SOURCE[0]}")
+
+[ -e "$LOCAL_PATH/../sites/$ENVIRONMENT/stack-env.sh" ] && . "$LOCAL_PATH/../sites/$ENVIRONMENT/stack-env.sh"
+
+[ -e "$LOCAL_PATH/../clouds/all.sh" ] && . "$LOCAL_PATH/../clouds/all.sh"
+[ -e "$LOCAL_PATH/../clouds/oracle.sh" ] && . "$LOCAL_PATH/../clouds/oracle.sh"
+
+[ -z "$ENVIRONMENT_CONFIGURATION_FILE" ] && ENVIRONMENT_CONFIGURATION_FILE="$LOCAL_PATH/../sites/$ENVIRONMENT/vars.yml"
+
+if [ -z "$ORACLE_REGION" ]; then
+    echo "No ORACLE_REGION set, exiting"
+    exit 2
+fi
+
+[ -z "$VAULT_PASSWORD_FILE" ] && VAULT_PASSWORD_FILE="$LOCAL_PATH/../.vault-password.txt"
+
+[ -z "$LOCAL_REGION" ] && LOCAL_REGION="$OCI_LOCAL_REGION"
+[ -z "$LOCAL_REGION" ] && LOCAL_REGION="us-phoenix-1"
+
+if [ -z "$NOMAD_ADDR" ]; then
+    export NOMAD_ADDR="https://$ENVIRONMENT-$LOCAL_REGION-nomad.$TOP_LEVEL_DNS_ZONE_NAME"
+fi
+
+NOMAD_DC="$ENVIRONMENT-$ORACLE_REGION"
+JOB_NAME="opus-synthetic-$ORACLE_REGION"
+PACKS_DIR="$LOCAL_PATH/../nomad/jitsi_packs/packs"
+
+# --- Cloudflare Access service token: same source jicofo uses (ansible-vault jicofo.yml). ---
+[ -z "$ENCRYPTED_JICOFO_CREDENTIALS_FILE" ] && ENCRYPTED_JICOFO_CREDENTIALS_FILE="$LOCAL_PATH/../ansible/secrets/jicofo.yml"
+CF_ACCESS_CLIENT_ID="$(ansible-vault view $ENCRYPTED_JICOFO_CREDENTIALS_FILE --vault-password $VAULT_PASSWORD_FILE | yq eval ".secrets_jicofo_opus_transcriber_client_id_by_environment.\"$ENVIRONMENT\" // \"\"" -)"
+CF_ACCESS_CLIENT_SECRET="$(ansible-vault view $ENCRYPTED_JICOFO_CREDENTIALS_FILE --vault-password $VAULT_PASSWORD_FILE | yq eval ".secrets_jicofo_opus_transcriber_secret_by_environment.\"$ENVIRONMENT\" // \"\"" -)"
+
+if [ -z "$CF_ACCESS_CLIENT_ID" ] || [ -z "$CF_ACCESS_CLIENT_SECRET" ]; then
+    echo "No opus-transcriber CF Access token for environment $ENVIRONMENT in $ENCRYPTED_JICOFO_CREDENTIALS_FILE, exiting"
+    exit 3
+fi
+
+# --- Endpoint: reuse the jicofo transcription URL template. Its {{MEETING_ID}} placeholder
+#     becomes __SESSION_ID__, which the job replaces at runtime with synthetic-<random>. ---
+URL_TEMPLATE="$(cat $ENVIRONMENT_CONFIGURATION_FILE | yq eval '.jicofo_transcription_url_template // ""' -)"
+if [ -z "$URL_TEMPLATE" ] || [ "$URL_TEMPLATE" == "false" ]; then
+    echo "No jicofo_transcription_url_template in $ENVIRONMENT_CONFIGURATION_FILE, exiting"
+    exit 3
+fi
+WS_URL_TEMPLATE="${URL_TEMPLATE//\{\{MEETING_ID\}\}/__SESSION_ID__}"
+
+# --- Cadence: how often the running service replays the test (prod defaults to 5m; stage 2h). ---
+[ -z "$OPUS_SYNTHETIC_INTERVAL_SECONDS" ] && OPUS_SYNTHETIC_INTERVAL_SECONDS="300"
+
+# --- Image: the opus-transcriber-proxy image built by the repo's Docker Hub pipeline. ---
+[ -z "$OPUS_SYNTHETIC_IMAGE" ] && OPUS_SYNTHETIC_IMAGE="jitsi/opus-transcriber-proxy:latest"
+
+VAR_FILE="./opus-synthetic-${NOMAD_DC}.hcl"
+cat > "$VAR_FILE" <<EOF
+job_name="$JOB_NAME"
+region="$ORACLE_REGION"
+datacenters=["$NOMAD_DC"]
+image="$OPUS_SYNTHETIC_IMAGE"
+interval_seconds="$OPUS_SYNTHETIC_INTERVAL_SECONDS"
+ws_url_template="$WS_URL_TEMPLATE"
+cf_access_client_id="$CF_ACCESS_CLIENT_ID"
+cf_access_client_secret="$CF_ACCESS_CLIENT_SECRET"
+EOF
+
+RENDER_DIR="/tmp/opus-synthetic-render-$$"
+
+nomad-pack render --name "$JOB_NAME" \
+  -var "job_name=$JOB_NAME" \
+  -var-file "$VAR_FILE" \
+  --to-dir "$RENDER_DIR" \
+  --auto-approve \
+  $PACKS_DIR/jitsi_opus_synthetic
+
+if [ $? -ne 0 ]; then
+    echo "Failed to render nomad opus-synthetic job, exiting"
+    rm -f "$VAR_FILE"
+    rm -rf "$RENDER_DIR"
+    exit 5
+fi
+
+RENDERED_JOB=$(find "$RENDER_DIR" -name "*.nomad" | head -1)
+if [ -z "$RENDERED_JOB" ]; then
+    echo "No rendered job file found in $RENDER_DIR, exiting"
+    rm -f "$VAR_FILE"
+    rm -rf "$RENDER_DIR"
+    exit 5
+fi
+
+nomad job run "$RENDERED_JOB"
+RUN_RC=$?
+
+# The rendered var-file and job carry the CF Access token in cleartext; remove them.
+rm -f "$VAR_FILE"
+rm -rf "$RENDER_DIR"
+
+if [ $RUN_RC -ne 0 ]; then
+    echo "Failed to run nomad opus-synthetic job, exiting"
+    exit 5
+fi


### PR DESCRIPTION
## Summary
- [JIT-16115](https://agile.8x8.com/browse/JIT-16115)
- `otp_*` metrics from opus-transcriber-proxy (Cloudflare Containers) now reach the regional prometheus via alloy-cloudflare (JIT-16103, [infra-customizations-private #1069](https://github.com/jitsi/infra-customizations-private/pull/1069)). This adds alerting on `otp_backend_errors_total`, placed next to the existing `Opus_Transcribe_Synthetic_*` alerts in the shared alerts template.

## Rules
Both use `sum by (env, job) (increase(otp_backend_errors_total[5m])) > 0`:
- **OTP_Backend_Errors** — `for: 2m`, severity **warn**: any backend errors occurring.
- **OTP_Backend_Errors_Sustained** — `for: 15m`, severity **severe** (non-paging): errors are ongoing, not a blip. `Opus_Transcribe_Synthetic_Failed` already pages when transcription is broken end-to-end.

## Placement
Shared template rather than the infra-customizations-private `prometheus_custom_alerts` hook: the metrics land identically in stage-8x8 and prod-8x8, and the absent-metric pattern (same as the opus synthetic alerts) keeps every other environment silent instead of duplicating YAML into two sites' vars.yml.

## Caveats
- `otp_backend_errors_total` is lazily registered — the series doesn't exist until the first-ever backend error (verified absent in stage-8x8 frankfurt while 17 other `otp_*` metrics are present). Both rules are safely no-data until then.
- The first increment after series creation may be missed since `increase()` needs two samples; follow-up in the service is to pre-register the counter at 0 on startup.