### PR TITLE
fix: Raise opus-transcriber-proxy monitor connect timeout to 30s

### DIFF
--- a/nomad/opus-transcriber-proxy-monitor.hcl
+++ b/nomad/opus-transcriber-proxy-monitor.hcl
@@ -49,9 +49,9 @@ variable "sample_dump" {
 }
 
 variable "connect_timeout" {
-  description = "Seconds to wait for the websocket to connect before failing"
+  description = "Seconds to wait for the websocket to open before failing (must cover a Cloudflare Container cold start, ~30s)"
   type        = string
-  default     = "15"
+  default     = "30"
 }
 
 variable "assert_min_finals" {


### PR DESCRIPTION
The Cloudflare Container backing `/transcribe` cold-starts (~30s) and the worker only completes the WebSocket upgrade once it is up, so the monitor intermittently failed with `did not connect within 15s` on an idle (cold) cycle while real transcription worked fine.

Bumps the standalone job's `connect_timeout` default 15 → 30 to cover one cold start. Pairs with opus-transcriber-proxy #115 (same image default + sessionId reuse across the retry so the retry lands on the warmed container).