### PR TITLE
Wire enableIceRestart/enableIceRestartOnNetworkChange into jitsi_meet_web nomad job

### DIFF
--- a/nomad/jitsi_packs/packs/jitsi_meet_web/templates/jitsi_meet_web.nomad.tpl
+++ b/nomad/jitsi_packs/packs/jitsi_meet_web/templates/jitsi_meet_web.nomad.tpl
@@ -164,6 +164,8 @@ job [[ template "job_name" . ]] {
         ENABLE_AUTH_DOMAIN = "false"
         ENABLE_IPV6 = "false"
         ENABLE_TRANSCRIPTIONS = "[[ or (env "CONFIG_jitsi_meet_enable_transcription") "false" ]]"
+        ENABLE_ICE_RESTART = "[[ or (env "CONFIG_jitsi_meet_enable_ice_restart") "false" ]]"
+        ENABLE_ICE_RESTART_ON_NETWORK_CHANGE = "[[ or (env "CONFIG_jitsi_meet_enable_ice_restart_on_network_change") "false" ]]"
         ENABLE_LOCAL_RECORDING_NOTIFY_ALL_PARTICIPANT = "true"
         ENABLE_PREJOIN_PAGE = "[[ if eq (env "CONFIG_jitsi_meet_enable_prejoin_page") "true" ]]true[[ else ]]false[[ end ]]"
         ENABLE_REQUIRE_DISPLAY_NAME = "[[ or (env "CONFIG_jitsi_meet_require_displayname") "false" ]]"


### PR DESCRIPTION
Passes jitsi_meet_enable_ice_restart and jitsi_meet_enable_ice_restart_on_network_change ansible vars through to the docker-jitsi-meet web container's ENABLE_ICE_RESTART / ENABLE_ICE_RESTART_ON_NETWORK_CHANGE env vars in the jitsi_meet_web nomad job template. Depends on jitsi/docker-jitsi-meet#2307 and jitsi/infra-configuration#943.