### PR TITLE
fix(selenium-grid): install a ChromeDriver matched to Chrome Beta

### DIFF
--- a/docker/selenium-grid-node/Dockerfile
+++ b/docker/selenium-grid-node/Dockerfile
@@ -71,6 +71,64 @@ RUN if [ "$(dpkg --print-architecture)" = "amd64" ]; then \
     && chown -R ${SEL_UID}:${SEL_GID} /opt/selenium/browsers/chrome_beta; \
   fi
 
+#============================================
+# ChromeDriver for Chrome Beta (amd64 only)
+#
+# The base image ships a single chromedriver, matched to its google-chrome-stable.
+# Chrome Beta is a major version ahead and chromedriver enforces a major-version
+# match, so the beta stereotype needs a driver of its own -- otherwise every
+# jitsi-beta session fails with "This version of ChromeDriver only supports
+# Chrome version N". Resolve it from Chrome for Testing against the exact beta
+# build frozen into the image just above.
+#============================================
+RUN if [ "$(dpkg --print-architecture)" = "amd64" ]; then \
+    set -eu; \
+    SE_CHROMEDRIVER_BETA=/opt/selenium/chromedriver-beta; \
+    CFT_BASE="https://googlechromelabs.github.io/chrome-for-testing"; \
+    CHROME_BETA_VERSION="$(cat /opt/selenium/browsers/chrome_beta/version)"; \
+    CHROME_BETA_BUILD="$(echo "${CHROME_BETA_VERSION}" | cut -d. -f1-3)"; \
+    CHROME_BETA_MAJOR="$(echo "${CHROME_BETA_VERSION}" | cut -d. -f1)"; \
+    echo "Chrome Beta ${CHROME_BETA_VERSION} (build ${CHROME_BETA_BUILD})"; \
+    curl -sSf -o /tmp/cft-builds.json "${CFT_BASE}/latest-patch-versions-per-build-with-downloads.json"; \
+    DRIVER_URL="$(jq -r --arg b "${CHROME_BETA_BUILD}" \
+      '.builds[$b].downloads.chromedriver[]? | select(.platform == "linux64") | .url' \
+      /tmp/cft-builds.json)"; \
+    if [ -z "${DRIVER_URL}" ]; then \
+      echo "No ChromeDriver for build ${CHROME_BETA_BUILD}, falling back to the latest ${CHROME_BETA_MAJOR}.x build"; \
+      DRIVER_URL="$(jq -r --arg m "${CHROME_BETA_MAJOR}" \
+        '[.builds | to_entries[] | select(.key | startswith($m + "."))] \
+         | sort_by(.value.version | split(".") | map(tonumber)) | last \
+         | .value.downloads.chromedriver[]? | select(.platform == "linux64") | .url' \
+        /tmp/cft-builds.json)"; \
+    fi; \
+    if [ -z "${DRIVER_URL}" ]; then \
+      echo "No ChromeDriver for major ${CHROME_BETA_MAJOR}, falling back to the Beta channel"; \
+      curl -sSf -o /tmp/cft-channels.json "${CFT_BASE}/last-known-good-versions-with-downloads.json"; \
+      DRIVER_URL="$(jq -r \
+        '.channels.Beta.downloads.chromedriver[]? | select(.platform == "linux64") | .url' \
+        /tmp/cft-channels.json)"; \
+    fi; \
+    if [ -z "${DRIVER_URL}" ]; then \
+      echo "FATAL: could not resolve a ChromeDriver for Chrome Beta ${CHROME_BETA_VERSION}"; \
+      exit 1; \
+    fi; \
+    echo "Using ChromeDriver from ${DRIVER_URL}"; \
+    curl -sSfL -o /tmp/chromedriver-beta.zip "${DRIVER_URL}"; \
+    python3 -c "import sys, zipfile; zipfile.ZipFile(sys.argv[1]).extractall(sys.argv[2])" \
+      /tmp/chromedriver-beta.zip /tmp/chromedriver-beta; \
+    find /tmp/chromedriver-beta -type f -name chromedriver -exec mv {} "${SE_CHROMEDRIVER_BETA}" \; ; \
+    rm -rf /tmp/chromedriver-beta /tmp/chromedriver-beta.zip /tmp/cft-builds.json /tmp/cft-channels.json; \
+    chmod 755 "${SE_CHROMEDRIVER_BETA}"; \
+    chown ${SEL_UID}:${SEL_GID} "${SE_CHROMEDRIVER_BETA}"; \
+    DRIVER_VERSION="$("${SE_CHROMEDRIVER_BETA}" --version | awk '{print $2}')"; \
+    if [ "$(echo "${DRIVER_VERSION}" | cut -d. -f1)" != "${CHROME_BETA_MAJOR}" ]; then \
+      echo "FATAL: ChromeDriver ${DRIVER_VERSION} does not match Chrome Beta ${CHROME_BETA_VERSION}"; \
+      exit 1; \
+    fi; \
+    echo "${DRIVER_VERSION}" > /opt/selenium/browsers/chrome_beta/driver_version; \
+    chown ${SEL_UID}:${SEL_GID} /opt/selenium/browsers/chrome_beta/driver_version; \
+  fi
+
 #=========
 # Firefox
 #=========
@@ -182,5 +240,13 @@ ENV SE_NODE_BROWSER_VERSION_CHROME=jitsi-stable \
     SE_NODE_BROWSER_VERSION_CHROME_BETA=jitsi-beta \
     SE_NODE_BROWSER_VERSION_FIREFOX=jitsi-stable \
     SE_NODE_BROWSER_VERSION_FIREFOX_BETA=jitsi-beta
