### PR TITLE
JIT-16153: point branding checkout at 8x8 org + deploy key

### DIFF
--- a/jenkins/groovy/validate-shards/Jenkinsfile
+++ b/jenkins/groovy/validate-shards/Jenkinsfile
@@ -17,10 +17,10 @@ pipeline {
           utils.SetupRepos(env.VIDEO_INFRA_BRANCH)
 
           // checkout the branding repo (source of the 8x8 meeting-settings e2e spec); latest master
-          sshagent (credentials: ['video-infra']) {
+          sshagent (credentials: ['jitsi-meet-branding-deploy']) {
             dir('jitsi-meet-branding') {
               retry(count: 3) {
-                git branch: 'master', url: env.BRANDING_REPO ?: 'git@github.com:8x8Cloud/jitsi-meet-branding.git', credentialsId: 'video-infra'
+                git branch: 'master', url: env.BRANDING_REPO ?: 'git@github.com:8x8/jitsi-meet-branding.git', credentialsId: 'jitsi-meet-branding-deploy'
               }
             }
           }

--- a/nomad/jitsi_packs/packs/jitsi_meet_backend/templates/jitsi_meet_backend.nomad.tpl
+++ b/nomad/jitsi_packs/packs/jitsi_meet_backend/templates/jitsi_meet_backend.nomad.tpl
@@ -535,7 +535,7 @@ EOF
         image        = "[[ env "CONFIG_prosody_repo" ]]:[[ env "CONFIG_prosody_tag" ]]"
         ports = ["prosody-http","prosody-client"]
         # The mod_c2s "Client XML parse error" log-level patch is now baked into
-        # the branding-built prosody image at build time (8x8Cloud/jitsi-meet-
+        # the branding-built prosody image at build time (8x8/jitsi-meet-
         # branding docker/prosody/Dockerfile) rather than patched at boot -- the
         # rootless image cannot sed /usr/lib/prosody as uid 1000.
         volumes = [


### PR DESCRIPTION
## What
Companion to [infra-customizations-private#1074](https://github.com/jitsi/infra-customizations-private/pull/1074). Points the `jitsi-meet-branding` checkout at the `8x8/` org and the dedicated read-only deploy key.

Ticket: [JIT-16153](https://agile.8x8.com/browse/JIT-16153)

## Changes
- `jenkins/groovy/validate-shards/Jenkinsfile` — `BRANDING_REPO` fallback URL org → `8x8`; `sshagent` + `git` credential → `jitsi-meet-branding-deploy`
- `nomad/.../jitsi_meet_backend.nomad.tpl` — org reference in comment (cosmetic)

## Rollout ordering
Merge **after** the GitHub repo transfer + deploy key + Jenkins credential exist. GitHub's redirect keeps the old `8x8Cloud/` URL working until then.