### PR TITLE
feat(selenium-grid): single Selenium version, arm64-only nodes, current Chrome + drivers, fortnightly auto-update

### DIFF
--- a/docker/selenium-grid-node/Dockerfile
+++ b/docker/selenium-grid-node/Dockerfile
@@ -1,11 +1,14 @@
-# amd64: Chrome only (Firefox installed via apt below)
-FROM --platform=linux/amd64 selenium/node-chrome:nightly AS base-amd64
-
-# arm64: Chromium only (Firefox installed via apt below)
-FROM --platform=linux/arm64 selenium/node-chromium:nightly AS base-arm64
-
-# Select the correct base for the target platform
-FROM base-${TARGETARCH}
+# arm64 only. Google now ships Chrome for linux-arm64 (stable, beta and canary
+# debs are in the apt repo) and Chrome for Testing publishes linux-arm64
+# chromedrivers from Chrome 153 onwards, so the amd64 half of this image is no
+# longer needed -- both browser channels run natively on ARM nodes.
+#
+# SELENIUM_VERSION pins the Grid version for the node image; the same variable
+# feeds the hub image (see scripts/selenium-version.sh) so the
+# two cannot drift apart. Previously this tracked :nightly, which meant the node
+# Selenium version -- and the stable browser -- changed silently on every rebuild.
+ARG SELENIUM_VERSION=4.47
+FROM selenium/node-chromium:${SELENIUM_VERSION}
 
 USER root
 
@@ -18,8 +21,8 @@ COPY --chown="${SEL_UID}:${SEL_GID}" chrome-cleanup.sh /opt/bin/chrome-cleanup.s
 COPY --chown="${SEL_UID}:${SEL_GID}" chrome-cleanup.conf /etc/supervisor/conf.d/chrome-cleanup.conf
 RUN chmod +x /opt/bin/firefox-cleanup.sh /opt/bin/chrome-cleanup.sh
 
-COPY --chown="${SEL_UID}:${SEL_GID}" get_lang_package.sh install-firefox-apt.sh /opt/bin/
-RUN chmod +x /opt/bin/get_lang_package.sh /opt/bin/install-firefox-apt.sh
+COPY --chown="${SEL_UID}:${SEL_GID}" get_lang_package.sh install-firefox-apt.sh install-chrome-channel.sh /opt/bin/
+RUN chmod +x /opt/bin/get_lang_package.sh /opt/bin/install-firefox-apt.sh /opt/bin/install-chrome-channel.sh
 
 # Patch upstream generate_config:
 #   - short_version returns the full version (not major.minor[0])
@@ -32,102 +35,28 @@ RUN sed -i 's/echo "${__major}.${__minor:0:1}"/echo "${__long_version}"/' /opt/b
 # Bust cache for all dynamic-version installs below
 ARG CACHEBUST=1
 
-# Pin (apt-hold) the stable browser shipped by the base image so neither the
-# rest of this Dockerfile nor any runtime `apt upgrade` rolls it forward.
-# Each rebuild of this image picks up whatever the base nightly tag currently
-# ships, and that exact version is then frozen into the resulting image.
-RUN if [ "$(dpkg --print-architecture)" = "amd64" ]; then \
-      apt-mark hold google-chrome-stable; \
-    else \
-      apt-mark hold chromium; \
-    fi
-
-# Disable Chrome/Chromium in-browser auto-update via enterprise policy.
-# apt-mark hold already blocks the cron-driven apt path, but Chrome also
-# reads managed policies at launch — these flatly disable the updater.
-RUN if [ "$(dpkg --print-architecture)" = "amd64" ]; then \
-      mkdir -p /etc/opt/chrome/policies/managed \
-      && printf '{"AutoUpdateCheckPeriodMinutes": 0, "UpdateDefault": 0}\n' \
-           > /etc/opt/chrome/policies/managed/no-update.json; \
-    else \
-      mkdir -p /etc/chromium/policies/managed \
-      && printf '{"AutoUpdateCheckPeriodMinutes": 0, "UpdateDefault": 0}\n' \
-           > /etc/chromium/policies/managed/no-update.json; \
-    fi
+# Freeze the base image's Chromium so the CVE upgrade in the Firefox step below
+# cannot roll it forward. It is no longer the browser behind any stereotype --
+# the "chrome" browser dir it created is overwritten by the stable channel
+# install below -- but it stays installed as part of the base image.
+RUN apt-mark hold chromium || true
 
 #============================================
-# Chrome Beta (amd64 only) + browser metadata for upstream generate_config
-#============================================
-RUN if [ "$(dpkg --print-architecture)" = "amd64" ]; then \
-    apt-get update -qqy \
-    && apt-get -qqy --no-install-recommends install google-chrome-beta \
-    && apt-mark hold google-chrome-beta \
-    && rm -f /etc/cron.daily/google-chrome \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mkdir -p /opt/selenium/browsers/chrome_beta \
-    && echo "chrome" > /opt/selenium/browsers/chrome_beta/name \
-    && google-chrome-beta --version | awk '{print $3}' > /opt/selenium/browsers/chrome_beta/version \
-    && echo '{"goog:chromeOptions": {"binary": "${SE_BROWSER_BINARY_LOCATION:-/usr/bin/google-chrome-beta}"}}' > /opt/selenium/browsers/chrome_beta/binary_location \
-    && chown -R ${SEL_UID}:${SEL_GID} /opt/selenium/browsers/chrome_beta; \
-  fi
-
-#============================================
-# ChromeDriver for Chrome Beta (amd64 only)
+# Google Chrome stable + beta, each with a version-matched ChromeDriver
 #
-# The base image ships a single chromedriver, matched to its google-chrome-stable.
-# Chrome Beta is a major version ahead and chromedriver enforces a major-version
-# match, so the beta stereotype needs a driver of its own -- otherwise every
-# jitsi-beta session fails with "This version of ChromeDriver only supports
-# Chrome version N". Resolve it from Chrome for Testing against the exact beta
-# build frozen into the image just above.
+# Both channels come from Google's apt repo at build time, the way Chrome Beta
+# and Firefox already did, rather than from the base image. That decouples
+# browser versions from SELENIUM_VERSION: a rebuild picks up current Chrome
+# without moving the Grid version, and vice versa. The base image is not a
+# usable source for stable anyway -- docker-selenium had published no Chrome 152
+# images weeks after 152 went stable.
+#
+# Each channel gets its own driver because ChromeDriver enforces a major-version
+# match and the two channels are always a major apart. The build fails loudly if
+# a matching driver cannot be resolved.
 #============================================
