### PR TITLE
fix(cloudprober): vault_nodes accepts standby HA-unhealthy code 474

### DIFF
--- a/nomad/jitsi_packs/packs/jitsi_cloudprober/templates/_cloudprober_config.tpl
+++ b/nomad/jitsi_packs/packs/jitsi_cloudprober/templates/_cloudprober_config.tpl
@@ -329,9 +329,11 @@ probe {
 # bypassing the load balancer. The LB-fronted "vault" probe above only ever
 # reaches the active node, so it stays green while a standby node is sealed
 # (silent loss of HA redundancy). "vault|any" includes nodes whose consul health
-# check is critical (e.g. sealed) so they are still probed. Healthy states are
-# 200 (active), 429 (standby) and 473 (perf-standby); a sealed node returns 503
-# and fails. Cert validation is disabled since nodes present the wildcard cert
+# check is critical (e.g. sealed) so they are still probed. "Up" states are
+# 200 (active), 429 (standby), 472 (DR secondary), 473 (perf-standby) and 474
+# (standby with an unhealthy HA connection) -- all mean the node is unsealed and
+# serving. A sealed node returns 503 (and a down node fails to connect), which is
+# what we want to alert on. Cert validation is disabled since nodes present the wildcard cert
 # on their own (non-matching) address. Nodes register themselves via the
 # consul-vault ansible role, so rotation needs no cloudprober redeploy.
 probe {
@@ -359,7 +361,7 @@ probe {
   validator {
       name: "status_code_ok"
       http_validator {
-          success_status_codes: "200-299,429,473"
+          success_status_codes: "200-299,429,472,473,474"
       }
   }
   interval_msec: 30000


### PR DESCRIPTION
## Problem (found in ops-prod post-release validation)

The `vault_nodes` probe flagged a healthy **standby** node as failing. Root cause: a Vault standby whose HA connection to the active node is unhealthy returns HTTP **474** (`haunhealthycode`) on `/v1/sys/health`. The validator accepted only `200-299,429,473`, so 474 counted as a probe failure.

This was invisible on ops-dev (single-node vault → always active/200; standby path never exercised).

## Fix

Accept `200-299,429,472,473,474` — active / standby / DR secondary / perf-standby / HA-unhealthy-standby all mean the node is **unsealed and serving**. Only a sealed node (`503`) or a down node (connection failure) fails the probe, which is exactly what we want the `Vault_Node_Sealed_Or_Down` alert to catch.

## Related
- Companion infra-configuration PR #940 fixes the seal-watchdog, which had the same 474 blind spot and was crash-looping the standby.
- The alert remains a page-candidate; still validating data flow before enabling paging.
- Separate follow-up: investigate the real dead forwarding link on 10.34.136.43.