### PR TITLE
fix: self-heal OCI connectivity in postinstall and terminate without recursion

### DIFF
--- a/terraform/lib/postinstall-eip-lib.sh
+++ b/terraform/lib/postinstall-eip-lib.sh
@@ -26,15 +26,26 @@ function switch_to_secondary_vnic() {
   SECONDARY_VNIC_DEVICE="${SECONDARY_VNIC_DEVICE::-1}"
   SECONDARY_VNIC_DEVICE="$(echo $SECONDARY_VNIC_DEVICE | cut -d'@' -f1)"
 
+  # compute and validate the new default route BEFORE deleting the existing
+  # ones, so a failure here cannot leave the host with no default route
+  export NIC2_ROUTE="default via "$(ip route show | grep "dev $SECONDARY_VNIC_DEVICE" | grep -v default | head -1 | awk '{ print substr($1,1,index($1,"/")-2)1 " " $2 " " $3}')
+  if [ "$NIC2_ROUTE" == "default via " ]; then
+    echo "Unable to determine route via secondary NIC $SECONDARY_VNIC_DEVICE, leaving routes untouched"
+    return 1
+  fi
+
   echo "Switch default routes to NIC2"
+  # NIC1_ROUTE_1 can be empty when a previous partial switch already removed
+  # the default routes; skip the delete so the switch can still complete
   export NIC1_ROUTE_1=$(ip route show | grep default -m 1)
-  sudo ip route delete $NIC1_ROUTE_1 || status_code=1
+  if [ ! -z "$NIC1_ROUTE_1" ]; then
+    sudo ip route delete $NIC1_ROUTE_1 || status_code=1
+  fi
 
   if [ $status_code -gt 0 ]; then
     return $status_code
   fi
 
-  # 
   export NIC1_ROUTE_2=$(ip route show | grep default -m 1)
   if [ ! -z "$NIC1_ROUTE_2" ]; then
     sudo ip route delete $NIC1_ROUTE_2 || status_code=1
@@ -44,7 +55,6 @@ function switch_to_secondary_vnic() {
     return $status_code
   fi
 
-  export NIC2_ROUTE="default via "$(ip route show | grep $SECONDARY_VNIC_DEVICE | awk '{ print substr($1,1,index($1,"/")-2)1 " " $2 " " $3}')
   sudo ip route add $NIC2_ROUTE || status_code=1
   return $status_code
 }

--- a/terraform/lib/postinstall-eip-lib.sh
+++ b/terraform/lib/postinstall-eip-lib.sh
@@ -53,25 +53,20 @@ function switch_to_primary_vnic() {
   status_code=0
   echo "Switch default route back to NIC1"
 
-  sudo ip route delete $NIC2_ROUTE || status_code=1
-
-  if [ $status_code -gt 0 ]; then
-    return $status_code
+  # restore as much routing as possible even if individual steps fail, so a
+  # partial switch to the secondary VNIC does not leave the routing table empty
+  if [ ! -z "$NIC2_ROUTE" ]; then
+    sudo ip route delete $NIC2_ROUTE || status_code=1
   fi
 
-  sudo ip route add $NIC1_ROUTE_1 || status_code=1
-
-  if [ $status_code -gt 0 ]; then
-    return $status_code
+  if [ ! -z "$NIC1_ROUTE_1" ]; then
+    sudo ip route add $NIC1_ROUTE_1 || status_code=1
   fi
 
   if [ ! -z "$NIC1_ROUTE_2" ]; then
     sudo ip route add $NIC1_ROUTE_2 || status_code=1
-
-    if [ $status_code -gt 0 ]; then
-      return $status_code
-    fi
   fi
+
   echo "Delete secondary NIC routing to avoid routing issues in the future"
   sudo /usr/local/bin/secondary_vnic_all_configure_oracle.sh -d || status_code=1
   return $status_code
@@ -193,18 +188,23 @@ function check_secondary_ip() {
 
 eip_assign() {
   [ -z "$PROVISION_COMMAND" ] && PROVISION_COMMAND="default_provision"
+  # the secondary VNIC can take a long time to appear in instance metadata
+  # (control-plane lag); the instance is useless without a public IP anyway,
+  # so wait up to ~35 minutes for it before giving up
+  [ -z "$EIP_SECONDARY_IP_RETRIES" ] && EIP_SECONDARY_IP_RETRIES=30
 
   EIP_EXIT_CODE=0
-  (retry check_secondary_ip) || EIP_EXIT_CODE=1
+  (retry check_secondary_ip $EIP_SECONDARY_IP_RETRIES) || EIP_EXIT_CODE=1
 
   if [ $EIP_EXIT_CODE -eq 0 ]; then
       switch_to_secondary_vnic || EIP_EXIT_CODE=1
-  fi
 
-  if [ $EIP_EXIT_CODE -eq 0 ]; then
-      (retry assign_reserved_public_ip 15 || retry assign_ephemeral_public_ip) || EIP_EXIT_CODE=1
-      switch_to_primary_vnic || EIP_EXIT_CODE=1
-  else
+      if [ $EIP_EXIT_CODE -eq 0 ]; then
+          (retry assign_reserved_public_ip 15 || retry assign_ephemeral_public_ip) || EIP_EXIT_CODE=1
+      fi
+
+      # only switch back if a switch was attempted; with no secondary VNIC
+      # there are no routes to restore and the route deletes would fail
       switch_to_primary_vnic || EIP_EXIT_CODE=1
   fi
 

--- a/terraform/lib/postinstall-eip-lib.sh
+++ b/terraform/lib/postinstall-eip-lib.sh
@@ -177,9 +177,14 @@ function check_secondary_ip() {
   local ip_status=1
 
   while [ $counter -le 2 ]; do
-    local my_private_ip=$(curl -s curl http://169.254.169.254/opc/v1/vnics/ | jq .[1].privateIp -r)
+    # fetch_vnics_metadata logs the full exchange with headers (X-Request-Id)
+    # so a missing secondary VNIC can be correlated with OCI support
+    local my_private_ip=$(fetch_vnics_metadata | jq .[1].privateIp -r)
 
     if [ -z "$my_private_ip" ] || [ "$my_private_ip" == "null" ]; then
+      # record what the OS sees while the metadata is missing the secondary
+      # VNIC; in past incidents the device existed here the whole time
+      ip -o link >&2
       sleep 30
       ((counter++))
     else

--- a/terraform/lib/postinstall-footer.sh
+++ b/terraform/lib/postinstall-footer.sh
@@ -20,7 +20,20 @@ if [ ! $EXIT_CODE -eq 0 ]; then
 
     echo "Terminating is enabled, so running terminate command $TERMINATE_INSTANCE_COMMAND"
 
-    $TERMINATE_INSTANCE_COMMAND
+    # retry in a loop rather than recursing: recursion eventually overflows the
+    # stack and segfaults, silently ending the retries. If the OCI API is
+    # unreachable (e.g. no public IP was ever attached), try to restore
+    # connectivity via a late-appearing secondary VNIC before each attempt.
+    # The instance is deliberately left RUNNING while retries continue so the
+    # autoscaler counts it as untracked and an operator can intervene.
+    while true; do
+      if ! oci_api_reachable; then
+        restore_oci_connectivity
+      fi
+      $TERMINATE_INSTANCE_COMMAND && break
+      echo "Terminate command $TERMINATE_INSTANCE_COMMAND failed, sleeping 60 then retrying"
+      sleep 60
+    done
 
   else
     echo "Skipping termination of instance"

--- a/terraform/lib/postinstall-lib.sh
+++ b/terraform/lib/postinstall-lib.sh
@@ -294,16 +294,37 @@ function default_provision() {
   run_ansible_playbook "$ANSIBLE_PLAYBOOK"  "$ANSIBLE_VARS" || status_code=1
   return $status_code;
 }
-function default_terminate() {
-  echo "Terminating the instance; we enable debug to have more details in case of oci cli failures"
-  INSTANCE_ID=`curl --connect-timeout 10 -s curl http://169.254.169.254/opc/v1/instance/ | jq -r .id`
-  sudo /usr/local/bin/oci compute instance terminate --debug --instance-id "$INSTANCE_ID" --preserve-boot-volume false --auth instance_principal --force
-  RET=$?
-  # infinite loop on failure
-  if [ $RET -gt 0 ]; then
-    echo "Failed to terminate instance, exit code: $RET, sleeping 10 then retrying"
-    sleep 10
-    default_terminate
+function oci_api_reachable() {
+  local region=$(curl --connect-timeout 10 -s http://169.254.169.254/opc/v1/instance/ | jq -r .canonicalRegionName)
+  local http_code=$(curl -s -m 10 -o /dev/null -w '%{http_code}' "https://auth.${region}.oraclecloud.com/v1/x509")
+  if [ "$http_code" == "000" ]; then
+    echo "OCI API auth endpoint for region $region is not reachable"
+    return 1
   fi
+  return 0
+}
+
+function restore_oci_connectivity() {
+  # the OCI API is unreachable when the primary VNIC never received a public
+  # IP; a secondary VNIC can appear in instance metadata minutes late, so
+  # re-check for one and route through it if found
+  local secondary_ip=$(curl --connect-timeout 10 -s http://169.254.169.254/opc/v1/vnics/ | jq -r '.[1].privateIp')
+  if [ -z "$secondary_ip" ] || [ "$secondary_ip" == "null" ]; then
+    echo "No secondary VNIC in metadata, unable to restore OCI API connectivity"
+    return 1
+  fi
+  if ! type switch_to_secondary_vnic > /dev/null 2>&1; then
+    echo "No switch_to_secondary_vnic function available, unable to restore OCI API connectivity"
+    return 1
+  fi
+  echo "Secondary VNIC with IP $secondary_ip found, switching default route to it to reach the OCI API"
+  switch_to_secondary_vnic
+}
+
+function default_terminate() {
+  # single attempt; the footer retries in a loop with connectivity self-healing
+  echo "Terminating the instance; we enable debug to have more details in case of oci cli failures"
+  INSTANCE_ID=`curl --connect-timeout 10 -s http://169.254.169.254/opc/v1/instance/ | jq -r .id`
+  sudo /usr/local/bin/oci compute instance terminate --debug --instance-id "$INSTANCE_ID" --preserve-boot-volume false --auth instance_principal --force
 }
 # end of postinstall-lib, this space intentionally left blank

--- a/terraform/lib/postinstall-lib.sh
+++ b/terraform/lib/postinstall-lib.sh
@@ -294,6 +294,24 @@ function default_provision() {
   run_ansible_playbook "$ANSIBLE_PLAYBOOK"  "$ANSIBLE_VARS" || status_code=1
   return $status_code;
 }
+VNIC_METADATA_LOG="/var/log/vnic-metadata-debug.log"
+function fetch_vnics_metadata() {
+  # fetch VNIC metadata, capturing the verbose exchange (request/response
+  # headers incl. X-Request-Id) to $VNIC_METADATA_LOG and stderr so it lands
+  # in cloud-init-output.log for correlation with OCI support; only the body
+  # goes to stdout for callers to parse
+  local verbose_log=$(mktemp) body=$(mktemp)
+  curl -sv --connect-timeout 10 http://169.254.169.254/opc/v1/vnics/ -o "$body" 2> "$verbose_log"
+  {
+    echo "=== $(date -u +%Y-%m-%dT%H:%M:%SZ) GET http://169.254.169.254/opc/v1/vnics/ ==="
+    cat "$verbose_log"
+    cat "$body"
+    echo ""
+  } | tee -a "$VNIC_METADATA_LOG" >&2
+  cat "$body"
+  rm -f "$verbose_log" "$body"
+}
+
 function oci_api_reachable() {
   local region=$(curl --connect-timeout 10 -s http://169.254.169.254/opc/v1/instance/ | jq -r .canonicalRegionName)
   local http_code=$(curl -s -m 10 -o /dev/null -w '%{http_code}' "https://auth.${region}.oraclecloud.com/v1/x509")
@@ -308,7 +326,7 @@ function restore_oci_connectivity() {
   # the OCI API is unreachable when the primary VNIC never received a public
   # IP; a secondary VNIC can appear in instance metadata minutes late, so
   # re-check for one and route through it if found
-  local secondary_ip=$(curl --connect-timeout 10 -s http://169.254.169.254/opc/v1/vnics/ | jq -r '.[1].privateIp')
+  local secondary_ip=$(fetch_vnics_metadata | jq -r '.[1].privateIp')
   if [ -z "$secondary_ip" ] || [ "$secondary_ip" == "null" ]; then
     echo "No secondary VNIC in metadata, unable to restore OCI API connectivity"
     return 1


### PR DESCRIPTION
## Problem

A JVB in ap-mumbai-1 (`10.62.122.163`, 6869 custom group) failed to boot on 2026-08-20 and was still RUNNING as a zombie 3+ days later. Root cause was OCI metadata-service lag: the secondary VNIC attachment existed before the OS booted (kernel saw the virtio device at first boot), but `/opc/v1/vnics/` reported only the primary VNIC for over 12 minutes. That cascaded:

1. `check_secondary_ip` gave up after ~12 minutes — just short of the metadata catching up (it does eventually; the same endpoint returns both VNICs today)
2. with no public IP ever attached and the secondary VNIC unconfigured, the instance had no route to the OCI API, so the terminate path could never succeed (chicken-and-egg)
3. `default_terminate` retried via **infinite recursion**; after ~72 hours (~3,400 stack frames) bash segfaulted (`part-001: Segmentation fault (core dumped)`), silently ending all retries and leaving the instance RUNNING
4. bonus latent bug: on the failure path `switch_to_primary_vnic` ran with unset route vars, executing a bare `ip route delete`

A healthy sibling (`10.62.84.65`) ran the identical script; the only difference was that metadata returned the secondary VNIC on the first poll.

## Changes

**Self-heal at boot** (`postinstall-eip-lib.sh`)
- wait up to ~35 min for the secondary VNIC to appear in metadata (configurable via `EIP_SECONDARY_IP_RETRIES`, default 30 retries); the instance is useless without a public IP anyway, so patience is free
- only call `switch_to_primary_vnic` when a switch to the secondary was actually attempted
- `switch_to_primary_vnic` now restores as much routing as it can instead of returning at the first error, so a partial switch can't strand the routing table

**Self-heal at terminate** (`postinstall-lib.sh`, `postinstall-footer.sh`)
- terminate retries moved into a `while` loop in the footer — no recursion, no stack overflow, no segfault
- before each attempt, probe the regional OCI auth endpoint; if unreachable, re-check metadata for a late-appearing secondary VNIC and route through it (`restore_oci_connectivity`), which would have terminated this instance within minutes of the metadata catching up
- the footer loop wraps `$TERMINATE_INSTANCE_COMMAND`, so role-specific terminate scripts (e.g. the JVB image's `/usr/local/bin/terminate_instance.sh`) also benefit from the connectivity restore
- the instance is deliberately left RUNNING while retries continue (no `shutdown`), so the autoscaler counts it as untracked and an operator can intervene

Assembled user-data (header + lib + eip-lib + JVB runner + footer) passes `bash -n`.

## Follow-ups (not in this PR)
- the same recursion bug exists in 5 terminate scripts in infra-configuration (jvb/jibri/jigasi/nomad-jitsi templates + autoscaler-sidecar) baked into images — needs a companion PR
- consider adding a service gateway route to JVB subnets so instance-principal calls work with no public IP at all
- the zombie instance in ap-mumbai-1 still needs a manual terminate