-RUN if [ "$(dpkg --print-architecture)" = "amd64" ]; then \
-    set -eu; \
-    SE_CHROMEDRIVER_BETA=/opt/selenium/chromedriver-beta; \
-    CFT_BASE="https://googlechromelabs.github.io/chrome-for-testing"; \
-    CHROME_BETA_VERSION="$(cat /opt/selenium/browsers/chrome_beta/version)"; \
-    CHROME_BETA_BUILD="$(echo "${CHROME_BETA_VERSION}" | cut -d. -f1-3)"; \
-    CHROME_BETA_MAJOR="$(echo "${CHROME_BETA_VERSION}" | cut -d. -f1)"; \
-    echo "Chrome Beta ${CHROME_BETA_VERSION} (build ${CHROME_BETA_BUILD})"; \
-    curl -sSf -o /tmp/cft-builds.json "${CFT_BASE}/latest-patch-versions-per-build-with-downloads.json"; \
-    DRIVER_URL="$(jq -r --arg b "${CHROME_BETA_BUILD}" \
-      '.builds[$b].downloads.chromedriver[]? | select(.platform == "linux64") | .url' \
-      /tmp/cft-builds.json)"; \
-    if [ -z "${DRIVER_URL}" ]; then \
-      echo "No ChromeDriver for build ${CHROME_BETA_BUILD}, falling back to the latest ${CHROME_BETA_MAJOR}.x build"; \
-      DRIVER_URL="$(jq -r --arg m "${CHROME_BETA_MAJOR}" \
-        '[.builds | to_entries[] | select(.key | startswith($m + "."))] \
-         | sort_by(.value.version | split(".") | map(tonumber)) | last \
-         | .value.downloads.chromedriver[]? | select(.platform == "linux64") | .url' \
-        /tmp/cft-builds.json)"; \
-    fi; \
-    if [ -z "${DRIVER_URL}" ]; then \
-      echo "No ChromeDriver for major ${CHROME_BETA_MAJOR}, falling back to the Beta channel"; \
-      curl -sSf -o /tmp/cft-channels.json "${CFT_BASE}/last-known-good-versions-with-downloads.json"; \
-      DRIVER_URL="$(jq -r \
-        '.channels.Beta.downloads.chromedriver[]? | select(.platform == "linux64") | .url' \
-        /tmp/cft-channels.json)"; \
-    fi; \
-    if [ -z "${DRIVER_URL}" ]; then \
-      echo "FATAL: could not resolve a ChromeDriver for Chrome Beta ${CHROME_BETA_VERSION}"; \
-      exit 1; \
-    fi; \
-    echo "Using ChromeDriver from ${DRIVER_URL}"; \
-    curl -sSfL -o /tmp/chromedriver-beta.zip "${DRIVER_URL}"; \
-    python3 -c "import sys, zipfile; zipfile.ZipFile(sys.argv[1]).extractall(sys.argv[2])" \
-      /tmp/chromedriver-beta.zip /tmp/chromedriver-beta; \
-    find /tmp/chromedriver-beta -type f -name chromedriver -exec mv {} "${SE_CHROMEDRIVER_BETA}" \; ; \
-    rm -rf /tmp/chromedriver-beta /tmp/chromedriver-beta.zip /tmp/cft-builds.json /tmp/cft-channels.json; \
-    chmod 755 "${SE_CHROMEDRIVER_BETA}"; \
-    chown ${SEL_UID}:${SEL_GID} "${SE_CHROMEDRIVER_BETA}"; \
-    DRIVER_VERSION="$("${SE_CHROMEDRIVER_BETA}" --version | awk '{print $2}')"; \
-    if [ "$(echo "${DRIVER_VERSION}" | cut -d. -f1)" != "${CHROME_BETA_MAJOR}" ]; then \
-      echo "FATAL: ChromeDriver ${DRIVER_VERSION} does not match Chrome Beta ${CHROME_BETA_VERSION}"; \
-      exit 1; \
-    fi; \
-    echo "${DRIVER_VERSION}" > /opt/selenium/browsers/chrome_beta/driver_version; \
-    chown ${SEL_UID}:${SEL_GID} /opt/selenium/browsers/chrome_beta/driver_version; \
-  fi
+RUN /opt/bin/install-chrome-channel.sh stable
+RUN /opt/bin/install-chrome-channel.sh beta
 
 #=========
 # Firefox
@@ -236,17 +165,20 @@ RUN apt-get update -y && apt-get install -y iproute2 && rm -rf /var/lib/apt/list
 # browserVersion of "stable" as a wildcard that matches any stereotype (see SeleniumHQ
 # selenium#15481, Step 6), which would let "stable" requests land on beta-stereotype slots.
 ENV SE_NODE_BROWSER_VERSION_CHROME=jitsi-stable \
-    SE_NODE_BROWSER_VERSION_CHROMIUM=jitsi-stable \
     SE_NODE_BROWSER_VERSION_CHROME_BETA=jitsi-beta \
     SE_NODE_BROWSER_VERSION_FIREFOX=jitsi-stable \
     SE_NODE_BROWSER_VERSION_FIREFOX_BETA=jitsi-beta
 
-# Point the chrome_beta stereotype at the beta-matched ChromeDriver installed above.
-# generate_config resolves the _CHROME_BETA suffix per browser directory (same
-# mechanism as SE_NODE_BROWSER_VERSION_CHROME_BETA) and json-merges this into that
-# stereotype only; the stable slots keep the base image's chromedriver on PATH.
-# Selenium reads se:webDriverExecutable off the stereotype in LocalNodeFactory and
-# passes it to DriverService.Builder.usingDriverExecutable().
-ENV SE_NODE_STEREOTYPE_EXTRA_CHROME_BETA='{"se:webDriverExecutable": "/opt/selenium/chromedriver-beta"}'
+# Point each chrome stereotype at its own version-matched ChromeDriver. Neither
+# channel can use the base image's driver now: both are installed from Google's
+# apt repo, so neither is guaranteed to match what the base shipped.
+#
+# generate_config resolves the _CHROME / _CHROME_BETA suffixes per browser
+# directory (same mechanism as SE_NODE_BROWSER_VERSION_*) and json-merges these
+# into that stereotype only. Selenium reads se:webDriverExecutable off the
+# stereotype in LocalNodeFactory and passes it to
+# DriverService.Builder.usingDriverExecutable().
+ENV SE_NODE_STEREOTYPE_EXTRA_CHROME='{"se:webDriverExecutable": "/opt/selenium/chromedriver-stable"}' \
+    SE_NODE_STEREOTYPE_EXTRA_CHROME_BETA='{"se:webDriverExecutable": "/opt/selenium/chromedriver-beta"}'
 
 USER ${SEL_UID}

--- a/docker/selenium-grid-node/Dockerfile
+++ b/docker/selenium-grid-node/Dockerfile
@@ -7,7 +7,7 @@
 # feeds the hub image (see scripts/selenium-version.sh) so the
 # two cannot drift apart. Previously this tracked :nightly, which meant the node
 # Selenium version -- and the stable browser -- changed silently on every rebuild.
-ARG SELENIUM_VERSION=4.47
+ARG SELENIUM_VERSION=4.48.0
 FROM selenium/node-chromium:${SELENIUM_VERSION}
 
 USER root

--- a/docker/selenium-grid-node/build.sh
+++ b/docker/selenium-grid-node/build.sh
@@ -1,8 +1,21 @@
 #!/bin/bash
+LOCAL_PATH=$(dirname "${BASH_SOURCE[0]}")
+
+# One value drives both the node image base and the hub image tag.
+. "$LOCAL_PATH/../../scripts/selenium-version.sh"
+
 [ -z "$TAG" ] && TAG=$1
 # if not set tag is git short hash
 [ -z "$TAG" ] && TAG="$(git rev-parse --short HEAD)"
 
 [ -z "$PRIVATE_DOCKER_REGISTRY" ] && PRIVATE_DOCKER_REGISTRY="ops-prod-us-phoenix-1-registry.jitsi.net/selenium/node-mixed"
 
-docker buildx build --platform=linux/arm64,linux/amd64 --push --pull --progress=plain --build-arg CACHEBUST=$(date +%s) --tag $PRIVATE_DOCKER_REGISTRY:$TAG --tag $PRIVATE_DOCKER_REGISTRY:latest .
+echo "Building selenium grid node image: selenium $SELENIUM_VERSION, tag $TAG"
+
+# arm64 only: Google now ships Chrome for linux-arm64 and Chrome for Testing
+# publishes linux-arm64 chromedrivers from Chrome 153 onwards, so amd64 nodes
+# are no longer needed. Scale the x86 instance pool to 0 before rolling this out.
+docker buildx build --platform=linux/arm64 --push --pull --progress=plain \
+  --build-arg CACHEBUST=$(date +%s) \
+  --build-arg SELENIUM_VERSION="$SELENIUM_VERSION" \
+  --tag $PRIVATE_DOCKER_REGISTRY:$TAG --tag $PRIVATE_DOCKER_REGISTRY:latest .