+
+# Point the chrome_beta stereotype at the beta-matched ChromeDriver installed above.
+# generate_config resolves the _CHROME_BETA suffix per browser directory (same
+# mechanism as SE_NODE_BROWSER_VERSION_CHROME_BETA) and json-merges this into that
+# stereotype only; the stable slots keep the base image's chromedriver on PATH.
+# Selenium reads se:webDriverExecutable off the stereotype in LocalNodeFactory and
+# passes it to DriverService.Builder.usingDriverExecutable().
+ENV SE_NODE_STEREOTYPE_EXTRA_CHROME_BETA='{"se:webDriverExecutable": "/opt/selenium/chromedriver-beta"}'
 
 USER ${SEL_UID}


### PR DESCRIPTION
## Problem

The nightly torture run failed **42/42 specs, with zero tests executed**. Every worker died at session creation:

```
session not created: This version of ChromeDriver only supports Chrome version 151
Current browser version is 153.0.8010.5 with binary path /usr/bin/google-chrome-beta
```

`docker/selenium-grid-node/Dockerfile` installs `google-chrome-beta` and registers it as a second stereotype, but **never installs a ChromeDriver for it**. GeckoDriver gets an explicit install; ChromeDriver is inherited entirely from `selenium/node-chrome:nightly`, which ships exactly one driver — matched to its own `google-chrome-stable`. ChromeDriver enforces a major-version match, and beta is by definition a major ahead, so the `jitsi-beta` slot points the stable driver at the beta binary.

`apt-mark hold` freezes both browsers into the image, so the drift widens between rebuilds rather than self-healing.

The blast radius was larger than the beta slots alone: a multiremote spec can't start with one instance down, so `p1` (pinned to `jitsi-beta` in `tests/wdio.conf.ts`) failing killed every spec.

## Changes

**1. `fix(selenium-grid)`: install a beta-matched ChromeDriver**

New amd64-only step after the Chrome Beta block, so it reads the version that step just froze in. Resolution order:

1. Exact build from CfT `latest-patch-versions-per-build-with-downloads.json` (`153.0.8010` → `153.0.8010.12`)
2. Latest `MAJOR.x` build — a major match is all ChromeDriver requires
3. The CfT `Beta` channel
4. Otherwise **fail the build**

Plus a hard guard: build fails if the installed driver's major ≠ Chrome Beta's major. Today a mismatch only surfaces at 03:00 in the nightly; this moves it to build time.

Wired to the beta stereotype only:

```dockerfile
ENV SE_NODE_STEREOTYPE_EXTRA_CHROME_BETA='{"se:webDriverExecutable": "/opt/selenium/chromedriver-beta"}'
```

No `generate_config` patch needed — `SE_NODE_STEREOTYPE_EXTRA` is in the script's `ENV_PREFIXES`, so the `_CHROME_BETA` suffix scopes it to that browser directory, same mechanism as the existing `SE_NODE_BROWSER_VERSION_CHROME_BETA`. Stable slots keep the base image's driver on PATH.

Extraction uses `python3 -c … zipfile` rather than `unzip`, since the preceding step wipes `/var/lib/apt/lists`.

**2. `chore(selenium-grid)`: bump grid hub to Selenium 4.47**

The nodes track `:nightly` and reported `4.48.0-SNAPSHOT` in the failure logs while the hub reported `4.41.0`.

## Testing

- **Capability route** — [`LocalNodeFactory.java:157`](https://github.com/SeleniumHQ/selenium/blob/trunk/java/src/org/openqa/selenium/grid/node/local/LocalNodeFactory.java#L157) reads `se:webDriverExecutable` straight off `stereotype.asMap()` and passes it to `usingDriverExecutable()`, so setting it via the stereotype is equivalent to the `webdriver-executable` TOML key.
- **Generated config** — ran the real upstream `generate_config` with this repo's three sed patches applied, inside a Selenium image. The beta slot gets `"se:webDriverExecutable":"/opt/selenium/chromedriver-beta"`; the stable slot does not. `se:browserVersion` and the `jitsi-stable`/`jitsi-beta` labels still come out correctly.
- **Install step executed on `linux/amd64`** with `153.0.8010.5` stubbed as the beta version: resolved and installed `ChromeDriver 153.0.8010.12`, mode 755, owned `SEL_UID:SEL_GID`, `/tmp` left clean. The major-match guard was also confirmed to fail correctly when the driver couldn't report a version.
- **Shell syntax** — `sh -n` (POSIX) after joining Docker's line continuations the way the parser does; asserted no `#` inside the `RUN`, since joining would comment out the remainder.

Not done: a full `buildx --push` two-platform build. Worth one local build before merge:

```
docker buildx build --platform=linux/amd64 --pull --progress=plain --build-arg CACHEBUST=$(date +%s) --load -t selenium-node-mixed:beta-driver-test docker/selenium-grid-node
```

## Caveats

- Image builds now depend on `googlechromelabs.github.io` being reachable from the builder.
- The build will fail loudly if apt's Chrome Beta ever outruns CfT's published drivers. Intended, but it is a behavior change.

## Out of scope

Sessions leak on partial multiremote init failure — 37 created, 0 deleted across the run, which saturated the 2-node grid ~75s in and turned the remaining 17 specs into `session` timeouts. That belongs in `jitsi-meet`'s wdio setup, not here.
