### PR TITLE
fix: require explicit image tag for opus-transcriber-proxy monitor

### DIFF
--- a/jenkins/jobs/provision-nomad-opus-transcriber-proxy-monitor.yaml
+++ b/jenkins/jobs/provision-nomad-opus-transcriber-proxy-monitor.yaml
@@ -24,7 +24,7 @@
           trim: true
       - string:
           name: OPUS_TRANSCRIBER_PROXY_MONITOR_IMAGE
-          description: "Overrides the opus-transcriber-proxy image (defaults to jitsi/opus-transcriber-proxy:latest)"
+          description: "Required: the opus-transcriber-proxy image to deploy. Must be a full image reference (repo:tag), not a bare commit hash - e.g. jitsi/opus-transcriber-proxy:1234abc using the short 7-char commit SHA tag published by the repo's dh.yml workflow. Do not use the 'latest' tag: re-running with the same image string is a no-op for Nomad (job diff sees no change and won't redeploy), so pin an explicit SHA tag every time."
           trim: true
       - string:
           name: OPUS_TRANSCRIBER_PROXY_MONITOR_INTERVAL_SECONDS

--- a/jenkins/jobs/release-nomad-opus-transcriber-proxy-monitor.yaml
+++ b/jenkins/jobs/release-nomad-opus-transcriber-proxy-monitor.yaml
@@ -25,7 +25,7 @@
           trim: true
       - string:
           name: OPUS_TRANSCRIBER_PROXY_MONITOR_IMAGE
-          description: "Overrides the opus-transcriber-proxy image (defaults to jitsi/opus-transcriber-proxy:latest)"
+          description: "Required: the opus-transcriber-proxy image to release. Must be a full image reference (repo:tag), not a bare commit hash - e.g. jitsi/opus-transcriber-proxy:1234abc using the short 7-char commit SHA tag published by the repo's dh.yml workflow. Do not use the 'latest' tag: re-running with the same image string is a no-op for Nomad (job diff sees no change and won't redeploy), so pin an explicit SHA tag every time."
           trim: true
       - string:
           name: OPUS_TRANSCRIBER_PROXY_MONITOR_INTERVAL_SECONDS

--- a/nomad/opus-transcriber-proxy-monitor.hcl
+++ b/nomad/opus-transcriber-proxy-monitor.hcl
@@ -8,9 +8,8 @@ variable "environment" {
 }
 
 variable "image" {
-  description = "The opus-transcriber-proxy docker image (run in monitor mode via a command override)"
+  description = "The opus-transcriber-proxy docker image (run in monitor mode via a command override). Required - no default, and must not be a \"latest\" tag: re-running with the same image string is a no-op for Nomad (job diff sees no change and won't redeploy)."
   type        = string
-  default     = "jitsi/opus-transcriber-proxy:latest"
 }
 
 variable "pool_type" {

--- a/scripts/deploy-nomad-opus-transcriber-proxy-monitor.sh
+++ b/scripts/deploy-nomad-opus-transcriber-proxy-monitor.sh
@@ -62,8 +62,17 @@ if [ -z "$OPUS_TRANSCRIBER_PROXY_MONITOR_INTERVAL_SECONDS" ]; then
 fi
 [ -z "$OPUS_TRANSCRIBER_PROXY_MONITOR_INTERVAL_SECONDS" ] && OPUS_TRANSCRIBER_PROXY_MONITOR_INTERVAL_SECONDS="300"
 
-# --- Image: the opus-transcriber-proxy image built by the repo's Docker Hub pipeline. ---
-[ -z "$OPUS_TRANSCRIBER_PROXY_MONITOR_IMAGE" ] && OPUS_TRANSCRIBER_PROXY_MONITOR_IMAGE="jitsi/opus-transcriber-proxy:latest"
+# --- Image: the opus-transcriber-proxy image built by the repo's Docker Hub pipeline. Required:
+#     no "latest" fallback, since re-running with the same image string is a no-op for Nomad (job
+#     diff sees no change and won't redeploy, regardless of docker pull policy). ---
+if [ -z "$OPUS_TRANSCRIBER_PROXY_MONITOR_IMAGE" ]; then
+    echo "No OPUS_TRANSCRIBER_PROXY_MONITOR_IMAGE set, exiting"
+    exit 2
+fi
+if [ "$OPUS_TRANSCRIBER_PROXY_MONITOR_IMAGE" == "jitsi/opus-transcriber-proxy:latest" ]; then
+    echo "OPUS_TRANSCRIBER_PROXY_MONITOR_IMAGE must not be 'latest' (re-running the same tag is a no-op for Nomad), exiting"
+    exit 2
+fi
 
 # The job's Nomad region is left at the default "global"; the OCI region is targeted via the
 # datacenter ($NOMAD_DC) and the region-specific NOMAD_ADDR (matches jitsi-test-lab/cloudprober).


### PR DESCRIPTION
## Summary
- OPUS_TRANSCRIBER_PROXY_MONITOR_IMAGE is now required, with no "latest" fallback/default, in both the deploy script and the Nomad job's HCL variable
- The deploy script rejects the literal `jitsi/opus-transcriber-proxy:latest` tag explicitly
- Updated the Jenkins job param docs (provision + release) with an example pinned SHA tag

## Why
Re-running the job with the var blank (defaulting to `latest`) is a no-op: Nomad diffs the submitted job spec against the running one, and an unchanged image string means no new allocation is created, so the monitor never actually redeploys, regardless of docker pull policy.