--- a/docker/selenium-grid-node/install-chrome-channel.sh
+++ b/docker/selenium-grid-node/install-chrome-channel.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+#
+# Install one Google Chrome channel plus a ChromeDriver whose major version
+# matches it, and register both with upstream generate_config.
+#
+# Usage: install-chrome-channel.sh <stable|beta>
+#
+# The Selenium base images ship at most one chromedriver, matched to whatever
+# browser that image happens to carry. Both of our channels are installed from
+# Google's apt repo at build time, so neither is guaranteed to match -- and
+# ChromeDriver enforces a major-version match. Each channel therefore gets its
+# own driver resolved from Chrome for Testing.
+#
+# Fails the build if no matching driver can be resolved, rather than leaving a
+# stereotype that only breaks at session-creation time in the nightly run.
+
+set -eu
+
+CHANNEL="${1:?usage: install-chrome-channel.sh <stable|beta>}"
+CFT_BASE="https://googlechromelabs.github.io/chrome-for-testing"
+
+case "$CHANNEL" in
+  stable) BROWSER_DIR="chrome";      CFT_CHANNEL="Stable" ;;
+  beta)   BROWSER_DIR="chrome_beta"; CFT_CHANNEL="Beta" ;;
+  *) echo "FATAL: unknown channel '$CHANNEL' (expected stable or beta)"; exit 1 ;;
+esac
+
+PKG="google-chrome-${CHANNEL}"
+BIN="/usr/bin/${PKG}"
+DRIVER_PATH="/opt/selenium/chromedriver-${CHANNEL}"
+
+DPKG_ARCH="$(dpkg --print-architecture)"
+case "$DPKG_ARCH" in
+  amd64) CFT_PLATFORM="linux64" ;;
+  arm64) CFT_PLATFORM="linux-arm64" ;;
+  *) echo "FATAL: unsupported architecture '$DPKG_ARCH'"; exit 1 ;;
+esac
+
+#-------------------------------------------------------------------
+# Google's apt repo. Present already on the Chrome base images, absent
+# on node-chromium (which installs Chromium from Debian sid), so add it
+# idempotently rather than assuming either way.
+#-------------------------------------------------------------------
+if [ ! -f /etc/apt/sources.list.d/google-chrome.list ]; then
+  echo "Adding Google Chrome apt repository for ${DPKG_ARCH}"
+  mkdir -p /etc/apt/keyrings
+  curl -fsSL https://dl.google.com/linux/linux_signing_key.pub \
+    | gpg --dearmor -o /etc/apt/keyrings/google-chrome.gpg
+  chmod 644 /etc/apt/keyrings/google-chrome.gpg
+  echo "deb [arch=${DPKG_ARCH} signed-by=/etc/apt/keyrings/google-chrome.gpg] https://dl.google.com/linux/chrome/deb/ stable main" \
+    > /etc/apt/sources.list.d/google-chrome.list
+fi
+
+#-------------------------------------------------------------------
+# Browser. --only-upgrade is deliberately NOT used: we want whatever the
+# repo currently offers, installed fresh, then frozen into the image.
+#-------------------------------------------------------------------
+apt-get update -qqy
+apt-get -qqy --no-install-recommends install "$PKG"
+apt-mark hold "$PKG"
+
+# Stop the cron-driven updater and the in-browser one. apt-mark hold only
+# covers the apt path; Chrome also reads managed policy at launch.
+rm -f /etc/cron.daily/google-chrome
+mkdir -p /etc/opt/chrome/policies/managed
+printf '{"AutoUpdateCheckPeriodMinutes": 0, "UpdateDefault": 0}\n' \
+  > /etc/opt/chrome/policies/managed/no-update.json
+
+rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+
+BROWSER_VERSION="$("$BIN" --version | grep -oE '[0-9]+(\.[0-9]+)+' | head -1)"
+BROWSER_BUILD="$(echo "$BROWSER_VERSION" | cut -d. -f1-3)"
+BROWSER_MAJOR="$(echo "$BROWSER_VERSION" | cut -d. -f1)"
+echo "Installed ${PKG} ${BROWSER_VERSION} (build ${BROWSER_BUILD}, ${DPKG_ARCH})"
+
+#-------------------------------------------------------------------
+# Matching ChromeDriver from Chrome for Testing.
+#   1. the exact build
+#   2. the latest build of the same major (a major match is all
+#      ChromeDriver requires)
+#   3. the channel's current release
+#-------------------------------------------------------------------
+curl -sSf -o /tmp/cft-builds.json "${CFT_BASE}/latest-patch-versions-per-build-with-downloads.json"
+
+DRIVER_URL="$(jq -r --arg b "$BROWSER_BUILD" --arg p "$CFT_PLATFORM" \
+  '.builds[$b].downloads.chromedriver[]? | select(.platform == $p) | .url' \
+  /tmp/cft-builds.json)"
+
+if [ -z "$DRIVER_URL" ]; then
+  echo "No ChromeDriver for build ${BROWSER_BUILD}, trying the latest ${BROWSER_MAJOR}.x build"
+  DRIVER_URL="$(jq -r --arg m "$BROWSER_MAJOR" --arg p "$CFT_PLATFORM" \
+    '[.builds | to_entries[] | select(.key | startswith($m + "."))]
+     | sort_by(.value.version | split(".") | map(tonumber)) | last
+     | .value.downloads.chromedriver[]? | select(.platform == $p) | .url' \
+    /tmp/cft-builds.json)"
+fi
+
+if [ -z "$DRIVER_URL" ]; then
+  echo "No ChromeDriver for major ${BROWSER_MAJOR}, trying the ${CFT_CHANNEL} channel"
+  curl -sSf -o /tmp/cft-channels.json "${CFT_BASE}/last-known-good-versions-with-downloads.json"
+  DRIVER_URL="$(jq -r --arg c "$CFT_CHANNEL" --arg p "$CFT_PLATFORM" \
+    '.channels[$c].downloads.chromedriver[]? | select(.platform == $p) | .url' \
+    /tmp/cft-channels.json)"
+fi
+
+if [ -z "$DRIVER_URL" ]; then
+  echo "FATAL: Chrome for Testing publishes no ${CFT_PLATFORM} ChromeDriver for ${PKG} ${BROWSER_VERSION}."
+  echo "       linux-arm64 drivers exist from Chrome 153 onwards only."
+  exit 1
+fi
+
+echo "Using ChromeDriver from ${DRIVER_URL}"
+curl -sSfL -o /tmp/chromedriver.zip "$DRIVER_URL"
+rm -rf /tmp/chromedriver-extract
+python3 -c "import sys, zipfile; zipfile.ZipFile(sys.argv[1]).extractall(sys.argv[2])" \
+  /tmp/chromedriver.zip /tmp/chromedriver-extract
+find /tmp/chromedriver-extract -type f -name chromedriver -exec mv {} "$DRIVER_PATH" \;
+rm -rf /tmp/chromedriver-extract /tmp/chromedriver.zip /tmp/cft-builds.json /tmp/cft-channels.json
+chmod 755 "$DRIVER_PATH"
+
+DRIVER_VERSION="$("$DRIVER_PATH" --version | awk '{print $2}')"
+if [ "$(echo "$DRIVER_VERSION" | cut -d. -f1)" != "$BROWSER_MAJOR" ]; then
+  echo "FATAL: ChromeDriver ${DRIVER_VERSION} does not match ${PKG} ${BROWSER_VERSION}"
+  exit 1
+fi
+echo "ChromeDriver ${DRIVER_VERSION} matches ${PKG} ${BROWSER_VERSION}"
+
+#-------------------------------------------------------------------
+# Browser metadata for upstream generate_config. It walks
+# /opt/selenium/browsers/*/ and emits one stereotype per directory.
+#-------------------------------------------------------------------
+mkdir -p "/opt/selenium/browsers/${BROWSER_DIR}"
+echo "chrome" > "/opt/selenium/browsers/${BROWSER_DIR}/name"
+echo "$BROWSER_VERSION" > "/opt/selenium/browsers/${BROWSER_DIR}/version"
+echo "$DRIVER_VERSION" > "/opt/selenium/browsers/${BROWSER_DIR}/driver_version"
+echo "{\"goog:chromeOptions\": {\"binary\": \"\${SE_BROWSER_BINARY_LOCATION:-${BIN}}\"}}" \
+  > "/opt/selenium/browsers/${BROWSER_DIR}/binary_location"
+
+chown -R "${SEL_UID}:${SEL_GID}" "/opt/selenium/browsers/${BROWSER_DIR}"
+chown "${SEL_UID}:${SEL_GID}" "$DRIVER_PATH"

--- a/docker/selenium-grid-node/install-chrome-channel.sh
+++ b/docker/selenium-grid-node/install-chrome-channel.sh
@@ -68,7 +68,15 @@ printf '{"AutoUpdateCheckPeriodMinutes": 0, "UpdateDefault": 0}\n' \
 
 rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
-BROWSER_VERSION="$("$BIN" --version | grep -oE '[0-9]+(\.[0-9]+)+' | head -1)"
+# "Google Chrome 153.0.8010.12 beta" / "Google Chrome 152.0.7977.64" -> field 3.
+# Anchored on the known field rather than "first dotted number anywhere": both
+# BROWSER_MAJOR and the driver-major assertion derive from this value, so a bad
+# parse would move both sides together and the assertion could not catch it.
+BROWSER_VERSION="$("$BIN" --version | awk '{print $3}')"
+if ! echo "$BROWSER_VERSION" | grep -qE '^[0-9]+(\.[0-9]+){3}$'; then
+  echo "FATAL: could not parse a version from: $("$BIN" --version)"
+  exit 1
+fi
 BROWSER_BUILD="$(echo "$BROWSER_VERSION" | cut -d. -f1-3)"
 BROWSER_MAJOR="$(echo "$BROWSER_VERSION" | cut -d. -f1)"
 echo "Installed ${PKG} ${BROWSER_VERSION} (build ${BROWSER_BUILD}, ${DPKG_ARCH})"

