### PR TITLE
fix: pin dual-homed coturn scrape replies to the primary VNIC (JIT-16318)

### DIFF
--- a/terraform/create-coturn-stack/user-data/postinstall-runner-oracle.sh
+++ b/terraform/create-coturn-stack/user-data/postinstall-runner-oracle.sh
@@ -1,6 +1,7 @@
 # override commands for dump, terminate, provisioning and EIP
 export MAIN_COMMAND="eip_assign"
 export PUBLIC_IP_ROLE="coturn"
+export PROVISION_COMMAND="provisioning"
 
 . /usr/local/bin/oracle_cache.sh
 
@@ -9,5 +10,6 @@ export HOST_ROLE="coturn"
 export ANSIBLE_VARS="hcv_environment=$ENVIRONMENT cloud_name=$CLOUD_NAME cloud_provider=oracle oracle_region=$ORACLE_REGION region=$ORACLE_REGION environment_domain_name=$DOMAIN prosody_domain_name=$DOMAIN release_branch=$GIT_BRANCH"
 
 function provisioning() {
+  configure_primary_source_routing
   default_provision
 }

--- a/terraform/lib/postinstall-lib.sh
+++ b/terraform/lib/postinstall-lib.sh
@@ -339,6 +339,42 @@ function restore_oci_connectivity() {
   switch_to_secondary_vnic
 }
 
+function configure_primary_source_routing() {
+  local vnics=$(curl --connect-timeout 10 -s http://169.254.169.254/opc/v1/vnics/)
+  [ "$(echo "$vnics" | jq -r length 2>/dev/null)" -ge 2 ] 2>/dev/null || return 0
+  local mac=$(echo "$vnics" | jq -r '.[0].macAddr')
+  local subnet=$(echo "$vnics" | jq -r '.[0].subnetCidrBlock')
+  local gw=$(echo "$vnics" | jq -r '.[0].virtualRouterIp')
+  local secondaries=$(echo "$vnics" | jq -r '.[1:][].subnetCidrBlock' | sort -u)
+  local dev=$(ip -o link | grep -i "$mac" | head -1 | awk -F': ' '{print $2}' | cut -d'@' -f1)
+  local np="/etc/netplan/99-jitsi-primary-source-routing.yaml"
+  local s
+  if [ -z "$dev" ] || [ -z "$secondaries" ] || [ "$subnet" == "null" ] || [ "$gw" == "null" ]; then
+    echo "configure_primary_source_routing: cannot derive primary VNIC details, skipping"
+    return 0
+  fi
+  if ip rule show | grep "lookup 100" | grep -qv "from $subnet"; then
+    echo "configure_primary_source_routing: routing table 100 already in use, skipping"
+    return 0
+  fi
+  echo "configure_primary_source_routing: from $subnet to [$(echo $secondaries)] via $gw dev $dev"
+  (umask 077; {
+    echo -e "network:\n  version: 2\n  ethernets:\n    $dev:\n      routing-policy:"
+    for s in $secondaries; do echo "      - {from: $subnet, to: $s, table: 100, priority: 100}"; done
+    echo -e "      routes:\n      - {to: default, via: $gw, table: 100}"
+  } > $np)
+  if ! netplan generate; then
+    echo "configure_primary_source_routing: netplan rejected $np, removing it"
+    rm -f $np && netplan generate
+    return 0
+  fi
+  ip route replace default via $gw dev $dev table 100
+  for s in $secondaries; do
+    ip rule show | grep -q "from $subnet to $s lookup 100" || ip rule add from $subnet to $s table 100 priority 100
+  done
+  return 0
+}
+
 function default_terminate() {
   # single attempt; the footer retries in a loop with connectivity self-healing
   echo "Terminating the instance; we enable debug to have more details in case of oci cli failures"


### PR DESCRIPTION
## Problem

Nomad coturns are unscrapeable from the consul private subnet, fleet-wide. They are dual-homed: primary VNIC in the public /24 (default route), secondary VNIC in the general private /18 where consul/monitoring hosts live. The kernel's automatic connected route for the /18 is more specific than the default route, so replies to scrape connections that arrived on the **primary** VNIC egress the **secondary** VNIC still sourced from the primary IP — an address that VNIC doesn't own — and OCI anti-spoof silently drops them:

```
enp0s10 In   10.40.157.155.40054 > 10.40.2.20.28370: [S]
enp1s0  Out  10.40.2.20.28370 > 10.40.157.155.40054: [S.]   <-- dropped
```

Consul catalog health can't catch this (checks run on the local agent and gossip the result). The scrape port is a Nomad dynamic port (`nomad/telegraf.hcl` — `port "telegraf-prometheus" {}`), so a security-list fix isn't possible either.

Why only coturn today: NobleBase images have no initramfs network config, so cloud-init's Oracle datasource falls back to IMDS — and that path configures **all** VNICs even with `configure_secondary_nics: false`. Jammy-era JVB/jigasi images get initramfs network config and their secondary VNICs stay unconfigured (no connected route, no bug). Any dual-homed pool moving to Noble-style images will hit this on first boot; a follow-up will invoke the new function from those runners too.

## Fix

New `configure_primary_source_routing()` in the postinstall lib, invoked from the coturn runner (via `PROVISION_COMMAND=provisioning`, after `eip_assign` has restored primary routing):

- pins traffic `from <primary-subnet> to <secondary-subnet>` out the primary VNIC via routing table 100; the `to`-scoping keeps DHCP, metadata (169.254.169.254) and on-link neighbor traffic on the main table
- everything derived from OCI VNIC metadata (`subnetCidrBlock` / `virtualRouterIp` / `macAddr`) — no per-region templating; clean no-op on single-homed hosts; refuses to touch table 100 if a foreign rule owns it; never fails the boot (a scrape-broken host beats footer termination)
- persistence via a separate `/etc/netplan/99-jitsi-primary-source-routing.yaml` (0600, validated with `netplan generate`; `50-cloud-init.yaml` is regenerated from metadata so it is never edited) and live application via `ip` directly — `netplan apply` is never run, nothing flaps on live media hosts

## Verification (pilot: meet-jit-si-eu-frankfurt-1-coturn-40-2-20)

- scrape from consul server 10.40.157.155: timeout → **200 in 4.7ms**; unpatched control (.17) still times out
- `ip route get 10.40.157.155 from 10.40.2.20` → via primary interface, table 100; metadata/DHCP paths unchanged
- rendered networkd unit keeps the cloud-init `PermanentMACAddress` match, `set-name` and MTU, with our `[Route]`/`[RoutingPolicyRule]` merged in
- re-running the function is idempotent (single rule, exit 0)

Rollout plan, root-cause analysis and fleet-patch steps: [JIT-16318](https://agile.8x8.com/browse/JIT-16318)