### PR TITLE
JIT-16092: per-region Gitea mirror (Nomad job + deploy script)

### DIFF
--- a/doc/git-mirror-bootstrap-plan.md
+++ b/doc/git-mirror-bootstrap-plan.md
@@ -274,9 +274,26 @@ today.
 
 - Which compartment OCID / dynamic group should the `vm-bootstrap` role bind to
   per environment?
-- Mirror `jitsi-meet` in all regions, or only where boots need it?
+- ~~Mirror `jitsi-meet` in all regions, or only where boots need it?~~
+  **Resolved (2026-07-28):** mirror `jitsi-meet` only in `us-phoenix-1` (where
+  the Jenkins/build host lives); everywhere else mirror just the three infra
+  repos. Implemented in `scripts/deploy-nomad-gitea-mirror.sh`.
 - Confirm the per-env `VAULT_ENVIRONMENT` / `DNS_ZONE` values used to construct
   `VAULT_ADDR` at boot for each environment.
+
+## Implementation status (2026-07-28)
+
+- **Stage 1 (this repo, branch `JIT-16092-gitea-mirror-bootstrap`): DONE.**
+  `nomad/gitea-mirror.hcl` + `scripts/deploy-nomad-gitea-mirror.sh`. Prereqs
+  before deploy: seed Vault `secret/default/gitea/admin` (username/password/email)
+  and `secret/default/gitea/github` (a GitHub PAT with read access to
+  `infra-customizations-private`).
+- **Stages 2-3 (infra-configuration): ON HOLD** until the mirror is deployed and
+  the first-sync health gate is verified per region (per the rollout order).
+  Blocked on the two remaining open questions above (compartment OCID / dynamic
+  group; per-env `VAULT_ADDR` values). Note: Vault auth methods/policies are not
+  currently codified in infra-configuration's `vault` role, so `vm-bootstrap` /
+  `bootstrap-read` will need a `vault` CLI script or a new role convention.
 
 ## References
 

--- a/doc/git-mirror-bootstrap-plan.md
+++ b/doc/git-mirror-bootstrap-plan.md
@@ -272,14 +272,22 @@ today.
 
 ## Open questions
 
-- Which compartment OCID / dynamic group should the `vm-bootstrap` role bind to
-  per environment?
+- ~~Which compartment OCID / dynamic group should the `vm-bootstrap` role bind
+  to per environment?~~ **Resolved (2026-07-28):** bind it to the same
+  `$ENVIRONMENT-dynamic-group` OCID the existing `$ENVIRONMENT-instance-role`
+  uses (looked up via `oci iam dynamic-group list` in
+  `terraform/vault-oci-instance-auth-config/vault-oci-instance-auth-config.sh`).
+  No new OCID to source.
 - ~~Mirror `jitsi-meet` in all regions, or only where boots need it?~~
   **Resolved (2026-07-28):** mirror `jitsi-meet` only in `us-phoenix-1` (where
   the Jenkins/build host lives); everywhere else mirror just the three infra
   repos. Implemented in `scripts/deploy-nomad-gitea-mirror.sh`.
-- Confirm the per-env `VAULT_ENVIRONMENT` / `DNS_ZONE` values used to construct
-  `VAULT_ADDR` at boot for each environment.
+- ~~Confirm the per-env `VAULT_ENVIRONMENT` / `DNS_ZONE` values used to construct
+  `VAULT_ADDR` at boot for each environment.~~ **Resolved (2026-07-28):** the
+  established form is `https://${VAULT_ENVIRONMENT}-${VAULT_REGION}-vault.jitsi.net`
+  (`VAULT_REGION` default `us-phoenix-1`, `VAULT_ENVIRONMENT` default `ops-prod`),
+  per the same `.sh` wrapper. The boot path should construct `VAULT_ADDR` the
+  same way rather than from `DNS_ZONE`.
 
 ## Implementation status (2026-07-28)
 
@@ -288,12 +296,24 @@ today.
   before deploy: seed Vault `secret/default/gitea/admin` (username/password/email)
   and `secret/default/gitea/github` (a GitHub PAT with read access to
   `infra-customizations-private`).
-- **Stages 2-3 (infra-configuration): ON HOLD** until the mirror is deployed and
-  the first-sync health gate is verified per region (per the rollout order).
-  Blocked on the two remaining open questions above (compartment OCID / dynamic
-  group; per-env `VAULT_ADDR` values). Note: Vault auth methods/policies are not
-  currently codified in infra-configuration's `vault` role, so `vm-bootstrap` /
-  `bootstrap-read` will need a `vault` CLI script or a new role convention.
+- **Stage 2 (Vault, infra-customizations-private terraform):** the OCI auth
+  method is **already enabled** (`terraform/vault-oci-auth-config` →
+  `vault_auth_backend.oci`), and `terraform/vault-oci-instance-auth-config`
+  already defines a per-env `$ENVIRONMENT-instance-policy` + an
+  `auth/oci/role/$ENVIRONMENT-instance-role` bound to the env dynamic group.
+  That existing instance policy **already grants instance principals read on
+  `secret/data/$ENVIRONMENT/*`**, so the ansible-vault password can move to
+  `secret/data/$ENVIRONMENT/ansible-vault-password` and be read at boot with the
+  *existing* role — no new role required for it. The only gap is the Gitea
+  read-token at `secret/data/default/gitea/read-token`, which is outside
+  `secret/data/$ENVIRONMENT/*`; add a read grant for that path (either extend the
+  instance policy, or add the dedicated least-privilege `bootstrap-read` policy +
+  `vm-bootstrap` role per decision 6). This slots into the existing terraform
+  module + its `.sh` `vault write auth/oci/role/...` step.
+- **Stage 3 (boot path, infra-configuration `postinstall-lib.sh`):** unchanged
+  from the plan. Construct `VAULT_ADDR` as above.
+- **Stages 2-3 held** until the mirror is deployed and the first-sync health gate
+  is verified per region (per the rollout order).
 
 ## References
 

--- a/jenkins/jobs/provision-nomad-gitea-mirror.yaml
+++ b/jenkins/jobs/provision-nomad-gitea-mirror.yaml
@@ -1,0 +1,66 @@
+- job:
+    name: provision-nomad-gitea-mirror
+    display-name: provision nomad gitea-mirror
+    description: "registers the regional Gitea pull-mirror of the infra repos in nomad in an oracle region in an environment, and creates its CNAME"
+    concurrent: true
+    parameters:
+      - string:
+          name: VIDEO_INFRA_BRANCH
+          default: main
+          description: "Controls checkout branch for infra repos, defaults to 'main'."
+          trim: true
+      - string:
+          name: ENVIRONMENT
+          description: "Environment to provision in"
+          trim: true
+      - string:
+          name: ORACLE_REGION
+          description: "Region to provision in"
+          trim: true
+      - string:
+          name: JOB_TYPE
+          default: gitea-mirror
+          description: "Nomad job type to provision, defaults to 'gitea-mirror' do not change"
+          trim: true
+      - string:
+          name: GITEA_HOSTNAME
+          description: "Overrides the internal hostname the mirror is served on (defaults to <environment>-<region>-git.jitsi.net). Set this for a test instance so it does not take over the real route."
+          trim: true
+      - string:
+          name: GITEA_REQUIRED_REPOS
+          description: "Overrides which repos are mirrored, as an HCL list, e.g. '[\"infra-configuration\",\"infra-provisioning\"]'. Leave blank for the default: the three infra repos everywhere, plus jitsi-meet in us-phoenix-1. Every repo listed must finish its first sync before the replica is considered healthy."
+          trim: true
+      - string:
+          name: GITEA_IMAGE_VERSION
+          description: "Overrides the Gitea image (defaults to gitea/gitea:1.22)"
+          trim: true
+      - string:
+          name: GITEA_MIRROR_INTERVAL
+          description: "Overrides how often Gitea re-pulls each mirror from GitHub (defaults to 10m)"
+          trim: true
+      - string:
+          name: INFRA_CONFIGURATION_REPO
+          default: git@github.com:jitsi/infra-configuration.git
+          description: "Repo for configuration code (ansible etc), defaults to 'git@github.com:jitsi/infra-configuration.git'."
+          trim: true
+      - string:
+          name: INFRA_CUSTOMIZATIONS_REPO
+          default: git@github.com:jitsi/infra-customizations-private.git
+          description: "Repo with customized configurations, defaults to 'git@github.com:jitsi/infra-customizations-private.git'."
+          trim: true
+
+    project-type: pipeline
+    sandbox: true
+    pipeline-scm:
+      scm:
+        - git:
+            url: git@github.com:jitsi/infra-provisioning.git
+            credentials-id: "video-infra"
+            branches:
+              - "origin/${{VIDEO_INFRA_BRANCH}}"
+            browser: githubweb
+            browser-url: https://github.com/jitsi/infra-provisioning
+            submodule:
+              recursive: true
+      script-path: jenkins/groovy/provision-nomad-job/Jenkinsfile
+      lightweight-checkout: true

