### PR TITLE
fix: don't fail oracle jibri/jigasi rotation on already-deleted old instance config

### DIFF
--- a/scripts/create-or-rotate-custom-jigasi-oracle.sh
+++ b/scripts/create-or-rotate-custom-jigasi-oracle.sh
@@ -363,9 +363,21 @@ elif [ "$getGroupHttpCode" == 200 ]; then
     echo "Successfully scaled down to $PROTECTED_INSTANCES_COUNT instances in group $GROUP_NAME"
 
     # only delete the old instance configuration once the rotation has
-    # completed successfully, so a failed rotation can still roll back to it
+    # completed successfully, so a failed rotation can still roll back to it.
+    # Terraform's own replace-and-destroy already deletes this same instance
+    # configuration whenever the new one forces a replacement (which happens on
+    # every version bump, since OCI instance configurations are immutable), so
+    # it is normal for this to already be gone.
     echo "Will delete the old Instance Configuration for group $GROUP_NAME"
-    oci compute-management instance-configuration delete --instance-configuration-id "$EXISTING_INSTANCE_CONFIGURATION_ID" --region "$ORACLE_REGION" --force
+    deleteConfigOutput=$(oci compute-management instance-configuration delete --instance-configuration-id "$EXISTING_INSTANCE_CONFIGURATION_ID" --region "$ORACLE_REGION" --force 2>&1)
+    deleteConfigExitCode=$?
+    if [ $deleteConfigExitCode -eq 0 ]; then
+      echo "Successfully deleted old Instance Configuration $EXISTING_INSTANCE_CONFIGURATION_ID"
+    elif echo "$deleteConfigOutput" | grep -q "NotAuthorizedOrNotFound"; then
+      echo "Old Instance Configuration $EXISTING_INSTANCE_CONFIGURATION_ID was already removed (likely by terraform's replace), continuing"
+    else
+      echo "Warning: failed to delete old Instance Configuration $EXISTING_INSTANCE_CONFIGURATION_ID: $deleteConfigOutput"
+    fi
   else
     echo "Error scaling down to $PROTECTED_INSTANCES_COUNT instances in group $GROUP_NAME. AutoScaler response status code is $scaleDownGroupHttpCode"
     exit 209

--- a/scripts/create-or-rotate-jibri-oracle.sh
+++ b/scripts/create-or-rotate-jibri-oracle.sh
@@ -476,9 +476,21 @@ elif [ "$getGroupHttpCode" == 200 ]; then
     echo "Successfully scaled down to $PROTECTED_INSTANCES_COUNT instances in group $GROUP_NAME"
 
     # only delete the old instance configuration once the rotation has
-    # completed successfully, so a failed rotation can still roll back to it
+    # completed successfully, so a failed rotation can still roll back to it.
+    # Terraform's own replace-and-destroy in create-jibri-instance-configuration.sh
+    # already deletes this same instance configuration whenever the new one forces
+    # a replacement (which happens on every jibri version bump, since OCI instance
+    # configurations are immutable), so it is normal for this to already be gone.
     echo "Will delete the old Instance Configuration for group $GROUP_NAME"
-    oci compute-management instance-configuration delete --instance-configuration-id "$EXISTING_INSTANCE_CONFIGURATION_ID" --region "$ORACLE_REGION" --force
+    deleteConfigOutput=$(oci compute-management instance-configuration delete --instance-configuration-id "$EXISTING_INSTANCE_CONFIGURATION_ID" --region "$ORACLE_REGION" --force 2>&1)
+    deleteConfigExitCode=$?
+    if [ $deleteConfigExitCode -eq 0 ]; then
+      echo "Successfully deleted old Instance Configuration $EXISTING_INSTANCE_CONFIGURATION_ID"
+    elif echo "$deleteConfigOutput" | grep -q "NotAuthorizedOrNotFound"; then
+      echo "Old Instance Configuration $EXISTING_INSTANCE_CONFIGURATION_ID was already removed (likely by terraform's replace), continuing"
+    else
+      echo "Warning: failed to delete old Instance Configuration $EXISTING_INSTANCE_CONFIGURATION_ID: $deleteConfigOutput"
+    fi
   else
     echo "Error scaling down to $PROTECTED_INSTANCES_COUNT instances in group $GROUP_NAME. AutoScaler response status code is $scaleDownGroupHttpCode"
     exit 209


### PR DESCRIPTION
## Summary
- Every Oracle jibri (and jigasi) rotation has been failing at the last step since #1117. Terraform already destroys the old `oci_core_instance_configuration` as part of its forced replacement (image OCID/metadata changes are ForceNew on this resource, and the image OCID changes on every release), so by the time the script tries to manually delete that same OCID as its final step, it 404s. Since #1117 moved this delete to be the last statement in the script with nothing after it, that 404 became the script's own exit code and failed otherwise-successful rotations.
- Made the cleanup delete idempotent in both `create-or-rotate-jibri-oracle.sh` and `create-or-rotate-custom-jigasi-oracle.sh` (same pattern in both): success logs and continues, a 404 (already removed by terraform) logs and continues, any other error just warns — none of these paths can fail the overall script anymore.

## Test plan
- [ ] `bash -n` syntax-checked both scripts
- [ ] Run a jibri release job against a stage environment and confirm the job now reports success after a normal rotation
- [ ] Run a jigasi rotation job against a stage environment and confirm the same