--- a/docker/selenium-grid-node/install-chrome-channel.sh
+++ b/docker/selenium-grid-node/install-chrome-channel.sh
@@ -14,7 +14,7 @@
 # Fails the build if no matching driver can be resolved, rather than leaving a
 # stereotype that only breaks at session-creation time in the nightly run.
 
-set -eu
+set -euo pipefail
 
 CHANNEL="${1:?usage: install-chrome-channel.sh <stable|beta>}"
 CFT_BASE="https://googlechromelabs.github.io/chrome-for-testing"
@@ -38,18 +38,28 @@ esac
 
 #-------------------------------------------------------------------
 # Google's apt repo. Present already on the Chrome base images, absent
-# on node-chromium (which installs Chromium from Debian sid), so add it
-# idempotently rather than assuming either way.
+# on node-chromium (which installs Chromium from Debian sid), so write it
+# out on every run rather than assuming either way.
+#
+# Deliberately NOT guarded on "is google-chrome.list already there". The first
+# channel's postinst rewrites apt's configuration underneath us: it migrates
+# our .list into google-chrome.sources and then, seeing no deb line in the
+# .list but its own, takes the `rm -f "$LEGACY_LIST"` branch of
+# remove_legacy_list(). The second run therefore finds no .list, decides the
+# repo is missing, and re-runs this block -- at which point `gpg --dearmor`
+# hits an existing keyring, tries to ask whether to overwrite it, finds no
+# /dev/tty in a buildkit container and dies. Everything below is idempotent,
+# so just always do it.
 #-------------------------------------------------------------------
-if [ ! -f /etc/apt/sources.list.d/google-chrome.list ]; then
-  echo "Adding Google Chrome apt repository for ${DPKG_ARCH}"
-  mkdir -p /etc/apt/keyrings
-  curl -fsSL https://dl.google.com/linux/linux_signing_key.pub \
-    | gpg --dearmor -o /etc/apt/keyrings/google-chrome.gpg
-  chmod 644 /etc/apt/keyrings/google-chrome.gpg
-  echo "deb [arch=${DPKG_ARCH} signed-by=/etc/apt/keyrings/google-chrome.gpg] https://dl.google.com/linux/chrome/deb/ stable main" \
-    > /etc/apt/sources.list.d/google-chrome.list
-fi
+echo "Configuring the Google Chrome apt repository for ${DPKG_ARCH}"
+mkdir -p /etc/apt/keyrings
+# --batch --yes is what keeps the second run alive: without it gpg prompts
+# before clobbering the keyring the first run wrote.
+curl -fsSL https://dl.google.com/linux/linux_signing_key.pub \
+  | gpg --batch --yes --dearmor -o /etc/apt/keyrings/google-chrome.gpg
+chmod 644 /etc/apt/keyrings/google-chrome.gpg
+echo "deb [arch=${DPKG_ARCH} signed-by=/etc/apt/keyrings/google-chrome.gpg] https://dl.google.com/linux/chrome/deb/ stable main" \
+  > /etc/apt/sources.list.d/google-chrome.list
 
 #-------------------------------------------------------------------
 # Browser. --only-upgrade is deliberately NOT used: we want whatever the
@@ -73,7 +83,7 @@ rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 # BROWSER_MAJOR and the driver-major assertion derive from this value, so a bad
 # parse would move both sides together and the assertion could not catch it.
 BROWSER_VERSION="$("$BIN" --version | awk '{print $3}')"
-if ! echo "$BROWSER_VERSION" | grep -qE '^[0-9]+(\.[0-9]+){3}$'; then
+if ! [[ "$BROWSER_VERSION" =~ ^[0-9]+(\.[0-9]+){3}$ ]]; then
   echo "FATAL: could not parse a version from: $("$BIN" --version)"
   exit 1
 fi