--- a/jenkins/jobs/release-nomad-gitea-mirror.yaml
+++ b/jenkins/jobs/release-nomad-gitea-mirror.yaml
@@ -1,0 +1,107 @@
+- job:
+    name: release-nomad-gitea-mirror
+    display-name: release nomad gitea-mirror
+    description: "release the regional Gitea pull-mirror of the infra repos to nomad in one or more regions in an environment."
+    concurrent: true
+    parameters:
+      - string:
+          name: VIDEO_INFRA_BRANCH
+          default: main
+          description: "Controls checkout branch for infra repos, defaults to 'main'."
+          trim: true
+      - string:
+          name: ENVIRONMENT
+          description: "Environment to release in"
+          trim: true
+      - string:
+          name: REGIONS
+          description: "REGIONS to release in, defaults to NOMAD_REGIONS for the environment."
+          trim: true
+      - string:
+          name: JOB_TYPE
+          default: gitea-mirror
+          description: "Nomad job type to release, defaults to 'gitea-mirror' do not change"
+          trim: true
+      - string:
+          name: GITEA_HOSTNAME
+          description: "Overrides the internal hostname the mirror is served on (defaults to <environment>-<region>-git.jitsi.net). Leave blank when releasing to more than one region, since the default is per-region."
+          trim: true
+      - string:
+          name: GITEA_REQUIRED_REPOS
+          description: "Overrides which repos are mirrored, as an HCL list, e.g. '[\"infra-configuration\",\"infra-provisioning\"]'. Leave blank for the default: the three infra repos everywhere, plus jitsi-meet in us-phoenix-1. Every repo listed must finish its first sync before the replica is considered healthy."
+          trim: true
+      - string:
+          name: GITEA_IMAGE_VERSION
+          description: "Overrides the Gitea image (defaults to gitea/gitea:1.22)"
+          trim: true
+      - string:
+          name: GITEA_MIRROR_INTERVAL
+          description: "Overrides how often Gitea re-pulls each mirror from GitHub (defaults to 10m)"
+          trim: true
+      - string:
+          name: INFRA_CONFIGURATION_REPO
+          default: git@github.com:jitsi/infra-configuration.git
+          description: "Repo for configuration code (ansible etc), defaults to 'git@github.com:jitsi/infra-configuration.git'."
+          trim: true
+      - string:
+          name: INFRA_CUSTOMIZATIONS_REPO
+          default: git@github.com:jitsi/infra-customizations-private.git
+          description: "Repo with customized configurations, defaults to 'git@github.com:jitsi/infra-customizations-private.git'."
+          trim: true
+      # ---- governance (standard) ----
+      - string:
+          name: RP_TICKET
+          default: ""
+          description: "RP ticket (format: RP-1234) for governance change tracking. Auto-extracted from governance if left empty."
+          trim: true
+      - string:
+          name: JIRA_TICKET
+          default: ""
+          description: "Optional JIRA ticket associated with this change, for governance tracking."
+          trim: true
+      - bool:
+          name: GOVERNANCE_ENABLED
+          default: true
+          description: "Enable governance hooks (pre/post release & deploy gates)."
+      - bool:
+          name: GOVERNANCE_STAGING
+          default: false
+          description: "Target the governance STAGING endpoint instead of production."
+      - bool:
+          name: FAST_TRACK
+          default: false
+          description: "Fast-track the change — skip manual verification/approval gates."
+      - bool:
+          name: GOVERNANCE_VERBOSE
+          default: false
+          description: "Mirror governance hook output (payloads, responses, gate results, shell traces) to the console. When off it goes only to the archived governance log artifact; warnings always show."
+      # ---- governance (advanced, optional) ----
+      - bool:
+          name: GOVERNANCE_ALLOW_OVERRIDE
+          default: true
+          description: "Allow a human to override a governance DENY via an input prompt instead of failing the build."
+      - bool:
+          name: GOVERNANCE_SKIP_GATES
+          default: false
+          description: "Send governance notifications but do not poll/block on the gate result."
+      - string:
+          name: GOVERNANCE_GATE_TIMEOUT
+          default: "60"
+          description: "Seconds a gate may stay PENDING before offering an interactive 'skip' prompt (0 disables the prompt)."
+          trim: true
+
+    project-type: pipeline
+    sandbox: true
+    pipeline-scm:
+      scm:
+        - git:
+            url: git@github.com:jitsi/infra-provisioning.git
+            credentials-id: "video-infra"
+            branches:
+              - "origin/${{VIDEO_INFRA_BRANCH}}"
+            browser: githubweb
+            browser-url: https://github.com/jitsi/infra-provisioning
+            submodule:
+              recursive: true
+      script-path: jenkins/groovy/release-nomad-job/Jenkinsfile
+      lightweight-checkout: true

--- a/nomad/gitea-mirror.hcl
+++ b/nomad/gitea-mirror.hcl
@@ -6,8 +6,10 @@ variable "gitea_hostname" {
   type = string
 }
 
