### PR TITLE
fix: durably tear down secondary VNIC to prevent stale routes surviving boot

### DIFF
--- a/terraform/lib/postinstall-eip-lib.sh
+++ b/terraform/lib/postinstall-eip-lib.sh
@@ -79,7 +79,69 @@ function switch_to_primary_vnic() {
 
   echo "Delete secondary NIC routing to avoid routing issues in the future"
   sudo /usr/local/bin/secondary_vnic_all_configure_oracle.sh -d || status_code=1
+
+  # secondary_vnic_all_configure_oracle.sh -d only removes the live `ip addr`.
+  # If cloud-init's network-config stage saw the secondary VNIC in instance
+  # metadata before this script ran (a race against OCI's metadata-service
+  # lag - see check_secondary_ip), it will have already written a permanent
+  # static entry for it into netplan. systemd-networkd enforces that
+  # declaratively and re-applies the address, silently undoing the `ip addr
+  # del` above and leaving a stale on-link route to the private subnet that
+  # breaks inbound connections from other hosts on that subnet (e.g.
+  # Prometheus, Consul) for the rest of the instance's life. Purge the
+  # netplan entry too so nothing re-applies it, on this boot or the next.
+  # Best-effort: do not fail the whole postinstall over a cleanup step.
+  purge_secondary_vnic_netplan || echo "WARNING: failed to purge secondary VNIC from netplan; instance may retain a stale route to the private subnet"
+
   return $status_code
+}
+
+function purge_secondary_vnic_netplan() {
+  local netplan_file="/etc/netplan/50-cloud-init.yaml"
+  if [ ! -f "$netplan_file" ]; then
+    echo "No $netplan_file found, nothing to purge"
+    return 0
+  fi
+
+  local secondary_mac
+  secondary_mac=$(fetch_vnics_metadata | jq -r '.[1].macAddr // empty')
+  if [ -z "$secondary_mac" ]; then
+    echo "Could not determine secondary VNIC MAC from metadata, skipping netplan purge"
+    return 1
+  fi
+
+  sudo python3 - "$netplan_file" "$secondary_mac" <<'PYEOF'
+import sys
+import yaml
+
+path, mac = sys.argv[1], sys.argv[2].lower()
+
+with open(path) as f:
+    config = yaml.safe_load(f) or {}
+
+ethernets = config.get("network", {}).get("ethernets", {})
+removed = [
+    name for name, cfg in list(ethernets.items())
+    if (cfg or {}).get("match", {}).get("macaddress", "").lower() == mac
+]
+
+for name in removed:
+    del ethernets[name]
+
+if removed:
+    with open(path, "w") as f:
+        yaml.safe_dump(config, f, default_flow_style=False)
+    print(f"Removed netplan entries for {mac}: {removed}")
+else:
+    print(f"No netplan entry found for {mac}, nothing to remove")
+PYEOF
+  local py_status=$?
+  if [ $py_status -ne 0 ]; then
+    return 1
+  fi
+
+  echo "Re-applying netplan so the secondary VNIC config change takes effect"
+  sudo netplan apply || return 1
 }
 
 function assign_reserved_public_ip() {


### PR DESCRIPTION
## Problem

Some coturn instances (and any others using the `eip_assign` secondary-VNIC dance) end up with a permanent on-link route to the private subnet through their secondary VNIC, even though `postinstall-eip-lib.sh`'s `switch_to_primary_vnic()` successfully tears the secondary VNIC's IP down at boot (confirmed in `cloud-init-output.log`: `"removed IP address ... from interface enp1s0"`, exit 0).

Root cause: cloud-init's own network-config stage runs *before* the userdata postinstall script and independently queries the same metadata endpoint (`/opc/v1/vnics/`). If OCI's metadata service happens to report the secondary VNIC early (a race — see the "control-plane lag" handling this same file already has in `check_secondary_ip`/`EIP_SECONDARY_IP_RETRIES`, and #1140's writeup of the same lag causing a JVB zombie via the *opposite* timing), cloud-init bakes a permanent static address for it into `/etc/netplan/50-cloud-init.yaml`. `systemd-networkd` then continuously enforces that declarative config, silently re-applying the address that `switch_to_primary_vnic()` just removed with `ip addr del`.

The result: any internal host on that private subnet (Prometheus, Consul servers, other Nomad clients) gets a broken TCP handshake when talking to the instance's primary IP, because replies get routed out the secondary interface with the wrong source address. The instance itself looks completely healthy the whole time — telegraf, Nomad, Consul, coturn all fine — this only shows up as unreachability from specific internal subnets, e.g. a Prometheus metrics gap.

Confirmed on live `meet-jit-si` coturn nodes: of 12 current instances across 3 regions, 11 have this stale route (all with a netplan entry for the secondary VNIC's MAC); the one without it is the only one reachable internally.

## Fix

`switch_to_primary_vnic()` now also purges the secondary VNIC's entry from netplan (matched by MAC from instance metadata, not by interface name, since device naming isn't guaranteed stable) and runs `netplan apply`, so nothing resurrects the address on this boot or a later one. This is *in addition to* the existing `secondary_vnic_all_configure_oracle.sh -d` call, not a replacement for it — that still handles immediate live cleanup.

Best-effort: a failure to purge netplan logs a warning but does not fail the overall postinstall/terminate the instance, consistent with #1140's philosophy of not terminating otherwise-healthy instances over a secondary concern.

Validated: `bash -n` on the assembled coturn user-data (header + lib + eip-lib + coturn runner + footer) passes. The netplan-editing logic was tested against copies of both a live broken node's config (correctly removes only the secondary VNIC's stanza, leaves the primary interface untouched) and a live working node's config (correct no-op, byte-identical output).

## Follow-ups (not in this PR)

- The 11 already-affected `meet-jit-si` coturn instances still need this fix applied and the live secondary VNIC address/route cleared — a rotation or manual remediation, not a config-only fix.
- Same secondary-VNIC dance is used by other instance classes beyond coturn (anything using `eip_assign`) — worth checking if any show the same drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)