### PR TITLE
fix: set the prosody rate limit session rate for visitor nodes

### DIFF
--- a/nomad/jitsi_packs/packs/jitsi_meet_backend/templates/jitsi_meet_backend.nomad.tpl
+++ b/nomad/jitsi_packs/packs/jitsi_meet_backend/templates/jitsi_meet_backend.nomad.tpl
@@ -375,6 +375,7 @@ job [[ template "job_name" . ]] {
         PROSODY_S2S_LIMIT="512kb/s"
         PROSODY_ENABLE_RATE_LIMITS="1"
         PROSODY_RATE_LIMIT_ALLOW_RANGES="[[ env "CONFIG_prosody_rate_limit_allow_ranges" ]]"
+        PROSODY_RATE_LIMIT_SESSION_RATE="2000"
         PROSODY_REGION_NAME="[[ env "CONFIG_octo_region" ]]"
         VISITORS_MAX_VISITORS_PER_NODE=
           [[- if and (env "CONFIG_prosody_visitors_muc_max_occupants") (ne (env "CONFIG_prosody_visitors_muc_max_occupants") "false") -]]


### PR DESCRIPTION
The main prosody task sets `PROSODY_RATE_LIMIT_SESSION_RATE` to 2000. The visitor node task did not set it, so it used the default of 200 bytes/s from the image. A throttled session on a visitor node was ten times slower than the same session on the main prosody.

Set the same value on both tasks.

### Related

Parts of the same fix:

- jitsi/jitsi-meet#17739 - do not rate limit s2s sessions
- jitsi/docker-jitsi-meet#2309 - add `::1` to the whitelist in the prosody templates
- jitsi/infra-configuration#944 - add `::1` to the ansible default whitelist
- jitsi/infra-provisioning#1139 - set the session rate on the visitor node task