-# Pinned Gitea image. Rooted (non-rootless) so the init task can run the gitea
-# CLI as root against the shared alloc dir without uid juggling.
+# Pinned Gitea image. The rooted (non-rootless) image is used because its
+# entrypoint runs `gitea web` as the built-in `git` user (uid 1000) and the
+# gitea CLI refuses to run as root, so the init task below is also run as
+# uid 1000 and everything under /alloc/gitea ends up owned by that user.
 variable "image_version" {
   type    = string
   default = "gitea/gitea:1.22"
@@ -48,7 +50,11 @@ variable "private_repos" {
   default = ["infra-customizations-private"]
 }
 
-job "gitea-mirror" {
+# Job name is substituted by scripts/deploy-nomad-gitea-mirror.sh as
+# gitea-mirror-<region>. Nomad runs one global region with per-region
+# datacenters, so a fixed name would make each region's deploy replace the
+# previous region's job.
+job "[JOB_NAME]" {
   datacenters = ["${var.dc}"]
 
   type = "service"
@@ -109,8 +115,15 @@ job "gitea-mirror" {
     # Runs the gitea CLI against the shared alloc dir (mounted at /alloc in every
     # task). Idempotent: on an in-place restart the admin already exists (|| true)
     # and a fresh uniquely-named token is minted for the gate.
+    #
+    # Must run as uid 1000 (the image's `git` user), not root: Gitea 1.22 exits
+    # fatally when run as root, and anything written as root under /alloc/gitea
+    # (app.ini, sqlite db) would be unwritable by the main gitea task, which the
+    # image entrypoint drops to `git` via su-exec. Nomad's shared /alloc dir is
+    # mode 0777 so uid 1000 can create the tree.
     task "init" {
       driver = "docker"
+      user   = "1000:1000"
 
       lifecycle {
         hook    = "prestart"
@@ -225,7 +238,10 @@ EOF
         GITEA__service__DISABLE_REGISTRATION = "true"
         GITEA__service__REQUIRE_SIGNIN_VIEW  = "false"
         GITEA__mirror__ENABLED               = "true"
-        GITEA__migrations__ALLOWED_DOMAINS   = "github.com"
+        # Must include *.github.com: the `service: github` migrator talks to
+        # api.github.com before cloning, and a bare "github.com" entry rejects
+        # that with "migration can only call allowed HTTP servers".
+        GITEA__migrations__ALLOWED_DOMAINS   = "github.com,*.github.com"
         GITEA__log__LEVEL                    = "Info"
       }
 

--- a/nomad/gitea-mirror.hcl
+++ b/nomad/gitea-mirror.hcl
@@ -304,6 +304,13 @@ EOF
         GITEA_PRIVATE_REPOS   = "${join(" ", var.private_repos)}"
         GITEA_MIRROR_INTERVAL = "${var.mirror_interval}"
         GATE_PORT             = "8080"
+        # Retry pacing for the mirror seed (see local/sync-gate.py).
+        # GATE_STALL_TIMEOUT is how long an empty repo may sit before it is
+        # treated as a dead stub and re-migrated, so it must comfortably exceed
+        # the first-clone time of the largest mirrored repo.
+        GATE_MIGRATE_TIMEOUT  = "1800"
+        GATE_STALL_TIMEOUT    = "900"
+        GATE_RETRY_BACKOFF    = "60"
       }
 
       template {
@@ -326,9 +333,18 @@ EOF
 
 1. Waits for Gitea, using the seed token written by the init task.
 2. Ensures the target org exists and each required repo is migrated as a pull
-   mirror from GitHub (idempotent create-if-absent).
+   mirror from GitHub, retrying until that succeeds.
 3. Serves /ready on GATE_PORT: 503 until every required repo reports
    "empty": false (first sync done), then 200.
+
+Retrying a migrate is not just a matter of calling it again. A migrate Gitea
+rejects still leaves a repo row behind (empty, no mirror interval) and that
+stub answers GET with 200 for good, so it has to be deleted first -- a second
+migrate over an existing repo returns 409. A migration that is still running
+looks exactly like that stub, and it keeps running even when our request times
+out client-side, so deleting on sight would destroy healthy in-flight clones.
+A stub is therefore only removed once the migrate has failed outright, or once
+it has sat there past GATE_STALL_TIMEOUT without becoming non-empty.
 """
 import json
 import os
@@ -348,7 +364,31 @@ GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN", "")
 GATE_PORT = int(os.environ.get("GATE_PORT", "8080"))
 TOKEN_FILE = "/alloc/gitea-seed/token"
 
+# How long to let a migrate request run before giving up on the answer. Gitea
+# migrates synchronously, so a big repo can hold the connection for minutes.
+MIGRATE_TIMEOUT = int(os.environ.get("GATE_MIGRATE_TIMEOUT", "1800"))
+# How long an empty repo may sit there before it is treated as a dead stub.
+# Must comfortably exceed the first-clone time of the largest mirrored repo.
+STALL_TIMEOUT = int(os.environ.get("GATE_STALL_TIMEOUT", "900"))
+# Minimum gap between migrate attempts for one repo, so a GitHub outage is not
+# hammered.
+RETRY_BACKOFF = int(os.environ.get("GATE_RETRY_BACKOFF", "60"))
+POLL_INTERVAL = int(os.environ.get("GATE_POLL_INTERVAL", "10"))
+
 _ready = threading.Event()
+
+
+class RepoState(object):
+    """What our last migrate attempt for one repo did.
+
+    outcome is None before the first attempt, "failed" when Gitea answered with
+    an error (so nothing is running and any stub is garbage), or "unknown" when
+    the attempt may still be progressing inside Gitea.
+    """
+
+    def __init__(self):
+        self.attempted_at = None
+        self.outcome = None
 
 
 def read_token():
@@ -364,7 +404,7 @@ def read_token():
     raise SystemExit("sync-gate: seed token never appeared at %s" % TOKEN_FILE)
 
 
-def api(method, path, token, body=None, expect=(200, 201)):
+def api(method, path, token, body=None, timeout=30):
     url = GITEA_URL + path
     data = json.dumps(body).encode() if body is not None else None
     req = urllib.request.Request(url, data=data, method=method)
@@ -372,7 +412,7 @@ def api(method, path, token, body=None, expect=(200, 201)):
     req.add_header("Content-Type", "application/json")
     req.add_header("Accept", "application/json")
     try:
-        with urllib.request.urlopen(req, timeout=30) as resp:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
             payload = resp.read()
             return resp.status, (json.loads(payload) if payload else {})
     except urllib.error.HTTPError as e:
@@ -383,6 +423,9 @@ def api(method, path, token, body=None, expect=(200, 201)):
             parsed = {"raw": payload.decode("utf-8", "replace")}
         return e.code, parsed
     except urllib.error.URLError:
+        return 0, {}
+    except OSError:
+        # Socket timeout on a long migrate: Gitea carries on regardless.
         return 0, {}
 
 
@@ -396,21 +439,21 @@ def wait_for_gitea(token):
 
 
 def ensure_org(token):
+    """True once the org exists. Retried by the caller until it does."""
     status, _ = api("GET", "/api/v1/orgs/%s" % GITEA_ORG, token)
     if status == 200:
-        return
+        return True
     status, body = api(
         "POST", "/api/v1/orgs", token,
         {"username": GITEA_ORG, "visibility": "public"},
     )
-    if status not in (201, 422):  # 422 => already exists (race)
-        print("sync-gate: WARN could not create org %s: %s %s" % (GITEA_ORG, status, body), flush=True)
+    if status in (201, 422):  # 422 => already exists (race)
+        return True
+    print("sync-gate: WARN could not create org %s: %s %s" % (GITEA_ORG, status, body), flush=True)
+    return False
 
 
-def ensure_mirror(token, repo):
-    status, _ = api("GET", "/api/v1/repos/%s/%s" % (GITEA_ORG, repo), token)
-    if status == 200:
-        return
+def start_migrate(token, repo, st):
     private = repo in PRIVATE
     body = {
         "clone_addr": "https://github.com/%s/%s.git" % (GITHUB_ORG, repo),
@@ -425,16 +468,63 @@ def ensure_mirror(token, repo):
     # sync path is immune to the deploy-key failure class that caused JIT-16092.
     if GITHUB_TOKEN:
         body["auth_token"] = GITHUB_TOKEN
-    status, resp = api("POST", "/api/v1/repos/migrate", token, body)
+    st.attempted_at = time.monotonic()
+    status, resp = api("POST", "/api/v1/repos/migrate", token, body, timeout=MIGRATE_TIMEOUT)
     if status in (201, 409):
+        st.outcome = "unknown"
         print("sync-gate: migrate %s -> %s" % (repo, status), flush=True)
+    elif status == 0:
+        # No answer: the clone is most likely still running inside Gitea, so
+        # this is explicitly not a failure. The stall timer covers it.
+        st.outcome = "unknown"
+        print("sync-gate: migrate %s: no answer yet, leaving it to run" % repo, flush=True)
     else:
+        st.outcome = "failed"
         print("sync-gate: WARN migrate %s failed: %s %s" % (repo, status, resp), flush=True)
 
 
-def repo_synced(token, repo):
+def drop_stub(token, repo, st, why):
+    """Delete an empty repo so the next pass can migrate it again."""
+    status, resp = api("DELETE", "/api/v1/repos/%s/%s" % (GITEA_ORG, repo), token)
+    if status in (204, 404):
+        # attempted_at is deliberately left alone: it paces the retry.
+        st.outcome = None
+        print("sync-gate: removed %s stub (%s), will migrate again" % (repo, why), flush=True)
+    else:
+        print("sync-gate: WARN could not remove %s stub: %s %s" % (repo, status, resp), flush=True)
+
+
+def reconcile(token, repo, st):
+    """Drive one repo towards being mirrored. True once its first sync is done."""
     status, body = api("GET", "/api/v1/repos/%s/%s" % (GITEA_ORG, repo), token)
-    return status == 200 and body.get("empty") is False
+
+    if status == 200 and body.get("empty") is False:
+        st.outcome = None
+        return True
+
+    now = time.monotonic()
+
+    if status == 404:
+        if st.attempted_at is None or now - st.attempted_at >= RETRY_BACKOFF:
+            start_migrate(token, repo, st)
+        return False
+
+    if status == 200:
+        # The repo exists but is still empty: either a clone in flight or a
+        # stub left behind by one that failed.
+        if st.attempted_at is None:
+            # Left by an earlier gate process. Time it out rather than delete
+            # it, in case Gitea is still working on it.
+            st.attempted_at = now
+            st.outcome = "unknown"
+        elif st.outcome == "failed":
+            drop_stub(token, repo, st, "migrate failed")
+        elif now - st.attempted_at >= STALL_TIMEOUT:
+            drop_stub(token, repo, st, "no progress in %ss" % STALL_TIMEOUT)
+        return False
+
+    # Gitea restarting or a transient error: just look again next pass.
+    return False
 
 
 class Handler(BaseHTTPRequestHandler):
@@ -463,18 +553,23 @@ def main():
 
     token = read_token()
     wait_for_gitea(token)
-    ensure_org(token)
-    for repo in REQUIRED:
-        ensure_mirror(token, repo)
+
+    state = dict((repo, RepoState()) for repo in REQUIRED)
+    org_ok = False
 
     while True:
-        if all(repo_synced(token, r) for r in REQUIRED):
+        if not org_ok:
+            org_ok = ensure_org(token)
+        # Not all(...): every repo must be reconciled on every pass, so this
+        # must not short-circuit on the first one that is not ready yet.
+        done = [reconcile(token, repo, state[repo]) for repo in REQUIRED] if org_ok else []
+        if org_ok and all(done):
             if not _ready.is_set():
                 print("sync-gate: all repos synced, ready", flush=True)
             _ready.set()
         else:
             _ready.clear()
-        time.sleep(10)
+        time.sleep(POLL_INTERVAL)
 
 
 if __name__ == "__main__":

--- a/nomad/gitea-mirror.hcl
+++ b/nomad/gitea-mirror.hcl
@@ -50,6 +50,18 @@ variable "private_repos" {
   default = ["infra-customizations-private"]
 }
 
+# Disk the alloc dir may use, in MB. Nomad assumes 300MB when this is not
+# declared, which is badly wrong here: measured in ops-dev, the four repos take
+# ~1.05GB on disk (jitsi-meet alone ~890MB, infra-customizations-private
+# ~152MB). Under-declaring lets the scheduler pack allocations onto a node that
+# cannot actually hold them. The default carries the jitsi-meet case plus room
+# for growth and for the extra space a first clone needs before git repacks;
+# regions that do not mirror jitsi-meet can be given a smaller value.
+variable "ephemeral_disk_size" {
+  type    = number
+  default = 3072
+}
+
 # Job name is substituted by scripts/deploy-nomad-gitea-mirror.sh as
 # gitea-mirror-<region>. Nomad runs one global region with per-region
 # datacenters, so a fixed name would make each region's deploy replace the
@@ -110,6 +122,15 @@ job "[JOB_NAME]" {
       delay    = "30s"
       interval = "10m"
       mode     = "delay"
+    }
+
+    # Explicitly not sticky and not migrated: state is ephemeral by design
+    # (decision 3), and a rescheduled replica re-mirrors from GitHub rather
+    # than dragging a stale copy of ~1GB of git data to its new node.
+    ephemeral_disk {
+      size    = var.ephemeral_disk_size
+      sticky  = false
+      migrate = false
     }
 
     # Bridge mode so the three tasks share a network namespace: the sync-gate
@@ -283,9 +304,14 @@ EOF
         }
       }
 
+      # Only ~100MB of this is anonymous memory; the rest is page cache for the
+      # mirrored repos. At 1024 the cgroup sat at its ceiling and hit the limit
+      # thousands of times, reclaiming the cache continuously (no OOM kills, but
+      # every clone re-read the repo data from disk). 2048 lets the working set
+      # for the current repo set stay resident.
       resources {
         cpu    = 2000
-        memory = 1024
+        memory = 2048
       }
     }
 

--- a/nomad/gitea-mirror.hcl
+++ b/nomad/gitea-mirror.hcl
@@ -466,7 +466,11 @@ def start_migrate(token, repo, st):
     }
     # Sync over HTTPS + token (never the SSH deploy key) so the mirror's own
     # sync path is immune to the deploy-key failure class that caused JIT-16092.
-    if GITHUB_TOKEN:
+    # Only the private repos get the token: Gitea sends it to api.github.com for
+    # every migrate it is attached to, so putting it on public repos too means a
+    # single bad or expired PAT fails every mirror, including the public ones the
+    # boot path depends on most.
+    if private and GITHUB_TOKEN:
         body["auth_token"] = GITHUB_TOKEN
     st.attempted_at = time.monotonic()
     status, resp = api("POST", "/api/v1/repos/migrate", token, body, timeout=MIGRATE_TIMEOUT)

--- a/nomad/gitea-mirror.hcl
+++ b/nomad/gitea-mirror.hcl
@@ -334,7 +334,9 @@ EOF
         force_pull = false
         ports      = ["health"]
         entrypoint = ["/bin/sh", "-c"]
-        args       = ["python3 /local/sync-gate.py"]
+        # exec so python replaces the shell as PID 1 and actually receives the
+        # SIGHUP nomad sends when the trigger key below changes.
+        args       = ["exec python3 /local/sync-gate.py"]
       }
 
       env {
@@ -365,6 +367,26 @@ GITHUB_TOKEN={{ .Data.data.token }}
 EOF
       }
 
+      # A release pokes every replica at once by writing this Consul key. Both
+      # replicas sit behind one Fabio route with independent databases, so an
+      # API call from outside would only ever sync whichever one it reached,
+      # and a replica started later would miss the poke entirely. Templating
+      # the key instead means each replica reacts for itself and a new replica
+      # simply reads the current value.
+      #
+      # keyOrDefault rather than key: a key that has never been written must
+      # not block the task from starting. The value is the tag being released,
+      # so it is self-describing in the logs, and an unchanged value renders
+      # identically and does not re-signal.
+      template {
+        destination   = "local/sync-trigger"
+        change_mode   = "signal"
+        change_signal = "SIGHUP"
+        data          = <<EOF
+{{ keyOrDefault "gitea-mirror/sync-trigger" "none" }}
+EOF
+      }
+
       template {
         perms       = 755
         destination = "local/sync-gate.py"
@@ -377,6 +399,10 @@ EOF
    mirror from GitHub, retrying until that succeeds.
 3. Serves /ready on GATE_PORT: 503 until every required repo reports
    "empty": false (first sync done), then 200, plus /metrics for Prometheus.
+4. On SIGHUP, asks Gitea to pull every repo immediately instead of waiting for
+   its next interval. Nomad raises that signal when the Consul key the task
+   templates changes, which is how a release pushes fresh refs to every replica
+   at once (see the template stanza in the job).
 
 /ready only ever guards the FIRST sync. Once a replica is serving, every later
 pull could fail and it would stay healthy, quietly handing boots older and
@@ -395,6 +421,7 @@ it has sat there past GATE_STALL_TIMEOUT without becoming non-empty.
 import datetime
 import json
 import os
+import signal
 import threading
 import time
 import urllib.error
@@ -423,6 +450,10 @@ RETRY_BACKOFF = int(os.environ.get("GATE_RETRY_BACKOFF", "60"))
 POLL_INTERVAL = int(os.environ.get("GATE_POLL_INTERVAL", "10"))
 
 _ready = threading.Event()
+
+# Set by SIGHUP, consumed by the main loop. A bare flag rather than an Event on
+# purpose: it is the only thing safe to touch from a signal handler.
+_sync_requested = False
 
 # repo -> {"synced": 0|1, "last_sync": float|None}, published on /metrics.
 _metrics = {}
@@ -519,6 +550,31 @@ def api(method, path, token, body=None, timeout=30):
     except OSError:
         # Socket timeout on a long migrate: Gitea carries on regardless.
         return 0, {}
+
+
+def request_sync(signum, frame):
+    """SIGHUP handler. Nomad signals the task when the Consul trigger key
+    changes, i.e. a release has pushed refs the mirrors have not pulled yet."""
+    global _sync_requested
+    _sync_requested = True
+
+
+def trigger_sync(token):
+    """Ask Gitea to pull every required repo now.
+
+    Each replica does this for its own Gitea. Both replicas sit behind one Fabio
+    route with independent databases, so a single API call from outside would
+    only ever sync whichever one it landed on.
+    """
+    for repo in REQUIRED:
+        status, body = api("POST", "/api/v1/repos/%s/%s/mirror-sync" % (GITEA_ORG, repo), token)
+        if status in (200, 202):
+            print("sync-gate: requested an immediate pull of %s" % repo, flush=True)
+        elif status == 404:
+            # Not migrated yet; the reconcile loop below will create it.
+            print("sync-gate: %s not present yet, leaving it to the reconcile loop" % repo, flush=True)
+        else:
+            print("sync-gate: WARN could not trigger a pull of %s: %s %s" % (repo, status, body), flush=True)
 
 
 def wait_for_gitea(token):
@@ -655,9 +711,12 @@ def serve():
 
 
 def main():
+    global _sync_requested
+
     # Serve /ready (503) immediately so the health check has an endpoint while
     # the mirrors are still being seeded.
     threading.Thread(target=serve, daemon=True).start()
+    signal.signal(signal.SIGHUP, request_sync)
 
     token = read_token()
     wait_for_gitea(token)
@@ -666,6 +725,12 @@ def main():
     org_ok = False
 
     while True:
+        if _sync_requested:
+            # Picked up within one poll interval: a signal does not cut the
+            # sleep below short, it only runs the handler.
+            _sync_requested = False
+            print("sync-gate: sync requested by signal", flush=True)
+            trigger_sync(token)
         if not org_ok:
             org_ok = ensure_org(token)
         # Not all(...): every repo must be reconciled on every pass, so this

--- a/nomad/gitea-mirror.hcl
+++ b/nomad/gitea-mirror.hcl
@@ -1,0 +1,473 @@
+variable "dc" {
+  type = string
+}
+
+variable "gitea_hostname" {
+  type = string
+}
+
+# Pinned Gitea image. Rooted (non-rootless) so the init task can run the gitea
+# CLI as root against the shared alloc dir without uid juggling.
+variable "image_version" {
+  type    = string
+  default = "gitea/gitea:1.22"
+}
+
+# Small stdlib-only image used by the sync-gate sidecar (seed + /ready server).
+variable "gate_image" {
+  type    = string
+  default = "python:3.12-alpine"
+}
+
+# How often Gitea re-pulls each mirror from GitHub.
+variable "mirror_interval" {
+  type    = string
+  default = "10m"
+}
+
+# GitHub org the source repos live under, and the Gitea org they are mirrored
+# into. Kept identical so boot clones use the same /jitsi/<repo> path.
+variable "github_org" {
+  type    = string
+  default = "jitsi"
+}
+
+# Repos that must finish their first sync before the replica is considered
+# ready (decision 4). Order does not matter.
+variable "required_repos" {
+  type    = list(string)
+  default = ["infra-configuration", "infra-provisioning", "infra-customizations-private", "jitsi-meet"]
+}
+
+# Subset of required_repos that must stay private in Gitea and therefore need
+# the GitHub token as migrate auth. Everything else is mirrored public/anon.
+variable "private_repos" {
+  type    = list(string)
+  default = ["infra-customizations-private"]
+}
+
+job "gitea-mirror" {
+  datacenters = ["${var.dc}"]
+
+  type = "service"
+
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
+  group "gitea" {
+    count = 2
+
+    constraint {
+      operator = "distinct_hosts"
+      value    = "true"
+    }
+
+    constraint {
+      attribute = "${meta.pool_type}"
+      operator  = "set_contains_any"
+      value     = "consul,general"
+    }
+
+    affinity {
+      attribute = "${meta.pool_type}"
+      value     = "consul"
+      weight    = -100
+    }
+
+    affinity {
+      attribute = "${meta.pool_type}"
+      value     = "general"
+      weight    = 100
+    }
+
+    restart {
+      attempts = 3
+      delay    = "30s"
+      interval = "10m"
+      mode     = "delay"
+    }
+
+    # Bridge mode so the three tasks share a network namespace: the sync-gate
+    # reaches Gitea over 127.0.0.1:3000, and only the gate's /ready is health
+    # checked. No host volume — state lives in the alloc dir and is re-mirrored
+    # on reschedule (decision 3).
+    network {
+      mode = "bridge"
+      port "http" {
+        to = 3000
+      }
+      port "health" {
+        to = 8080
+      }
+    }
+
+    # --- init: create the Gitea admin + a scoped seed token before Gitea starts.
+    # Runs the gitea CLI against the shared alloc dir (mounted at /alloc in every
+    # task). Idempotent: on an in-place restart the admin already exists (|| true)
+    # and a fresh uniquely-named token is minted for the gate.
+    task "init" {
+      driver = "docker"
+
+      lifecycle {
+        hook    = "prestart"
+        sidecar = false
+      }
+
+      vault {
+        change_mode = "noop"
+      }
+
+      config {
+        image      = "${var.image_version}"
+        force_pull = false
+        entrypoint = ["/bin/sh", "-c"]
+        args       = ["/local/init.sh"]
+      }
+
+      env {
+        GITEA_WORK_DIR                = "/alloc/gitea"
+        GITEA_CUSTOM                  = "/alloc/gitea/custom"
+        GITEA_APP_INI                 = "/alloc/gitea/custom/conf/app.ini"
+        GITEA__database__DB_TYPE      = "sqlite3"
+        GITEA__database__PATH         = "/alloc/gitea/data/gitea.db"
+        GITEA__repository__ROOT       = "/alloc/gitea/data/repositories"
+        GITEA__server__APP_DATA_PATH  = "/alloc/gitea/data"
+        GITEA__security__INSTALL_LOCK = "true"
+      }
+
+      template {
+        destination = "secrets/admin.env"
+        env         = true
+        change_mode = "noop"
+        data        = <<EOF
+{{ with secret "secret/default/gitea/admin" -}}
+GITEA_ADMIN_USER={{ .Data.data.username }}
+GITEA_ADMIN_PASSWORD={{ .Data.data.password }}
+GITEA_ADMIN_EMAIL={{ .Data.data.email }}
+{{ end -}}
+EOF
+      }
+
+      template {
+        perms       = 755
+        destination = "local/init.sh"
+        data        = <<EOF
+#!/bin/sh
+set -e
+
+mkdir -p /alloc/gitea/custom/conf /alloc/gitea/data /alloc/gitea/data/repositories /alloc/gitea-seed
+
+# Render app.ini from the GITEA__* env to the shared path so the CLI here and
+# the main gitea task agree on the DB/repo locations.
+if [ -x /usr/local/bin/environment-to-ini ]; then
+  environment-to-ini -o "$GITEA_APP_INI"
+fi
+
+CONF="$GITEA_APP_INI"
+
+# Initialise / migrate the sqlite schema (safe to re-run).
+gitea -c "$CONF" migrate
+
+# Create the site admin (first user is a site admin). Idempotent across restarts.
+gitea -c "$CONF" admin user create \
+  --admin \
+  --username "$GITEA_ADMIN_USER" \
+  --password "$GITEA_ADMIN_PASSWORD" \
+  --email "$GITEA_ADMIN_EMAIL" \
+  --must-change-password=false || true
+
+# Mint a fresh, uniquely-named token for the sync-gate to seed/inspect mirrors.
+TOKEN=$(gitea -c "$CONF" admin user generate-access-token \
+  --username "$GITEA_ADMIN_USER" \
+  --token-name "seed-$(date +%s)" \
+  --scopes "write:repository,write:organization,write:admin,read:user" \
+  --raw)
+printf '%s' "$TOKEN" > /alloc/gitea-seed/token
+chmod 600 /alloc/gitea-seed/token
+echo "init: admin ensured and seed token written"
+EOF
+      }
+
+      resources {
+        cpu    = 500
+        memory = 256
+      }
+    }
+
+    # --- gitea: the mirror server itself. Serves git over HTTP through Fabio.
+    task "gitea" {
+      driver         = "docker"
+      shutdown_delay = "10s"
+
+      config {
+        image      = "${var.image_version}"
+        force_pull = false
+        ports      = ["http"]
+      }
+
+      env {
+        GITEA_WORK_DIR                       = "/alloc/gitea"
+        GITEA_CUSTOM                         = "/alloc/gitea/custom"
+        GITEA_APP_INI                        = "/alloc/gitea/custom/conf/app.ini"
+        GITEA__database__DB_TYPE             = "sqlite3"
+        GITEA__database__PATH                = "/alloc/gitea/data/gitea.db"
+        GITEA__repository__ROOT              = "/alloc/gitea/data/repositories"
+        GITEA__server__APP_DATA_PATH         = "/alloc/gitea/data"
+        GITEA__server__HTTP_PORT             = "3000"
+        GITEA__server__ROOT_URL              = "https://${var.gitea_hostname}/"
+        GITEA__server__DOMAIN                = "${var.gitea_hostname}"
+        GITEA__server__DISABLE_SSH           = "true"
+        GITEA__security__INSTALL_LOCK        = "true"
+        GITEA__service__DISABLE_REGISTRATION = "true"
+        GITEA__service__REQUIRE_SIGNIN_VIEW  = "false"
+        GITEA__mirror__ENABLED               = "true"
+        GITEA__migrations__ALLOWED_DOMAINS   = "github.com"
+        GITEA__log__LEVEL                    = "Info"
+      }
+
+      service {
+        name = "gitea-mirror"
+        tags = ["int-urlprefix-${var.gitea_hostname}/"]
+        port = "http"
+
+        # Health is the sync-gate's /ready, NOT Gitea's own liveness: a replica
+        # stays out of Fabio until every required repo has finished first sync
+        # (decision 4). limit = 0 so the gate returning 503 during initial sync
+        # never restarts the task.
+        check {
+          name     = "ready"
+          type     = "http"
+          port     = "health"
+          path     = "/ready"
+          interval = "15s"
+          timeout  = "5s"
+
+          check_restart {
+            limit = 0
+          }
+        }
+      }
+
+      resources {
+        cpu    = 2000
+        memory = 1024
+      }
+    }
+
+    # --- sync-gate: poststart sidecar. Seeds the mirrors (idempotent) then
+    # serves /ready — 503 until all required repos report "empty": false.
+    task "sync-gate" {
+      driver = "docker"
+
+      lifecycle {
+        hook    = "poststart"
+        sidecar = true
+      }
+
+      vault {
+        change_mode = "noop"
+      }
+
+      config {
+        image      = "${var.gate_image}"
+        force_pull = false
+        ports      = ["health"]
+        entrypoint = ["/bin/sh", "-c"]
+        args       = ["python3 /local/sync-gate.py"]
+      }
+
+      env {
+        GITEA_URL             = "http://127.0.0.1:3000"
+        GITEA_ORG             = "${var.github_org}"
+        GITHUB_ORG            = "${var.github_org}"
+        GITEA_REQUIRED_REPOS  = "${join(" ", var.required_repos)}"
+        GITEA_PRIVATE_REPOS   = "${join(" ", var.private_repos)}"
+        GITEA_MIRROR_INTERVAL = "${var.mirror_interval}"
+        GATE_PORT             = "8080"
+      }
+
+      template {
+        destination = "secrets/github.env"
+        env         = true
+        change_mode = "noop"
+        data        = <<EOF
+{{ with secret "secret/default/gitea/github" -}}
+GITHUB_TOKEN={{ .Data.data.token }}
+{{ end -}}
+EOF
+      }
+
+      template {
+        perms       = 755
+        destination = "local/sync-gate.py"
+        data        = <<EOF
+#!/usr/bin/env python3
+"""Sync-gate for the Gitea regional mirror.
+
+1. Waits for Gitea, using the seed token written by the init task.
+2. Ensures the target org exists and each required repo is migrated as a pull
+   mirror from GitHub (idempotent create-if-absent).
+3. Serves /ready on GATE_PORT: 503 until every required repo reports
+   "empty": false (first sync done), then 200.
+"""
+import json
+import os
+import threading
+import time
+import urllib.error
+import urllib.request
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+GITEA_URL = os.environ["GITEA_URL"].rstrip("/")
+GITEA_ORG = os.environ["GITEA_ORG"]
+GITHUB_ORG = os.environ["GITHUB_ORG"]
+REQUIRED = os.environ.get("GITEA_REQUIRED_REPOS", "").split()
+PRIVATE = set(os.environ.get("GITEA_PRIVATE_REPOS", "").split())
+INTERVAL = os.environ.get("GITEA_MIRROR_INTERVAL", "10m")
+GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN", "")
+GATE_PORT = int(os.environ.get("GATE_PORT", "8080"))
+TOKEN_FILE = "/alloc/gitea-seed/token"
+
+_ready = threading.Event()
+
+
+def read_token():
+    for _ in range(120):
+        try:
+            with open(TOKEN_FILE) as fh:
+                tok = fh.read().strip()
+            if tok:
+                return tok
+        except OSError:
+            pass
+        time.sleep(2)
+    raise SystemExit("sync-gate: seed token never appeared at %s" % TOKEN_FILE)
+
+
+def api(method, path, token, body=None, expect=(200, 201)):
+    url = GITEA_URL + path
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(url, data=data, method=method)
+    req.add_header("Authorization", "token " + token)
+    req.add_header("Content-Type", "application/json")
+    req.add_header("Accept", "application/json")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            payload = resp.read()
+            return resp.status, (json.loads(payload) if payload else {})
+    except urllib.error.HTTPError as e:
+        payload = e.read()
+        try:
+            parsed = json.loads(payload) if payload else {}
+        except ValueError:
+            parsed = {"raw": payload.decode("utf-8", "replace")}
+        return e.code, parsed
+    except urllib.error.URLError:
+        return 0, {}
+
+
+def wait_for_gitea(token):
+    while True:
+        status, _ = api("GET", "/api/v1/version", token)
+        if status == 200:
+            print("sync-gate: gitea is up", flush=True)
+            return
+        time.sleep(3)
+
+
+def ensure_org(token):
+    status, _ = api("GET", "/api/v1/orgs/%s" % GITEA_ORG, token)
+    if status == 200:
+        return
+    status, body = api(
+        "POST", "/api/v1/orgs", token,
+        {"username": GITEA_ORG, "visibility": "public"},
+    )
+    if status not in (201, 422):  # 422 => already exists (race)
+        print("sync-gate: WARN could not create org %s: %s %s" % (GITEA_ORG, status, body), flush=True)
+
+
+def ensure_mirror(token, repo):
+    status, _ = api("GET", "/api/v1/repos/%s/%s" % (GITEA_ORG, repo), token)
+    if status == 200:
+        return
+    private = repo in PRIVATE
+    body = {
+        "clone_addr": "https://github.com/%s/%s.git" % (GITHUB_ORG, repo),
+        "repo_owner": GITEA_ORG,
+        "repo_name": repo,
+        "mirror": True,
+        "mirror_interval": INTERVAL,
+        "private": private,
+        "service": "github",
+    }
+    # Sync over HTTPS + token (never the SSH deploy key) so the mirror's own
+    # sync path is immune to the deploy-key failure class that caused JIT-16092.
+    if GITHUB_TOKEN:
+        body["auth_token"] = GITHUB_TOKEN
+    status, resp = api("POST", "/api/v1/repos/migrate", token, body)
+    if status in (201, 409):
+        print("sync-gate: migrate %s -> %s" % (repo, status), flush=True)
+    else:
+        print("sync-gate: WARN migrate %s failed: %s %s" % (repo, status, resp), flush=True)
+
+
+def repo_synced(token, repo):
+    status, body = api("GET", "/api/v1/repos/%s/%s" % (GITEA_ORG, repo), token)
+    return status == 200 and body.get("empty") is False
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path.startswith("/ready"):
+            code = 200 if _ready.is_set() else 503
+        else:
+            code = 200
+        self.send_response(code)
+        self.send_header("Content-Type", "text/plain")
+        self.end_headers()
+        self.wfile.write(b"ok\n" if code == 200 else b"syncing\n")
+
+    def log_message(self, *args):
+        pass
+
+
+def serve():
+    HTTPServer(("0.0.0.0", GATE_PORT), Handler).serve_forever()
+
+
+def main():
+    # Serve /ready (503) immediately so the health check has an endpoint while
+    # the mirrors are still being seeded.
+    threading.Thread(target=serve, daemon=True).start()
+
+    token = read_token()
+    wait_for_gitea(token)
+    ensure_org(token)
+    for repo in REQUIRED:
+        ensure_mirror(token, repo)
+
+    while True:
+        if all(repo_synced(token, r) for r in REQUIRED):
+            if not _ready.is_set():
+                print("sync-gate: all repos synced, ready", flush=True)
+            _ready.set()
+        else:
+            _ready.clear()
+        time.sleep(10)
+
+
+if __name__ == "__main__":
+    main()
+EOF
+      }
+
+      resources {
+        cpu    = 200
+        memory = 128
+      }
+    }
+  }
+}

--- a/nomad/gitea-mirror.hcl
+++ b/nomad/gitea-mirror.hcl
@@ -33,10 +33,12 @@ variable "github_org" {
 }
 
 # Repos that must finish their first sync before the replica is considered
-# ready (decision 4). Order does not matter.
+# ready (decision 4). Order does not matter. jitsi-meet is NOT in the default
+# set — it is only cloned by boots in us-phoenix-1, so the deploy script adds it
+# there (see scripts/deploy-nomad-gitea-mirror.sh).
 variable "required_repos" {
   type    = list(string)
-  default = ["infra-configuration", "infra-provisioning", "infra-customizations-private", "jitsi-meet"]
+  default = ["infra-configuration", "infra-provisioning", "infra-customizations-private"]
 }
 
 # Subset of required_repos that must stay private in Gitea and therefore need

--- a/nomad/gitea-mirror.hcl
+++ b/nomad/gitea-mirror.hcl
@@ -64,6 +64,21 @@ job "[JOB_NAME]" {
     value     = "linux"
   }
 
+  # The health check is the sync-gate's /ready, which deliberately stays 503
+  # until every required repo has finished its first clone (decision 4). In
+  # us-phoenix-1 that includes jitsi-meet, so a cold replica legitimately takes
+  # far longer than Nomad's default 5m healthy_deadline, which would fail the
+  # rollout while the mirror is still syncing normally. auto_revert keeps the
+  # previous, already-synced version serving when a new one never gets there.
+  update {
+    max_parallel      = 1
+    health_check      = "checks"
+    min_healthy_time  = "10s"
+    healthy_deadline  = "20m"
+    progress_deadline = "30m"
+    auto_revert       = true
+  }
+
   group "gitea" {
     count = 2
 

--- a/nomad/gitea-mirror.hcl
+++ b/nomad/gitea-mirror.hcl
@@ -350,7 +350,12 @@ EOF
 2. Ensures the target org exists and each required repo is migrated as a pull
    mirror from GitHub, retrying until that succeeds.
 3. Serves /ready on GATE_PORT: 503 until every required repo reports
-   "empty": false (first sync done), then 200.
+   "empty": false (first sync done), then 200, plus /metrics for Prometheus.
+
+/ready only ever guards the FIRST sync. Once a replica is serving, every later
+pull could fail and it would stay healthy, quietly handing boots older and
+older code, so /metrics exports the last-sync time per repo for a staleness
+alert.
 
 Retrying a migrate is not just a matter of calling it again. A migrate Gitea
 rejects still leaves a repo row behind (empty, no mirror interval) and that
@@ -361,6 +366,7 @@ out client-side, so deleting on sight would destroy healthy in-flight clones.
 A stub is therefore only removed once the migrate has failed outright, or once
 it has sat there past GATE_STALL_TIMEOUT without becoming non-empty.
 """
+import datetime
 import json
 import os
 import threading
@@ -392,6 +398,10 @@ POLL_INTERVAL = int(os.environ.get("GATE_POLL_INTERVAL", "10"))
 
 _ready = threading.Event()
 
+# repo -> {"synced": 0|1, "last_sync": float|None}, published on /metrics.
+_metrics = {}
+_metrics_lock = threading.Lock()
+
 
 class RepoState(object):
     """What our last migrate attempt for one repo did.
@@ -404,6 +414,47 @@ class RepoState(object):
     def __init__(self):
         self.attempted_at = None
         self.outcome = None
+
+
+def parse_timestamp(value):
+    """Gitea's RFC3339 mirror_updated as a unix time, or None if never synced."""
+    if not value or value.startswith("0001-01-01"):
+        return None
+    try:
+        return datetime.datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
+    except ValueError:
+        return None
+
+
+def record_repo(repo, body):
+    with _metrics_lock:
+        _metrics[repo] = {
+            "synced": 1 if body.get("empty") is False else 0,
+            "last_sync": parse_timestamp(body.get("mirror_updated")),
+        }
+
+
+def render_metrics():
+    with _metrics_lock:
+        snap = dict((repo, dict(v)) for repo, v in _metrics.items())
+    out = [
+        "# HELP gitea_mirror_ready Whether every required repo has finished its first sync.",
+        "# TYPE gitea_mirror_ready gauge",
+        "gitea_mirror_ready %d" % (1 if _ready.is_set() else 0),
+        "# HELP gitea_mirror_repo_synced Whether this repo has finished its first sync.",
+        "# TYPE gitea_mirror_repo_synced gauge",
+    ]
+    for repo in sorted(snap):
+        out.append('gitea_mirror_repo_synced{repo="%s"} %d' % (repo, snap[repo]["synced"]))
+    out.append("# HELP gitea_mirror_last_sync_timestamp_seconds Unix time Gitea last pulled this mirror.")
+    out.append("# TYPE gitea_mirror_last_sync_timestamp_seconds gauge")
+    for repo in sorted(snap):
+        ts = snap[repo]["last_sync"]
+        # Only emitted once the repo has actually synced. A mirror still doing
+        # its first clone would otherwise read as infinitely stale.
+        if ts is not None:
+            out.append('gitea_mirror_last_sync_timestamp_seconds{repo="%s"} %.0f' % (repo, ts))
+    return "\n".join(out) + "\n"
 
 
 def read_token():
@@ -516,6 +567,10 @@ def drop_stub(token, repo, st, why):
 def reconcile(token, repo, st):
     """Drive one repo towards being mirrored. True once its first sync is done."""
     status, body = api("GET", "/api/v1/repos/%s/%s" % (GITEA_ORG, repo), token)
+    if status == 200:
+        # Only on a good read: a transient error must not wipe the last known
+        # sync time and blind the staleness alert.
+        record_repo(repo, body)
 
     if status == 200 and body.get("empty") is False:
         st.outcome = None
@@ -548,6 +603,14 @@ def reconcile(token, repo, st):
 
 class Handler(BaseHTTPRequestHandler):
     def do_GET(self):
+        if self.path.startswith("/metrics"):
+            payload = render_metrics().encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain; version=0.0.4")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+            return
         if self.path.startswith("/ready"):
             code = 200 if _ready.is_set() else 503
         else:
@@ -594,6 +657,15 @@ def main():
 if __name__ == "__main__":
     main()
 EOF
+      }
+
+      # Registered purely so prometheus can scrape /metrics off the gate port.
+      # Deliberately has no check: scraping has to keep working precisely when
+      # the gate is reporting not-ready, and the routable service is the gitea
+      # one above.
+      service {
+        name = "gitea-mirror-metrics"
+        port = "health"
       }
 
       resources {

--- a/nomad/prometheus.hcl
+++ b/nomad/prometheus.hcl
@@ -205,6 +205,16 @@ ${var.custom_relabels}
       - target_label: service
         replacement: 'jitsi'
 ${var.custom_relabels}
+  - job_name: 'gitea-mirror'
+    scrape_interval: 60s
+    metrics_path: /metrics
+    consul_sd_configs:
+    - server: '{{ env "NOMAD_IP_prometheus_ui" }}:8500'
+      services: ['gitea-mirror-metrics']
+    metric_relabel_configs:
+      - target_label: service
+        replacement: 'infra'
+${var.custom_relabels}
   - job_name: 'prometheus'
     scrape_interval: 5s
     static_configs:
@@ -464,6 +474,47 @@ groups:
         modifying the allocated CPU and re-deploying the job.
       dashboard_url: ${var.grafana_url}
       alert_url: https://${var.prometheus_hostname}/alerts?search=nomad_job
+
+  - alert: Gitea_Mirror_Stale
+    # The regional Gitea mirror's /ready gate only ever guards the FIRST sync, so a
+    # replica keeps serving happily even if every scheduled pull since has failed --
+    # handing booting VMs progressively older infra code with nothing else to notice.
+    # gitea_mirror_last_sync_timestamp_seconds is Gitea's own mirror_updated, which
+    # advances on each successful pull; the default mirror interval is 10m, so an hour
+    # without one means several consecutive failures. The series is absent until a repo
+    # has synced at least once, so a replica still doing its first clone cannot fire this.
+    expr: time() - gitea_mirror_last_sync_timestamp_seconds > 3600
+    for: 10m
+    labels:
+      service: infra
+      severity: warn
+    annotations:
+      summary: gitea mirror {{ $labels.repo }} is stale in ${var.dc}
+      description: >-
+        The regional Gitea mirror in ${var.dc} has not pulled {{ $labels.repo }} from
+        GitHub for over an hour (last sync {{ $value | humanizeDuration }} ago), while the
+        mirror interval is 10m. The replica is still serving the last snapshot, so VM boots
+        are cloning increasingly stale code. Check the sync-gate logs and the mirror's
+        status page for the repo.
+      dashboard_url: ${var.grafana_url}
+      alert_url: https://${var.prometheus_hostname}/alerts?search=gitea_mirror
+  - alert: Gitea_Mirror_Stale_Critical
+    # Same signal held far longer: the mirror has been failing to pull for most of a day,
+    # so anything booting from it is materially behind main.
+    expr: time() - gitea_mirror_last_sync_timestamp_seconds > 21600
+    for: 10m
+    labels:
+      service: infra
+      severity: severe
+    annotations:
+      summary: gitea mirror {{ $labels.repo }} has been stale for hours in ${var.dc}
+      description: >-
+        The regional Gitea mirror in ${var.dc} has not pulled {{ $labels.repo }} from GitHub
+        for over six hours (last sync {{ $value | humanizeDuration }} ago). VM boots served
+        by this mirror are getting materially outdated infra code. Check whether GitHub
+        auth (the PAT in secret/default/gitea/github) or egress is broken.
+      dashboard_url: ${var.grafana_url}
+      alert_url: https://${var.prometheus_hostname}/alerts?search=gitea_mirror
 
 - name: cloudprober_alerts
   rules:

--- a/scripts/deploy-nomad-gitea-mirror.sh
+++ b/scripts/deploy-nomad-gitea-mirror.sh
@@ -56,5 +56,28 @@ export NOMAD_VAR_required_repos="$GITEA_REQUIRED_REPOS"
 
 export NOMAD_VAR_dc="$NOMAD_DC"
 
-nomad job run -var="dc=$NOMAD_DC" "$NOMAD_JOB_PATH/gitea-mirror.hcl"
-exit $?
+# Per-region job name, same pattern as loki-/prometheus-/tempo-$ORACLE_REGION:
+# the Nomad region is shared across all of an environment's datacenters, so a
+# fixed name would be clobbered by the next region's deploy. Overridable so a
+# test instance can run alongside the real one.
+[ -z "$JOB_NAME" ] && JOB_NAME="gitea-mirror-$ORACLE_REGION"
+
+sed -e "s/\[JOB_NAME\]/$JOB_NAME/" "$NOMAD_JOB_PATH/gitea-mirror.hcl" | nomad job run -var="dc=$NOMAD_DC" -
+RET=$?
+
+# Route53 CNAME for the mirror hostname -> the region's internal general-pool
+# (Fabio) target, same pattern as deploy-nomad-loki.sh / -prometheus.sh. The
+# record label is derived from GITEA_HOSTNAME so an overridden test hostname
+# gets its own record; skipped if the hostname is outside the top-level zone.
+if [[ "$GITEA_HOSTNAME" == *".${TOP_LEVEL_DNS_ZONE_NAME}" ]]; then
+    export RESOURCE_NAME_ROOT="${GITEA_HOSTNAME%.${TOP_LEVEL_DNS_ZONE_NAME}}"
+    export STACK_NAME="${RESOURCE_NAME_ROOT}-cname"
+    export UNIQUE_ID="${RESOURCE_NAME_ROOT}"
+    export CNAME_TARGET="${ENVIRONMENT}-${ORACLE_REGION}-nomad-pool-general-internal.${DEFAULT_DNS_ZONE_NAME}"
+    export CNAME_VALUE="${RESOURCE_NAME_ROOT}"
+    $LOCAL_PATH/create-oracle-cname-stack.sh
+else
+    echo "GITEA_HOSTNAME $GITEA_HOSTNAME is not under $TOP_LEVEL_DNS_ZONE_NAME, skipping CNAME creation"
+fi
+
+exit $RET

--- a/scripts/deploy-nomad-gitea-mirror.sh
+++ b/scripts/deploy-nomad-gitea-mirror.sh
@@ -37,6 +37,19 @@ NOMAD_DC="$ENVIRONMENT-$ORACLE_REGION"
 [ -z "$GITEA_HOSTNAME" ] && GITEA_HOSTNAME="${ENVIRONMENT}-${ORACLE_REGION}-git.${TOP_LEVEL_DNS_ZONE_NAME}"
 export NOMAD_VAR_gitea_hostname="$GITEA_HOSTNAME"
 
+# Repos to mirror. jitsi-meet is only cloned by boots in us-phoenix-1 (where the
+# Jenkins/build host lives), so it is mirrored there only; everywhere else just
+# the three infra repos. Override wholesale with GITEA_REQUIRED_REPOS (HCL/JSON
+# list syntax, e.g. '["infra-configuration","jitsi-meet"]').
+if [ -z "$GITEA_REQUIRED_REPOS" ]; then
+    if [ "$ORACLE_REGION" == "us-phoenix-1" ]; then
+        GITEA_REQUIRED_REPOS='["infra-configuration","infra-provisioning","infra-customizations-private","jitsi-meet"]'
+    else
+        GITEA_REQUIRED_REPOS='["infra-configuration","infra-provisioning","infra-customizations-private"]'
+    fi
+fi
+export NOMAD_VAR_required_repos="$GITEA_REQUIRED_REPOS"
+
 # Optional overrides (all have sane defaults in the job).
 [ -n "$GITEA_IMAGE_VERSION" ] && export NOMAD_VAR_image_version="$GITEA_IMAGE_VERSION"
 [ -n "$GITEA_MIRROR_INTERVAL" ] && export NOMAD_VAR_mirror_interval="$GITEA_MIRROR_INTERVAL"

--- a/scripts/deploy-nomad-gitea-mirror.sh
+++ b/scripts/deploy-nomad-gitea-mirror.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Deploys the per-region Gitea mirror (nomad/gitea-mirror.hcl). Modeled on
+# deploy-nomad-ops-repo.sh: dc = $ENVIRONMENT-$ORACLE_REGION, served internal-only
+# via a Fabio int-urlprefix tag on the mirror hostname. See JIT-16092.
+
+if [ -z "$ENVIRONMENT" ]; then
+    echo "No ENVIRONMENT set, exiting"
+    exit 2
+fi
+
+LOCAL_PATH=$(dirname "${BASH_SOURCE[0]}")
+
+[ -e "$LOCAL_PATH/../sites/$ENVIRONMENT/stack-env.sh" ] && . "$LOCAL_PATH/../sites/$ENVIRONMENT/stack-env.sh"
+
+[ -e "$LOCAL_PATH/../clouds/all.sh" ] && . "$LOCAL_PATH/../clouds/all.sh"
+[ -e "$LOCAL_PATH/../clouds/oracle.sh" ] && . "$LOCAL_PATH/../clouds/oracle.sh"
+
+if [ -z "$ORACLE_REGION" ]; then
+    echo "No ORACLE_REGION set, exiting"
+    exit 2
+fi
+
+[ -z "$LOCAL_REGION" ] && LOCAL_REGION="$OCI_LOCAL_REGION"
+[ -z "$LOCAL_REGION" ] && LOCAL_REGION="us-phoenix-1"
+
+if [ -z "$NOMAD_ADDR" ]; then
+    export NOMAD_ADDR="https://$ENVIRONMENT-$LOCAL_REGION-nomad.$TOP_LEVEL_DNS_ZONE_NAME"
+fi
+
+NOMAD_JOB_PATH="$LOCAL_PATH/../nomad"
+NOMAD_DC="$ENVIRONMENT-$ORACLE_REGION"
+
+# Regional mirror hostname. Internal-only (served behind Fabio's int- prefix),
+# one per env+region so boots clone from their own region's mirror. Overridable
+# for test instances so they don't collide with the production route.
+[ -z "$GITEA_HOSTNAME" ] && GITEA_HOSTNAME="${ENVIRONMENT}-${ORACLE_REGION}-git.${TOP_LEVEL_DNS_ZONE_NAME}"
+export NOMAD_VAR_gitea_hostname="$GITEA_HOSTNAME"
+
+# Optional overrides (all have sane defaults in the job).
+[ -n "$GITEA_IMAGE_VERSION" ] && export NOMAD_VAR_image_version="$GITEA_IMAGE_VERSION"
+[ -n "$GITEA_MIRROR_INTERVAL" ] && export NOMAD_VAR_mirror_interval="$GITEA_MIRROR_INTERVAL"
+
+export NOMAD_VAR_dc="$NOMAD_DC"
+
+nomad job run -var="dc=$NOMAD_DC" "$NOMAD_JOB_PATH/gitea-mirror.hcl"
+exit $?

--- a/scripts/trigger-nomad-gitea-mirror-sync.sh
+++ b/scripts/trigger-nomad-gitea-mirror-sync.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+# Tells the per-region Gitea mirrors to pull from GitHub now, instead of waiting
+# for their next scheduled interval. See JIT-16092.
+#
+# Why a Consul key rather than calling the mirrors directly: each region runs two
+# Gitea replicas behind one Fabio route, each with its own database, so an API
+# call to the mirror hostname only ever syncs whichever replica it lands on. Every
+# replica templates this key and nomad signals its sync-gate when the value
+# changes, so one write per region reaches both replicas, and a replica that
+# starts later just reads the current value.
+#
+# Run this after a release tags a repo. Boots check out a specific tag, so
+# without it a boot can reach a replica that has not pulled the tag yet. That
+# still works (the boot path falls back to github) but it defeats the point of
+# having a local mirror.
+#
+# Usage: ENVIRONMENT=prod-8x8 scripts/trigger-nomad-gitea-mirror-sync.sh <label> [ssh-user]
+#   <label>   what is being released, recorded as the key's value for the logs.
+#             Defaults to $GIT_BRANCH, or "manual".
+#   REGIONS   defaults to the environment's NOMAD_REGIONS.
+
+[ -e ./stack-env.sh ] && . ./stack-env.sh
+
+if [ -z "$ENVIRONMENT" ]; then
+  echo "No ENVIRONMENT found. Exiting..."
+  exit 203
+fi
+
+[ -e ./sites/$ENVIRONMENT/stack-env.sh ] && . ./sites/$ENVIRONMENT/stack-env.sh
+
+LOCAL_PATH=$(dirname "${BASH_SOURCE[0]}")
+
+[ -e "$LOCAL_PATH/../clouds/all.sh" ] && . "$LOCAL_PATH/../clouds/all.sh"
+[ -e "$LOCAL_PATH/../clouds/oracle.sh" ] && . "$LOCAL_PATH/../clouds/oracle.sh"
+
+TRIGGER_LABEL="$1"
+[ -z "$TRIGGER_LABEL" ] && TRIGGER_LABEL="$GIT_BRANCH"
+[ -z "$TRIGGER_LABEL" ] && TRIGGER_LABEL="manual"
+
+if [ -z "$2" ]; then
+  ANSIBLE_SSH_USER=$(whoami)
+else
+  ANSIBLE_SSH_USER=$2
+fi
+
+[ -z "$REGIONS" ] && REGIONS="$NOMAD_REGIONS"
+if [ -z "$REGIONS" ]; then
+  echo "No REGIONS or NOMAD_REGIONS set, exiting"
+  exit 1
+fi
+
+[ -z "$OCI_LOCAL_REGION" ] && OCI_LOCAL_REGION="us-phoenix-1"
+OCI_LOCAL_DATACENTER="$ENVIRONMENT-$OCI_LOCAL_REGION"
+
+# A timestamp is appended so a repeat of the same tag still changes the rendered
+# value: nomad only signals when the template output actually differs.
+TRIGGER_VALUE="$TRIGGER_LABEL $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+PORT_OCI=$(python3 -c 'import socket; s=socket.socket(); s.bind(("", 0)); print(s.getsockname()[1]); s.close()')
+
+# Consul forwards KV writes to another datacenter via ?dc=, so one tunnel to the
+# environment's local region covers every region in it.
+ssh -fNT -L127.0.0.1:$PORT_OCI:$OCI_LOCAL_DATACENTER-consul.$TOP_LEVEL_DNS_ZONE_NAME:443 $ANSIBLE_SSH_USER@$OCI_LOCAL_REGION-$ENVIRONMENT-ssh.$DEFAULT_DNS_ZONE_NAME
+if [ $? -ne 0 ]; then
+  echo "Failed to open the consul tunnel, exiting"
+  exit 2
+fi
+
+OCI_CONSUL_HOST="consul-local.$TOP_LEVEL_DNS_ZONE_NAME"
+OCI_CONSUL_URL="https://$OCI_CONSUL_HOST:$PORT_OCI"
+
+FINAL_RET=0
+for REGION in $REGIONS; do
+  KV_URL="$OCI_CONSUL_URL/v1/kv/gitea-mirror/sync-trigger?dc=$ENVIRONMENT-$REGION"
+  RESPONSE=$(curl -s --resolve $OCI_CONSUL_HOST:$PORT_OCI:127.0.0.1 -d "$TRIGGER_VALUE" -X PUT "$KV_URL")
+  if [ $? -eq 0 ] && [ "$RESPONSE" == "true" ]; then
+    echo "triggered a mirror sync in $ENVIRONMENT-$REGION for '$TRIGGER_VALUE'"
+  else
+    # Never fatal to a release: the mirrors still pull on their own interval, and
+    # boots fall back to github for anything not mirrored yet.
+    echo "WARNING: could not trigger a mirror sync in $ENVIRONMENT-$REGION: $RESPONSE"
+    FINAL_RET=1
+  fi
+done
+
+SSH_OCI_PID=$(ps auxww | grep "ssh \-fNT -L127.0.0.1:$PORT_OCI" | grep -v grep | awk '{print $2}')
+[ -n "$SSH_OCI_PID" ] && kill $SSH_OCI_PID
+
+exit $FINAL_RET

--- a/scripts/trigger-nomad-gitea-mirror-sync.sh
+++ b/scripts/trigger-nomad-gitea-mirror-sync.sh
@@ -15,10 +15,11 @@
 # still works (the boot path falls back to github) but it defeats the point of
 # having a local mirror.
 #
-# Usage: ENVIRONMENT=prod-8x8 scripts/trigger-nomad-gitea-mirror-sync.sh <label> [ssh-user]
-#   <label>   what is being released, recorded as the key's value for the logs.
-#             Defaults to $GIT_BRANCH, or "manual".
-#   REGIONS   defaults to the environment's NOMAD_REGIONS.
+# Usage: ENVIRONMENT=prod-8x8 scripts/trigger-nomad-gitea-mirror-sync.sh <label>
+#   <label>      what is being released, recorded as the key's value for the
+#                logs. Defaults to $GIT_BRANCH, or "manual".
+#   REGIONS      defaults to the environment's NOMAD_REGIONS.
+#   CONSUL_HOST  overrides the consul endpoint for every region, for a one-off.
 
 [ -e ./stack-env.sh ] && . ./stack-env.sh
 
@@ -38,42 +39,25 @@ TRIGGER_LABEL="$1"
 [ -z "$TRIGGER_LABEL" ] && TRIGGER_LABEL="$GIT_BRANCH"
 [ -z "$TRIGGER_LABEL" ] && TRIGGER_LABEL="manual"
 
-if [ -z "$2" ]; then
-  ANSIBLE_SSH_USER=$(whoami)
-else
-  ANSIBLE_SSH_USER=$2
-fi
-
 [ -z "$REGIONS" ] && REGIONS="$NOMAD_REGIONS"
 if [ -z "$REGIONS" ]; then
   echo "No REGIONS or NOMAD_REGIONS set, exiting"
   exit 1
 fi
 
-[ -z "$OCI_LOCAL_REGION" ] && OCI_LOCAL_REGION="us-phoenix-1"
-OCI_LOCAL_DATACENTER="$ENVIRONMENT-$OCI_LOCAL_REGION"
-
 # A timestamp is appended so a repeat of the same tag still changes the rendered
 # value: nomad only signals when the template output actually differs.
 TRIGGER_VALUE="$TRIGGER_LABEL $(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
-PORT_OCI=$(python3 -c 'import socket; s=socket.socket(); s.bind(("", 0)); print(s.getsockname()[1]); s.close()')
-
-# Consul forwards KV writes to another datacenter via ?dc=, so one tunnel to the
-# environment's local region covers every region in it.
-ssh -fNT -L127.0.0.1:$PORT_OCI:$OCI_LOCAL_DATACENTER-consul.$TOP_LEVEL_DNS_ZONE_NAME:443 $ANSIBLE_SSH_USER@$OCI_LOCAL_REGION-$ENVIRONMENT-ssh.$DEFAULT_DNS_ZONE_NAME
-if [ $? -ne 0 ]; then
-  echo "Failed to open the consul tunnel, exiting"
-  exit 2
-fi
-
-OCI_CONSUL_HOST="consul-local.$TOP_LEVEL_DNS_ZONE_NAME"
-OCI_CONSUL_URL="https://$OCI_CONSUL_HOST:$PORT_OCI"
-
 FINAL_RET=0
 for REGION in $REGIONS; do
-  KV_URL="$OCI_CONSUL_URL/v1/kv/gitea-mirror/sync-trigger?dc=$ENVIRONMENT-$REGION"
-  RESPONSE=$(curl -s --resolve $OCI_CONSUL_HOST:$PORT_OCI:127.0.0.1 -d "$TRIGGER_VALUE" -X PUT "$KV_URL")
+  # Each region's consul is reached directly. dc is still named explicitly so the
+  # write cannot land in a neighbouring datacenter if a hostname is ever repointed.
+  REGION_CONSUL_HOST="$CONSUL_HOST"
+  [ -z "$REGION_CONSUL_HOST" ] && REGION_CONSUL_HOST="$ENVIRONMENT-$REGION-consul.$TOP_LEVEL_DNS_ZONE_NAME"
+  KV_URL="https://$REGION_CONSUL_HOST/v1/kv/gitea-mirror/sync-trigger?dc=$ENVIRONMENT-$REGION"
+
+  RESPONSE=$(curl -s -m 20 -d "$TRIGGER_VALUE" -X PUT "$KV_URL")
   if [ $? -eq 0 ] && [ "$RESPONSE" == "true" ]; then
     echo "triggered a mirror sync in $ENVIRONMENT-$REGION for '$TRIGGER_VALUE'"
   else
@@ -83,8 +67,5 @@ for REGION in $REGIONS; do
     FINAL_RET=1
   fi
 done
-
-SSH_OCI_PID=$(ps auxww | grep "ssh \-fNT -L127.0.0.1:$PORT_OCI" | grep -v grep | awk '{print $2}')
-[ -n "$SSH_OCI_PID" ] && kill $SSH_OCI_PID
 
 exit $FINAL_RET


### PR DESCRIPTION
## JIT-16092 — Stage 1: per-region Gitea mirror

Stands up a per-region Gitea pull-mirror so VM boots can clone the infra repos from an always-available in-region mirror instead of GitHub SSH deploy keys — the failure class that took down `prod-8x8` JVB provisioning during the 2026-07-21 GitHub deploy-key incident. See `doc/git-mirror-bootstrap-plan.md`.

### What's here (stage 1 only)
- **`nomad/gitea-mirror.hcl`** — modeled on `nomad/ops-repo.hcl`: `count=2`, `distinct_hosts`, `general` pool, bridge network, **no host volume** (ephemeral alloc-dir state, re-mirrored on reschedule). Three tasks:
  - `init` (prestart): creates the Gitea admin + a scoped seed token via the gitea CLI against the shared alloc dir.
  - `gitea`: serves git over HTTP through Fabio (`int-urlprefix`, internal-only).
  - `sync-gate` (poststart sidecar): idempotently migrates each repo as a pull-mirror from GitHub over **HTTPS+token** (never the SSH deploy key), and serves `/ready` — returns 503 until every required repo reports `empty:false`, so Fabio never routes to a cold replica (`check_restart { limit = 0 }`).
  - Public repos mirrored anonymously; `infra-customizations-private` stays private.
- **`scripts/deploy-nomad-gitea-mirror.sh`** — `dc=$ENVIRONMENT-$ORACLE_REGION`, per-region mirror hostname; `jitsi-meet` mirrored only in `us-phoenix-1`.
- **`doc/git-mirror-bootstrap-plan.md`** — resolves the three open questions and records stage status.

### Deploy prereqs
Seed Vault `secret/default/gitea/admin` (username/password/email) and `secret/default/gitea/github` (GitHub PAT with read on `infra-customizations-private`).

### Not in this PR (held until stage 1 is verified per region)
- Vault instance-policy grant for the Gitea read-token → jitsi/infra-customizations-private PR (separate).
- Boot-path `fetch_credentials` rewrite (stage 3) in infra-configuration.

### Validation
`nomad job validate` passes (incl. the list-var path the deploy script uses); embedded Python gate passes `py_compile`; `bash -n` on the deploy script.

Stage-1 verification to watch on canary: the gitea admin/seed bootstrap (`environment-to-ini` output path + `gitea admin user create`/`generate-access-token` flags) against the pinned `gitea/gitea:1.22` image.