--- a/jenkins/groovy/auto-update-selenium-grid/Jenkinsfile
+++ b/jenkins/groovy/auto-update-selenium-grid/Jenkinsfile
@@ -1,0 +1,90 @@
+// Fortnightly refresh of a Selenium grid.
+//
+// Rebuilding the node image is what picks up new browsers: Chrome stable and
+// beta are installed from Google's apt repo at build time, and each gets a
+// version-matched ChromeDriver resolved from Chrome for Testing. The Grid
+// version does not move -- that is pinned by SELENIUM_VERSION in clouds/all.sh
+// -- so this advances browsers only.
+//
+// The trigger fires every Wednesday 04:00 UTC and this keeps every other one.
+// Off-cadence weeks skip their stages and finish green: failing them would send
+// a failure notification every second Wednesday forever.
+
+def onCadence(anchor, force) {
+    if (force) {
+        echo "FORCE_RUN set, running regardless of cadence"
+        return true
+    }
+    // Whole days between the anchor and today, both at UTC midnight. Counting
+    // days rather than using ISO week parity keeps the cadence correct across
+    // the week-53 year boundary.
+    def days = sh(
+        returnStdout: true,
+        script: """#!/bin/bash
+            set -eu
+            anchor_epoch=\$(date -u -d "${anchor}" +%s)
+            today_epoch=\$(date -u -d "\$(date -u +%Y-%m-%d)" +%s)
+            echo \$(( (today_epoch - anchor_epoch) / 86400 ))
+        """
+    ).trim() as Integer
+
+    if (days < 0) {
+        echo "Cadence starts ${anchor}, ${-days} day(s) from now -- skipping"
+        return false
+    }
+    if (days % 14 != 0) {
+        echo "${days} day(s) since ${anchor} is not a multiple of 14 -- off-cadence week, skipping"
+        return false
+    }
+    echo "${days} day(s) since ${anchor} -- on cadence"
+    return true
+}
+
+pipeline {
+    agent any
+    options {
+        ansiColor('xterm')
+        timestamps()
+        buildDiscarder(logRotator(numToKeepStr: '30', artifactNumToKeepStr: '30'))
+    }
+    stages {
+        stage('Check cadence') {
+            steps {
+                script {
+                    env.ON_CADENCE = onCadence(params.SCHEDULE_ANCHOR, params.FORCE_RUN).toString()
+                    currentBuild.description = (env.ON_CADENCE == 'true')
+                        ? "updating ${params.GRID_NAME}"
+                        : 'off-cadence week, skipped'
+                }
+            }
+        }
+        stage('Rebuild node image') {
+            when { expression { env.ON_CADENCE == 'true' } }
+            steps {
+                script {
+                    // TAG is left unset so build.sh tags with the git short hash and
+                    // also moves :latest, which is what the node job deploys.
+                    build job: 'build-docker-image-selenium-grid-node', parameters: [
+                        [$class: 'StringParameterValue', name: 'VIDEO_INFRA_BRANCH', value: params.VIDEO_INFRA_BRANCH]
+                    ]
+                }
+            }
+        }
+        stage('Redeploy grid') {
+            when { expression { env.ON_CADENCE == 'true' } }
+            steps {
+                script {
+                    // UPGRADE_GRID stays false: with it set, terraform re-applies the
+                    // instance pools and resets their sizes to the script defaults.
+                    build job: 'provision-selenium-grid', parameters: [
+                        [$class: 'StringParameterValue', name: 'VIDEO_INFRA_BRANCH', value: params.VIDEO_INFRA_BRANCH],
+                        [$class: 'StringParameterValue', name: 'GRID_NAME', value: params.GRID_NAME],
+                        [$class: 'StringParameterValue', name: 'ENVIRONMENT', value: params.ENVIRONMENT],
+                        [$class: 'StringParameterValue', name: 'ORACLE_REGION', value: params.ORACLE_REGION],
+                        [$class: 'BooleanParameterValue', name: 'UPGRADE_GRID', value: false]
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/jenkins/groovy/auto-update-selenium-grid/Jenkinsfile
+++ b/jenkins/groovy/auto-update-selenium-grid/Jenkinsfile
@@ -3,12 +3,39 @@
 // Rebuilding the node image is what picks up new browsers: Chrome stable and
 // beta are installed from Google's apt repo at build time, and each gets a
 // version-matched ChromeDriver resolved from Chrome for Testing. The Grid
-// version does not move -- that is pinned by SELENIUM_VERSION in clouds/all.sh
-// -- so this advances browsers only.
+// version does not move -- that is pinned by SELENIUM_VERSION in
+// scripts/selenium-version.sh -- so this advances browsers only.
 //
 // The trigger fires every Wednesday 04:00 UTC and this keeps every other one.
 // Off-cadence weeks skip their stages and finish green: failing them would send
 // a failure notification every second Wednesday forever.
+//
+// The image is built and deployed under an immutable tag (<git-sha>-<date>).
+// Deploying ":latest" would not roll anything: an unchanged nomad job spec
+// produces no new allocations, so running nodes keep the cached image and the
+// rebuild would never reach the grid.
+
+// SCHEDULE_ANCHOR is operator-editable free text that gets interpolated into a
+// shell command, so validate it before use: a value `date` cannot parse would
+// abort the build (the failure this design avoids), and a crafted value would
+// execute on the agent.
+def validateAnchor(anchor) {
+    if (!(anchor ==~ /\d{4}-\d{2}-\d{2}/)) {
+        error("SCHEDULE_ANCHOR must be YYYY-MM-DD, got: '${anchor}'")
+    }
+    // The cron only fires on Wednesdays and `days % 14 == 0` can only be true on
+    // the anchor's own weekday, so a non-Wednesday anchor would make the job
+    // never run on-cadence -- silently, with no error.
+    // Format alone is not enough: 2026-13-09 matches the regex but is not a date.
+    def dow = sh(returnStdout: true,
+                 script: "date -u -d '${anchor}' +%u 2>/dev/null || echo invalid").trim()
+    if (dow == 'invalid') {
+        error("SCHEDULE_ANCHOR '${anchor}' is not a real date")
+    }
+    if (dow != '3') {
+        error("SCHEDULE_ANCHOR ${anchor} is weekday ${dow}; it must be a Wednesday (3) to match the cron trigger")
+    }
+}
 
 def onCadence(anchor, force) {
     if (force) {
@@ -51,10 +78,19 @@ pipeline {
         stage('Check cadence') {
             steps {
                 script {
+                    validateAnchor(params.SCHEDULE_ANCHOR)
                     env.ON_CADENCE = onCadence(params.SCHEDULE_ANCHOR, params.FORCE_RUN).toString()
-                    currentBuild.description = (env.ON_CADENCE == 'true')
-                        ? "updating ${params.GRID_NAME}"
-                        : 'off-cadence week, skipped'
+                    if (env.ON_CADENCE == 'true') {
+                        // Date is part of the tag on purpose: the git sha alone does not
+                        // change between fortnights when no code landed, so it would not
+                        // force a new nomad deployment even though the browsers moved.
+                        def sha = sh(returnStdout: true, script: 'git rev-parse --short HEAD').trim()
+                        def stamp = sh(returnStdout: true, script: 'date -u +%Y%m%d').trim()
+                        env.IMAGE_TAG = "${sha}-${stamp}"
+                        currentBuild.description = "updating ${params.GRID_NAME} @ ${env.IMAGE_TAG}"
+                    } else {
+                        currentBuild.description = 'off-cadence week, skipped'
+                    }
                 }
             }
         }
@@ -62,10 +98,10 @@ pipeline {
             when { expression { env.ON_CADENCE == 'true' } }
             steps {
                 script {
-                    // TAG is left unset so build.sh tags with the git short hash and
-                    // also moves :latest, which is what the node job deploys.
+                    // build.sh also moves :latest, so manual deploys stay current.
                     build job: 'build-docker-image-selenium-grid-node', parameters: [
-                        [$class: 'StringParameterValue', name: 'VIDEO_INFRA_BRANCH', value: params.VIDEO_INFRA_BRANCH]
+                        [$class: 'StringParameterValue', name: 'VIDEO_INFRA_BRANCH', value: params.VIDEO_INFRA_BRANCH],
+                        [$class: 'StringParameterValue', name: 'TAG', value: env.IMAGE_TAG]
                     ]
                 }
             }
@@ -76,11 +112,14 @@ pipeline {
                 script {
                     // UPGRADE_GRID stays false: with it set, terraform re-applies the
                     // instance pools and resets their sizes to the script defaults.
+                    // IMAGE_VERSION is what actually rolls the nodes -- it changes the
+                    // job spec, so nomad creates new allocations on the new image.
                     build job: 'provision-selenium-grid', parameters: [
                         [$class: 'StringParameterValue', name: 'VIDEO_INFRA_BRANCH', value: params.VIDEO_INFRA_BRANCH],
                         [$class: 'StringParameterValue', name: 'GRID_NAME', value: params.GRID_NAME],
                         [$class: 'StringParameterValue', name: 'ENVIRONMENT', value: params.ENVIRONMENT],
                         [$class: 'StringParameterValue', name: 'ORACLE_REGION', value: params.ORACLE_REGION],
+                        [$class: 'StringParameterValue', name: 'IMAGE_VERSION', value: env.IMAGE_TAG],
                         [$class: 'BooleanParameterValue', name: 'UPGRADE_GRID', value: false]
                     ]
                 }

--- a/jenkins/groovy/auto-update-selenium-grid/Jenkinsfile
+++ b/jenkins/groovy/auto-update-selenium-grid/Jenkinsfile
@@ -10,10 +10,24 @@
 // Off-cadence weeks skip their stages and finish green: failing them would send
 // a failure notification every second Wednesday forever.
 //
-// The image is built and deployed under an immutable tag (<git-sha>-<date>).
-// Deploying ":latest" would not roll anything: an unchanged nomad job spec
-// produces no new allocations, so running nodes keep the cached image and the
-// rebuild would never reach the grid.
+// The image is built and deployed under an immutable tag
+// (<git-sha>-<date>-b<build>). Deploying ":latest" would not roll anything: an
+// unchanged nomad job spec produces no new allocations, so running nodes keep
+// the cached image and the rebuild would never reach the grid.
+//
+// ASSUMES A NOMAD-BASED GRID. The image roll works through the nomad node job
+// (force_pull plus a changed image tag). On a plain OCI instance-pool grid,
+// provision-selenium-grid runs create-selenium-grid-oracle.sh, which sets
+// RUN_TF=false when UPGRADE_GRID != true, so no instance is recycled and the
+// running nodes keep the image they booted with -- this job would then finish
+// green while updating nothing. Whether a grid is nomad-based is decided by the
+// selenium_grid_nomad_enabled ansible var, which lives outside this repo, so it
+// cannot be asserted here.
+//
+// Note: passing SELENIUM_GRID_NOMAD_ENABLED=true to provision-selenium-grid is
+// NOT the fix. That flag forces the nomad path rather than verifying it, so on a
+// genuinely instance-pool grid it would deploy nomad jobs that do not belong
+// there. Point this job only at grids already known to be nomad-based.
 
 // SCHEDULE_ANCHOR is operator-editable free text that gets interpolated into a
 // shell command, so validate it before use: a value `date` cannot parse would
@@ -84,9 +98,12 @@ pipeline {
                         // Date is part of the tag on purpose: the git sha alone does not
                         // change between fortnights when no code landed, so it would not
                         // force a new nomad deployment even though the browsers moved.
+                        // BUILD_NUMBER keeps the tag unique within a day, so a FORCE_RUN,
+                        // a retry or a same-day code push cannot overwrite an image that
+                        // is already deployed somewhere.
                         def sha = sh(returnStdout: true, script: 'git rev-parse --short HEAD').trim()
                         def stamp = sh(returnStdout: true, script: 'date -u +%Y%m%d').trim()
-                        env.IMAGE_TAG = "${sha}-${stamp}"
+                        env.IMAGE_TAG = "${sha}-${stamp}-b${env.BUILD_NUMBER}"
                         currentBuild.description = "updating ${params.GRID_NAME} @ ${env.IMAGE_TAG}"
                     } else {
                         currentBuild.description = 'off-cadence week, skipped'

--- a/jenkins/groovy/auto-update-selenium-grid/Jenkinsfile
+++ b/jenkins/groovy/auto-update-selenium-grid/Jenkinsfile
@@ -21,7 +21,7 @@
 // RUN_TF=false when UPGRADE_GRID != true, so no instance is recycled and the
 // running nodes keep the image they booted with -- this job would then finish
 // green while updating nothing. Whether a grid is nomad-based is decided by the
-// selenium_grid_nomad_enabled ansible var, which lives outside this repo, so it
+// selenium_grid_enable_nomad ansible var, which lives outside this repo, so it
 // cannot be asserted here.
 //
 // Note: passing SELENIUM_GRID_NOMAD_ENABLED=true to provision-selenium-grid is

--- a/jenkins/groovy/provision-selenium-grid/Jenkinsfile
+++ b/jenkins/groovy/provision-selenium-grid/Jenkinsfile
@@ -76,6 +76,12 @@ pipeline {
                             string(credentialsId: 'jenkins-aws-id', variable: 'AWS_ACCESS_KEY_ID')
                         ]) {
                             sh '''#!/bin/bash
+                                # deploy-nomad-selenium-grid-node.sh reads the node image tag from
+                                # SELENIUM_GRID_IMAGE_VERSION. Only override it when IMAGE_VERSION was
+                                # given, so the unset case keeps whatever the environment config sets.
+                                if [ -n "$IMAGE_VERSION" ]; then
+                                    export SELENIUM_GRID_IMAGE_VERSION="$IMAGE_VERSION"
+                                fi
                                 GRID=$GRID_NAME scripts/deploy-nomad-selenium-grid-hub.sh
                                 GRID=$GRID_NAME scripts/deploy-nomad-selenium-grid-node.sh
                                 RET=$?

--- a/jenkins/groovy/provision-selenium-grid/Jenkinsfile
+++ b/jenkins/groovy/provision-selenium-grid/Jenkinsfile
@@ -31,7 +31,14 @@ pipeline {
                         skipNomad = false;
                     } else {
                         dir('infra-provisioning') {
-                            def nomadEnabled = utils.GetAnsibleVar(env.ENVIRONMENT, 'selenium_grid_nomad_enabled')
+                            // The var is selenium_grid_enable_nomad, not
+                            // selenium_grid_nomad_enabled: the latter exists in no vars.yml, so
+                            // GetAnsibleVar's `yq` returned the string "null" -- non-empty, so
+                            // returned as-is -- and this branch never matched. Nomad grids were
+                            // then detected only when an operator ticked
+                            // SELENIUM_GRID_NOMAD_ENABLED by hand; an unattended build skipped
+                            // the nomad stage and finished green having deployed nothing.
+                            def nomadEnabled = utils.GetAnsibleVar(env.ENVIRONMENT, 'selenium_grid_enable_nomad')
                             if (nomadEnabled == "true") {
                                 skipNomad = false;
                             }

--- a/jenkins/jobs/auto-update-selenium-grid.yaml
+++ b/jenkins/jobs/auto-update-selenium-grid.yaml
@@ -18,7 +18,7 @@
       - string:
           name: GRID_NAME
           default: validate
-          description: "Grid to rebuild and redeploy, defaults to 'validate' (the nightly torture grid)."
+          description: "Grid to rebuild and redeploy, defaults to 'validate' (the nightly torture grid). Must be a nomad-based grid: on an OCI instance-pool grid the redeploy recycles no instance, so the rebuilt image never lands and the job finishes green having updated nothing."
           trim: true
       - string:
           name: ENVIRONMENT

--- a/jenkins/jobs/auto-update-selenium-grid.yaml
+++ b/jenkins/jobs/auto-update-selenium-grid.yaml
@@ -1,0 +1,57 @@
+- job:
+    name: auto-update-selenium-grid
+    display-name: auto update selenium grid
+    concurrent: false
+    # Fires every Wednesday 04:00 UTC; the Jenkinsfile drops the off-weeks so the
+    # effective cadence is fortnightly, anchored on 2026-09-09. Plain cron cannot
+    # express "every second Wednesday", and ISO-week parity breaks across the
+    # week-53 boundary, so the guard counts days from the anchor instead.
+    # Set FORCE_RUN to run off-cadence.
+    triggers:
+      - timed: '0 4 * * 3'
+    parameters:
+      - string:
+          name: VIDEO_INFRA_BRANCH
+          default: main
+          description: "Controls checkout branch for infra repos, defaults to 'main'."
+          trim: true
+      - string:
+          name: GRID_NAME
+          default: validate
+          description: "Grid to rebuild and redeploy, defaults to 'validate' (the nightly torture grid)."
+          trim: true
+      - string:
+          name: ENVIRONMENT
+          default: torture-test
+          description: "Environment the grid lives in, defaults to 'torture-test'."
+          trim: true
+      - string:
+          name: ORACLE_REGION
+          default: us-phoenix-1
+          description: "Oracle Region the grid lives in."
+          trim: true
+      - string:
+          name: SCHEDULE_ANCHOR
+          default: '2026-09-09'
+          description: "First run of the fortnightly cadence; runs happen every 14 days from this date."
+          trim: true
+      - bool:
+          name: FORCE_RUN
+          default: false
+          description: "Run even if today is not on the fortnightly cadence."
+
+    project-type: pipeline
+    sandbox: true
+    pipeline-scm:
+      scm:
+        - git:
+            url: git@github.com:jitsi/infra-provisioning.git
+            credentials-id: "video-infra"
+            branches:
+              - "origin/${{VIDEO_INFRA_BRANCH}}"
+            browser: githubweb
+            browser-url: https://github.com/jitsi/infra-provisioning
+            submodule:
+              recursive: true
+      script-path: jenkins/groovy/auto-update-selenium-grid/Jenkinsfile
+      lightweight-checkout: true

--- a/jenkins/jobs/provision-selenium-grid.yaml
+++ b/jenkins/jobs/provision-selenium-grid.yaml
@@ -30,6 +30,10 @@
           description: "Check to re-run terraform for existing grid"
           default: false
       - string:
+          name: IMAGE_VERSION
+          description: "Node image tag to deploy. Empty keeps the job default ('latest'). Pass an immutable tag to guarantee running allocations actually roll onto a rebuilt image."
+          trim: true
+      - string:
           name: ACTION
           default: apply
           description: "\"apply\" or \"import\" into the terraform. import is only needed if the state of the stack has gotten out of sync."

--- a/nomad/selenium-grid-hub.hcl
+++ b/nomad/selenium-grid-hub.hcl
@@ -16,6 +16,8 @@ variable "service_tag_urlprefix" {
 
 variable "selenium_version" {
   type = string
+  # Fallback only. The real value comes from scripts/selenium-version.sh,
+  # exported as NOMAD_VAR_selenium_version by deploy-nomad-selenium-grid-hub.sh.
   default = "4.47"
 }
 

--- a/nomad/selenium-grid-hub.hcl
+++ b/nomad/selenium-grid-hub.hcl
@@ -18,7 +18,7 @@ variable "selenium_version" {
   type = string
   # Fallback only. The real value comes from scripts/selenium-version.sh,
   # exported as NOMAD_VAR_selenium_version by deploy-nomad-selenium-grid-hub.sh.
-  default = "4.47"
+  default = "4.48.0"
 }
 
 job "[JOB_NAME]" {

--- a/nomad/selenium-grid-node.hcl
+++ b/nomad/selenium-grid-node.hcl
@@ -36,6 +36,15 @@ job "[JOB_NAME]" {
     value     = "linux"
   }
 
+  // The node image is arm64-only (Google now ships Chrome for linux-arm64).
+  // Without this, a system job schedules onto x86 pool hosts too and the task
+  // dies at container start with "exec format error" -- silently missing slots
+  // with a green deploy.
+  constraint {
+    attribute = "${attr.cpu.arch}"
+    value     = "arm64"
+  }
+
   group "grid-node" {
     constraint {
       attribute  = "${meta.pool_type}"
@@ -77,6 +86,12 @@ job "[JOB_NAME]" {
 
       config {
         image        = "${var.registry_prefix}selenium/node-mixed:${var.image_version}"
+        # image_version defaults to "latest", a mutable tag. Without force_pull a
+        # restarted allocation keeps the cached layer, so a rebuilt image never
+        # reaches the node. Callers that want a guaranteed roll should also pass an
+        # immutable tag (SELENIUM_GRID_IMAGE_VERSION), since an unchanged job spec
+        # produces no new allocations at all.
+        force_pull   = true
         ports = ["http","vnc","no-vnc"]
         volumes = [
           "/opt/jitsi/jitsi-meet-torture:/usr/share/jitsi-meet-torture:ro",

--- a/scripts/deploy-nomad-selenium-grid-hub.sh
+++ b/scripts/deploy-nomad-selenium-grid-hub.sh
@@ -42,6 +42,11 @@ NOMAD_DC="$ENVIRONMENT-$ORACLE_REGION"
 JOB_NAME="grid-hub-$GRID"
 export NOMAD_VAR_grid="$GRID"
 
+# Hub image tag comes from the same SELENIUM_VERSION the node image is built
+# against, so hub and nodes cannot drift apart.
+. "$LOCAL_PATH/selenium-version.sh"
+export NOMAD_VAR_selenium_version="$SELENIUM_VERSION"
+
 sed -e "s/\[JOB_NAME\]/$JOB_NAME/" "$NOMAD_JOB_PATH/selenium-grid-hub.hcl" | nomad job run -var="dc=$NOMAD_DC" -
 
 if [ $? -ne 0 ]; then

--- a/scripts/selenium-version.sh
+++ b/scripts/selenium-version.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# Single source of truth for the Selenium Grid version.
+#
+# Sourced by:
+#   docker/selenium-grid-node/build.sh       -> --build-arg SELENIUM_VERSION
+#                                               (node image base: selenium/node-chromium:$SELENIUM_VERSION)
+#   scripts/deploy-nomad-selenium-grid-hub.sh -> NOMAD_VAR_selenium_version
+#                                               (hub image: selenium/hub:$SELENIUM_VERSION)
+#
+# Keeping both in step matters: the hub used to be pinned to a release while the
+# nodes tracked :nightly, so the two drifted onto different Grid versions with
+# nothing recording which node image contained which Selenium build.
+#
+# An already-exported SELENIUM_VERSION wins, so a Jenkins parameter or a one-off
+# build can override this without editing the file.
+#
+# This is deliberately NOT in clouds/all.sh: that path is a symlink into the
+# separate infra-customizations-private repo, and this pins tooling rather than
+# environment configuration.
+#
+# Browser versions are intentionally a separate axis. Chrome stable and beta are
+# installed from Google's apt repo at image build time and get their drivers from
+# Chrome for Testing, so browsers advance on a rebuild without moving this value.
+
+export SELENIUM_VERSION="${SELENIUM_VERSION:-4.47}"

--- a/scripts/selenium-version.sh
+++ b/scripts/selenium-version.sh
@@ -23,4 +23,4 @@
 # installed from Google's apt repo at image build time and get their drivers from
 # Chrome for Testing, so browsers advance on a rebuild without moving this value.
 
-export SELENIUM_VERSION="${SELENIUM_VERSION:-4.47}"
+export SELENIUM_VERSION="${SELENIUM_VERSION:-4.48.0}"

--- a/terraform/selenium-grid/create-selenium-grid-oracle.sh
+++ b/terraform/selenium-grid/create-selenium-grid-oracle.sh
@@ -59,7 +59,9 @@ fi
 [ -z "$MEMORY_IN_GBS_ARM" ] && MEMORY_IN_GBS_ARM="12"
 [ -z "$OCPUS_ARM" ] && OCPUS_ARM="6"
 
-[ -z "$INSTANCE_POOL_SIZE_X86" ] && INSTANCE_POOL_SIZE_X86=1
+# INSTANCE_POOL_SIZE_X86 is deliberately left unset here: it means two
+# different things depending on the grid type, so its default is set per
+# branch alongside the pool lookups below.
 [ -z "$INSTANCE_POOL_SIZE_ARM" ] && INSTANCE_POOL_SIZE_ARM=1
 
 [ -z "$INSTANCE_POOL_NAME" ] && INSTANCE_POOL_NAME="GridInstancePool"
@@ -84,6 +86,12 @@ RESOURCE_NAME_ROOT="$NAME"
 
 # look up existing instance pools to preserve their current sizes
 if [[ "$SELENIUM_GRID_NOMAD_ENABLED" == "true" ]]; then
+  # The selenium-grid node image is arm64-only, so a new nomad grid gets no
+  # x86 nodes -- an amd64 node could not pull the image anyway. Existing pools
+  # keep whatever size they are already running (see the lookup below), so
+  # this only governs grids created from here on.
+  [ -z "$INSTANCE_POOL_SIZE_X86" ] && INSTANCE_POOL_SIZE_X86=0
+
   POOL_DETAILS_X86="$(oci compute-management instance-pool list --region "$ORACLE_REGION" -c "$COMPARTMENT_OCID" --all --display-name "$GRID_NAME Grid x86 Nodes" | jq '.data[0]')"
   if [ -n "$POOL_DETAILS_X86" ] && [ "$POOL_DETAILS_X86" != "null" ]; then
     INSTANCE_POOL_SIZE_X86=$(echo "$POOL_DETAILS_X86" | jq -r '.size')
@@ -100,6 +108,10 @@ if [[ "$SELENIUM_GRID_NOMAD_ENABLED" == "true" ]]; then
     echo "No existing ARM pool found. Using default size $INSTANCE_POOL_SIZE_ARM"
   fi
 else
+  # A non-nomad grid passes this as instance_pool_size for its ONE node pool,
+  # so 0 here would build a grid with no nodes at all.
+  [ -z "$INSTANCE_POOL_SIZE_X86" ] && INSTANCE_POOL_SIZE_X86=1
+
   POOL_DETAILS="$(oci compute-management instance-pool list --region "$ORACLE_REGION" -c "$COMPARTMENT_OCID" --all --display-name "$GRID_NAME Grid Nodes" | jq '.data[0]')"
   if [ -n "$POOL_DETAILS" ] && [ "$POOL_DETAILS" != "null" ]; then
     INSTANCE_POOL_SIZE_X86=$(echo "$POOL_DETAILS" | jq -r '.size')


### PR DESCRIPTION
## What this does

### 1. One variable drives both hub and nodes

`scripts/selenium-version.sh` exports `SELENIUM_VERSION` (**4.48.0**), sourced by:

| consumer | uses it as |
|---|---|
| `docker/selenium-grid-node/build.sh` | `--build-arg SELENIUM_VERSION` → node base `selenium/node-chromium:$SELENIUM_VERSION` |
| `scripts/deploy-nomad-selenium-grid-hub.sh` | `NOMAD_VAR_selenium_version` → hub image `selenium/hub:$SELENIUM_VERSION` |

An already-exported value wins, so a Jenkins parameter or one-off build can override it. The HCL default and the Dockerfile `ARG` are fallbacks only.

Until now the hub was pinned to a release while the nodes tracked `:nightly` — hub 4.41 against nodes reporting `4.48.0-SNAPSHOT` — and nothing recorded which node image held which Selenium build. That skew made a recent grid failure considerably harder to attribute.

It lives in this repo rather than `clouds/all.sh` because that path is a symlink into **infra-customizations-private**, and this pins tooling rather than environment config.

### 2. arm64-only node image

Google now publishes Chrome for `linux-arm64` (stable/beta/canary debs are in the apt repo) and Chrome for Testing publishes `linux-arm64` chromedrivers, so ARM nodes run both channels natively. The multi-arch `FROM` selection and every `if amd64` branch around the browsers are gone; the Dockerfile drops ~150 lines.

Upside beyond simplification: beta stops being amd64-only, so `chrome`+`jitsi-beta` slots go from 2 to one per node. That removes the zero-headroom condition where 2 beta slots served 2 concurrent wdio workers with nothing spare — the amplifier that turned a transient stumble into 41/42 failures recently.

### 3. Chrome stable + beta from apt, each with a matching driver

`install-chrome-channel.sh` takes a channel and: adds Google's apt repo, installs and holds the package, resolves a version-matched ChromeDriver from Chrome for Testing (exact build → latest same-major → channel release), asserts the majors match, and registers the browser directory for `generate_config`. Both stereotypes get their own driver via `SE_NODE_STEREOTYPE_EXTRA_CHROME` / `..._CHROME_BETA`.

The build **fails loudly** if no matching driver resolves, rather than shipping a stereotype that only breaks at session-creation time at 03:00.

This is the pattern Beta and Firefox already used, now applied to stable too. Taking stable from the base image is not viable: **docker-selenium published no Chrome 152 images weeks after 152 went stable**, so nodes were stuck on 151 with no rebuild able to advance them. Browser versions are now a separate axis from `SELENIUM_VERSION` — a rebuild picks up current Chrome without moving the Grid version, and vice versa.

The repo setup runs unguarded on every invocation, which matters because the script runs twice. Installing the first channel rewrites apt's configuration underneath us: `google-chrome-stable`'s postinst migrates our `google-chrome.list` into `google-chrome.sources`, then `remove_legacy_list()` finds no `deb` line but its own and takes its `rm -f "$LEGACY_LIST"` branch. A guard on "is the `.list` already there" therefore reads false on the beta run and re-enters the block, where `gpg --dearmor` meets the keyring the stable run wrote, tries to ask about overwriting it, finds no `/dev/tty` under buildkit and exits 2. Everything in the block is idempotent, so it simply always runs, with `--batch --yes` on the dearmor. `set -o pipefail` is on for the same reason: the failure lived in a `curl | gpg` pipeline where a failing `curl` would have been masked into a corrupt keyring and a far more confusing error downstream.

Two notes: the arm64 base ships Chromium from Debian sid with no Google apt repo, so the script adds it; Chromium stays installed but is behind no stereotype. And `chrome-cleanup.sh` starts working on these nodes — it greps Google Chrome's process paths, which never matched Chromium.

### 4. Zero x86 nodes on new grids

The node image is arm64-only, so an x86 node could not pull it. `INSTANCE_POOL_SIZE_X86` now defaults to **0** on the nomad path in `create-selenium-grid-oracle.sh`.

The default could not simply move to 0 at the top of the script: the non-nomad branch passes the same variable as `instance_pool_size` for its *single* node pool, so a global 0 would build a grid with no nodes at all. It is set per branch instead — 0 for nomad, 1 for non-nomad — beside the pool lookups it belongs with.

Zero is safe on the nomad path: the x86 instance pool resource is still declared (`size = 0`), so the `NODE_POOL_ID_X86` state lookup still resolves and the script does not `exit 4`; the instance datasources and `verify_cloud_init_node_x86`, both `count = var.instance_pool_size_x86`, collapse to nothing.

⚠️ **This governs new grids only.** Where a pool already exists the lookup replaces the default with its current OCI size, so running grids keep the size they have — see *Reviewer attention*.

### 5. Fortnightly auto-update

`auto-update-selenium-grid` rebuilds the node image and redeploys a grid **every second Wednesday 04:00 UTC**, anchored on **2026-09-09** (→ 09-23, 10-07, …).

Plain cron can't express a fortnightly cadence, so the trigger fires every Wednesday (`0 4 * * 3`) and the Jenkinsfile drops off-weeks by counting whole days from the anchor and requiring a multiple of 14. ISO-week parity was rejected — it breaks across the week-53 boundary. Off-cadence weeks skip their stages via `when{}` and finish **green**; calling `error()` would fire a failure notification every second Wednesday forever. `SCHEDULE_ANCHOR` and `FORCE_RUN` are parameters.

It chains the existing jobs: `build-docker-image-selenium-grid-node` → `provision-selenium-grid`, passing `UPGRADE_GRID=false` deliberately, since with it set terraform re-applies the instance pools and resets their sizes to the script defaults. `GRID_NAME` defaults to `validate`.

### 6. Nomad grid auto-detection actually works

`provision-selenium-grid` decided whether a grid was nomad-based by reading the ansible var `selenium_grid_nomad_enabled` — a name **no `vars.yml` defines**. `GetAnsibleVar` shells out to `yq`, which prints the string `null` for a missing key; that is non-empty, so it was returned verbatim and never equalled `"true"`.

Nomad grids were therefore detected only when an operator ticked `SELENIUM_GRID_NOMAD_ENABLED` by hand. Survivable for manual runs, fatal for the new auto-update job, which deliberately does not pass the flag — forcing it would deploy nomad jobs to genuinely instance-pool grids. Unattended, the nomad stage would skip, `IMAGE_VERSION` would never reach the node job, and the build would finish green having rolled nothing: the exact silent no-op `auto-update-selenium-grid`'s own header warns about.

The real var is `selenium_grid_enable_nomad`, set in `sites/torture-test/vars.yml` (`"true"`) with a `false` default in `config/vars.yml`. `GetAnsibleVar` only reads `sites/$ENVIRONMENT/vars.yml`, so detection changes for **torture-test environments only** — everything else still resolves to `null` → non-nomad, exactly as before.

## Chrome 153 / arm64 availability

The original gate on this PR has cleared. Chrome stable is **153.0.8010.36**, published for arm64, with a matching CfT `linux-arm64` chromedriver:

| | version | arm64 deb | CfT `linux-arm64` driver |
|---|---|---|---|
| stable | `153.0.8010.36-1` | ✅ | ✅ exact build |
| beta | `154.0.8037.0-1` | ✅ | ✅ same-major (`154.0.8037.9`) |

Driver coverage across all builds of a major:

| major | builds with `linux-arm64` chromedriver |
|---|---|
| 151 | 0 / 67 |
| 152 | 0 / 70 |
| 153 | 13 / 40 |
| 154 | 23 / 23 |

153 is only partially covered, so a future rebuild could land on a 153 build with no arm64 driver; the script's "latest same-major" fallback covers that rather than failing.

## Testing

- **Full `linux/arm64` image build, green.** stable `153.0.8010.36` with an exact-build driver, beta `154.0.8037.0` with driver `154.0.8037.9` (same major, the documented fallback). Resulting image carries four stereotypes — `chrome`, `chrome_beta`, `firefox`, `firefox_beta` — both chromedrivers owned by `seluser`, and holds on `chromium`, `firefox`, `firefox-beta`, `google-chrome-stable`, `google-chrome-beta`.
- **The gpg failure reproduced and fixed** in a `linux/arm64` container: second `gpg --dearmor` over an existing keyring gives `cannot open '/dev/tty'` / exit 2; with `--batch --yes`, exit 0.
- **Chrome's postinst behaviour confirmed from the deb itself**: control archive extracted from the arm64 package, and its own `REPOCONFIGREGEX` run against our `deb` line — it matches, no other source is present, so the `rm -f` branch deletes our `.list`.
- **Image tags verified against Docker Hub**: `selenium/hub:4.48.0` and `selenium/node-chromium:4.48.0` both publish `linux/arm64` manifests.
- **x86 default exercised across all six paths** (nomad/non-nomad × new/existing pool × preset override): new nomad grid → 0, existing pool → preserved, explicit value → honoured, non-nomad new grid → 1.
- **Variable plumbing**: `build.sh` dry-run with `docker` stubbed emits `--platform=linux/arm64 ... --build-arg SELENIUM_VERSION`, and an exported override is honoured.
- **`GetAnsibleVar` fix verified** by running the same `yq` call against the real `sites/torture-test/vars.yml`: old name → `null`, new name → `true`.
- **Shell/YAML**: `bash -n` on the new and changed scripts, YAML parse on the job definition.
- **Not tested**: a live Jenkins run of the new job.

## Reviewer attention

- **Existing grids still need their x86 pools drained by hand.** The new default only reaches grids that do not have a pool yet; for the rest the lookup preserves the live OCI size, and `UPGRADE_GRID=false` means terraform is not re-applied at all. Note also that the lookup overwrites an operator-supplied `INSTANCE_POOL_SIZE_X86`, so the pool cannot be shrunk by passing the variable — scale it directly with `oci compute-management instance-pool update --instance-pool-id <id> --size 0`. Left as-is here; making the variable authoritative is a broader change to shared provisioning code.
- **Both Jenkins jobs need seeding** via `update-jenkins-job-from-yaml` after merge: `auto-update-selenium-grid` (new job and its cron trigger) and `provision-selenium-grid` (the new `IMAGE_VERSION` parameter — without a re-seed the parameter does not exist and the image tag never reaches the deploy).
- **The `selenium_grid_enable_nomad` fix also changes manual runs.** Previously, forgetting to tick `SELENIUM_GRID_NOMAD_ENABLED` meant the nomad stage silently skipped; now it runs. Correct, but it means the other grids sharing this job — aaron, stable, validate, validocker, prdocker, autoscaler — start deploying nomad jobs on runs where they previously no-op'd.
- This touches shared paths (`build.sh`, hub deploy, node image), so **all** grids pick it up on their next build/deploy, moving them onto hub+node 4.48.0 together.
