### PR TITLE
fix: gzip postinstall user-data to fit the 32KB metadata limit (JIT-16318)

### DIFF
--- a/terraform/consul-server/create-consul-server-oracle.tf
+++ b/terraform/consul-server/create-consul-server-oracle.tf
@@ -61,7 +61,7 @@ locals {
     "${var.tag_namespace}.Name" = var.name
   }
   common_metadata = {
-      user_data = base64encode(join("",[
+      user_data = base64gzip(join("",[
         file("${path.cwd}/${var.user_data_lib_path}/postinstall-header.sh"), # load the header
         file("${path.cwd}/${var.user_data_lib_path}/postinstall-lib.sh"), # load the lib
         "\nexport INFRA_CONFIGURATION_REPO=${var.infra_configuration_repo}\nexport INFRA_CUSTOMIZATIONS_REPO=${var.infra_customizations_repo}\n", #repo variables

--- a/terraform/create-coturn-stack/create-coturn-stack-oracle.tf
+++ b/terraform/create-coturn-stack/create-coturn-stack-oracle.tf
@@ -234,7 +234,7 @@ resource "oci_core_instance_configuration" "oci_instance_configuration" {
       }
 
       metadata = {
-        user_data = base64encode(join("",[
+        user_data = base64gzip(join("",[
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-header.sh"), # load the header
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-lib.sh"), # load the lib
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-eip-lib.sh"), # load the EIP lib

--- a/terraform/create-jigasi-instance-configuration/create-jigasi-instance-configuration.tf
+++ b/terraform/create-jigasi-instance-configuration/create-jigasi-instance-configuration.tf
@@ -110,7 +110,7 @@ resource "oci_core_instance_configuration" "oci_instance_configuration" {
       }
 
       metadata = {
-        user_data = base64encode(join("",[
+        user_data = base64gzip(join("",[
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-header.sh"), # load the header
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-lib.sh"), # load the lib
           "\nexport INFRA_CONFIGURATION_REPO=${var.infra_configuration_repo}\nexport INFRA_CUSTOMIZATIONS_REPO=${var.infra_customizations_repo}\n", #repo variables

--- a/terraform/create-jvb-instance-configuration/create-jvb-instance-configuration.tf
+++ b/terraform/create-jvb-instance-configuration/create-jvb-instance-configuration.tf
@@ -191,7 +191,7 @@ resource "oci_core_instance_configuration" "oci_instance_configuration" {
       }
 
       metadata = {
-        user_data = base64encode(join("",[
+        user_data = base64gzip(join("",[
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-header.sh"), # load the header
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-lib.sh"), # load the lib
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-eip-lib.sh"), # load the EIP lib
@@ -250,7 +250,7 @@ resource "oci_core_instance_configuration" "oci_instance_configuration_use_eip" 
       }
 
       metadata = {
-        user_data = base64encode(join("",[
+        user_data = base64gzip(join("",[
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-header.sh"), # load the header
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-lib.sh"), # load the lib
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-eip-lib.sh"), # load the EIP lib

--- a/terraform/haproxy-shards/create-haproxy-stack-oracle.tf
+++ b/terraform/haproxy-shards/create-haproxy-stack-oracle.tf
@@ -382,7 +382,7 @@ resource "oci_core_instance_configuration" "oci_instance_configuration" {
       }
 
       metadata = {
-        user_data = base64encode(join("",[
+        user_data = base64gzip(join("",[
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-header.sh"), # load the header
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-lib.sh"), # load the lib
           "\nexport INFRA_CONFIGURATION_REPO=${var.infra_configuration_repo}\nexport INFRA_CUSTOMIZATIONS_REPO=${var.infra_customizations_repo}\n", #repo variables

--- a/terraform/iperf-server/iperf-server.tf
+++ b/terraform/iperf-server/iperf-server.tf
@@ -132,7 +132,7 @@ resource "oci_core_instance" "instance" {
     }
 
     metadata = {
-        user_data = base64encode(join("",[
+        user_data = base64gzip(join("",[
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-header.sh"), # load the header
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-lib.sh"), # load the lib
           file("${path.cwd}/${var.user_data_file}"), # load our customizations

--- a/terraform/jenkins-server/create-jenkins-server-oracle.tf
+++ b/terraform/jenkins-server/create-jenkins-server-oracle.tf
@@ -178,7 +178,7 @@ resource "oci_core_instance" "instance" {
     }
 
     metadata = {
-        user_data = base64encode(join("",[
+        user_data = base64gzip(join("",[
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-header.sh"), # load the header
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-lib.sh"), # load the lib
           file("${path.cwd}/${var.user_data_file}"), # load our customizations

--- a/terraform/jibri-instance-configuration/create-jibri-instance-configuration.tf
+++ b/terraform/jibri-instance-configuration/create-jibri-instance-configuration.tf
@@ -140,7 +140,7 @@ resource "oci_core_instance_configuration" "oci_instance_configuration" {
       }
 
       metadata = {
-        user_data = base64encode(join("",[
+        user_data = base64gzip(join("",[
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-header.sh"), # load the header
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-lib.sh"), # load the lib
           "\nexport INFRA_CONFIGURATION_REPO=${var.infra_configuration_repo}\nexport INFRA_CUSTOMIZATIONS_REPO=${var.infra_customizations_repo}\n", #repo variables

--- a/terraform/jigasi-proxy/create-jigasi-proxy-oracle.tf
+++ b/terraform/jigasi-proxy/create-jigasi-proxy-oracle.tf
@@ -175,7 +175,7 @@ resource "oci_core_instance_configuration" "oci_instance_configuration" {
       }
 
       metadata = {
-        user_data = base64encode(join("",[
+        user_data = base64gzip(join("",[
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-header.sh"), # load the header
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-lib.sh"), # load the lib
           "\nexport INFRA_CONFIGURATION_REPO=${var.infra_configuration_repo}\nexport INFRA_CUSTOMIZATIONS_REPO=${var.infra_customizations_repo}\n", #repo variables

--- a/terraform/lib/postinstall-eip-lib.sh
+++ b/terraform/lib/postinstall-eip-lib.sh
@@ -1,8 +1,5 @@
-
-
 function should_assign_eip() {
   use_eip=$(curl -s curl http://169.254.169.254/opc/v1/instance/ | jq '."definedTags" | to_entries[] | select((.key | startswith("eghtjitsi")) or (.key == "jitsi")) |.value."use_eip"' -r)
-
   if [ ! -z "$use_eip" ] && [ "$use_eip" == 'true' ]; then
     echo "Will assign a reserved public ip to the instance"
     return 0
@@ -11,98 +8,72 @@ function should_assign_eip() {
     return 1
   fi
 }
-
 function switch_to_secondary_vnic() {
   status_code=0
   echo "Configure secondary NIC with routing"
   sudo /usr/local/bin/secondary_vnic_all_configure_oracle.sh -c || status_code=1
-
   if [ $status_code -gt 0 ]; then
     return $status_code
   fi
-
   echo "Detect secondary NIC"
   SECONDARY_VNIC_DEVICE="$(ip addr | egrep '^[0-9]' | egrep -v 'lo|docker' | tail -1 | awk '{print $2}')"
   SECONDARY_VNIC_DEVICE="${SECONDARY_VNIC_DEVICE::-1}"
   SECONDARY_VNIC_DEVICE="$(echo $SECONDARY_VNIC_DEVICE | cut -d'@' -f1)"
-
-  # compute and validate the new default route BEFORE deleting the existing
-  # ones, so a failure here cannot leave the host with no default route
   export NIC2_ROUTE="default via "$(ip route show | grep "dev $SECONDARY_VNIC_DEVICE" | grep -v default | head -1 | awk '{ print substr($1,1,index($1,"/")-2)1 " " $2 " " $3}')
   if [ "$NIC2_ROUTE" == "default via " ]; then
     echo "Unable to determine route via secondary NIC $SECONDARY_VNIC_DEVICE, leaving routes untouched"
     return 1
   fi
-
   echo "Switch default routes to NIC2"
-  # NIC1_ROUTE_1 can be empty when a previous partial switch already removed
-  # the default routes; skip the delete so the switch can still complete
   export NIC1_ROUTE_1=$(ip route show | grep default -m 1)
   if [ ! -z "$NIC1_ROUTE_1" ]; then
     sudo ip route delete $NIC1_ROUTE_1 || status_code=1
   fi
-
   if [ $status_code -gt 0 ]; then
     return $status_code
   fi
-
   export NIC1_ROUTE_2=$(ip route show | grep default -m 1)
   if [ ! -z "$NIC1_ROUTE_2" ]; then
     sudo ip route delete $NIC1_ROUTE_2 || status_code=1
   fi
-
   if [ $status_code -gt 0 ]; then
     return $status_code
   fi
-
   sudo ip route add $NIC2_ROUTE || status_code=1
   return $status_code
 }
-
 function switch_to_primary_vnic() {
   status_code=0
   echo "Switch default route back to NIC1"
-
-  # restore as much routing as possible even if individual steps fail, so a
-  # partial switch to the secondary VNIC does not leave the routing table empty
   if [ ! -z "$NIC2_ROUTE" ]; then
     sudo ip route delete $NIC2_ROUTE || status_code=1
   fi
-
   if [ ! -z "$NIC1_ROUTE_1" ]; then
     sudo ip route add $NIC1_ROUTE_1 || status_code=1
   fi
-
   if [ ! -z "$NIC1_ROUTE_2" ]; then
     sudo ip route add $NIC1_ROUTE_2 || status_code=1
   fi
-
   echo "Delete secondary NIC routing to avoid routing issues in the future"
   sudo /usr/local/bin/secondary_vnic_all_configure_oracle.sh -d || status_code=1
   return $status_code
 }
-
 function assign_reserved_public_ip() {
   [ -z "$PUBLIC_IP_ROLE" ] && PUBLIC_IP_ROLE="JVB"
-
   vnic_id=$(curl -s curl http://169.254.169.254/opc/v1/vnics/ | jq .[0].vnicId -r)
   vnic_details_result=$(oci network vnic get --vnic-id "$vnic_id" --auth instance_principal)
   if [ $? -eq 0 ]; then
     public_ip=$(echo "$vnic_details_result" | jq -r '.data["public-ip"]')
-
     private_ip=$(echo "$vnic_details_result" | jq -r '.data["private-ip"]')
     subnet_id=$(echo "$vnic_details_result" | jq -r '.data["subnet-id"]')
     private_ip_details=$(oci network private-ip list --subnet-id "$subnet_id" --ip-address "$private_ip" --auth instance_principal)
     private_ip_ocid=$(echo "$private_ip_details" | jq -r '.data[0] | .id')
-
     echo "Public ip is: $public_ip"
-
     if [ -z "$public_ip" ] || [ "$public_ip" == "null" ]; then
       echo "Search for a reserved public ip"
       compartment_id=$(echo "$vnic_details_result" | jq -r '.data["compartment-id"]')
       tag_namespace="jitsi"
       reserved_ips=$(oci network public-ip list --compartment-id "$compartment_id" --scope REGION --lifetime RESERVED --all --query 'data[?"defined-tags".'\"$tag_namespace\"'."shard-role" == `'$PUBLIC_IP_ROLE'`]' --auth instance_principal)
-
       reserved_unasigned_ips_count=$(echo "$reserved_ips" | jq '[.[] | select(."lifecycle-state" == "AVAILABLE")] | length' -r)
       if [ "$reserved_unasigned_ips_count" == 0 ]; then
         echo "No AVAILABLE and UNASIGNED reserved IPs. Exiting.."
@@ -111,18 +82,14 @@ function assign_reserved_public_ip() {
       random_ip_index=$(((RANDOM % reserved_unasigned_ips_count)))
       reserved_public_ip=$(echo "$reserved_ips" | jq --arg index "$random_ip_index" '[.[] | select(."lifecycle-state" == "AVAILABLE")][$index|tonumber] | ."ip-address"' -r)
       reserved_public_ip_ocid=$(echo "$reserved_ips" | jq --arg index "$random_ip_index" '[.[] | select(."lifecycle-state" == "AVAILABLE")][$index|tonumber] | ."id"' -r)
-
       reserved_public_ip_details=$(oci network public-ip get --public-ip-address "$reserved_public_ip" --auth instance_principal)
       reserved_public_ip_state=$(echo "$reserved_public_ip_details" | jq -r '.data["lifecycle-state"]')
       if [ "$reserved_public_ip_state" == "ASSIGNED" ]; then
         echo "Public ip $reserved_public_ip was assigned in the meantime to another instance"
         return 1
       fi
-
       etag_reserved_public_ip=$(echo "$reserved_public_ip_details" | jq -r '.etag')
-
       echo "Found unasigned public ip: $reserved_public_ip"
-
       echo "Assign public ip $reserved_public_ip to private ip: $private_ip"
       oci network public-ip update --public-ip-id "$reserved_public_ip_ocid" --private-ip-id "$private_ip_ocid" --wait-for-state ASSIGNED --if-match "$etag_reserved_public_ip" --max-wait-seconds 180 --auth instance_principal
       if [ "$?" -gt 0 ]; then
@@ -142,20 +109,16 @@ function assign_reserved_public_ip() {
     return 1
   fi
 }
-
 function assign_ephemeral_public_ip() {
   vnic_id=$(curl -s curl http://169.254.169.254/opc/v1/vnics/ | jq .[0].vnicId -r)
   vnic_details_result=$(oci network vnic get --vnic-id "$vnic_id" --auth instance_principal)
   compartment_id=$(echo "$vnic_details_result" | jq -r '.data["compartment-id"]')
   public_ip=$(echo "$vnic_details_result" | jq -r '.data["public-ip"]')
-
   private_ip=$(echo "$vnic_details_result" | jq -r '.data["private-ip"]')
   subnet_id=$(echo "$vnic_details_result" | jq -r '.data["subnet-id"]')
   private_ip_details=$(oci network private-ip list --subnet-id "$subnet_id" --ip-address "$private_ip" --auth instance_principal)
   private_ip_ocid=$(echo "$private_ip_details" | jq -r '.data[0] | .id')
-
   echo "Public ip is: $public_ip"
-
   if [ -z "$public_ip" ] || [ "$public_ip" == "null" ]; then
     echo "Create and assign ephemeral public ip"
     oci network public-ip create --compartment-id "$compartment_id" --lifetime EPHEMERAL --private-ip-id "$private_ip_ocid" --wait-for-state ASSIGNED --auth instance_principal
@@ -171,19 +134,12 @@ function assign_ephemeral_public_ip() {
     return 0
   fi
 }
-
 function check_secondary_ip() {
   local counter=1
   local ip_status=1
-
   while [ $counter -le 2 ]; do
-    # fetch_vnics_metadata logs the full exchange with headers (X-Request-Id)
-    # so a missing secondary VNIC can be correlated with OCI support
     local my_private_ip=$(fetch_vnics_metadata | jq .[1].privateIp -r)
-
     if [ -z "$my_private_ip" ] || [ "$my_private_ip" == "null" ]; then
-      # record what the OS sees while the metadata is missing the secondary
-      # VNIC; in past incidents the device existed here the whole time
       ip -o link >&2
       sleep 30
       ((counter++))
@@ -192,7 +148,6 @@ function check_secondary_ip() {
       break
     fi
   done
-
   if [ $ip_status -eq 1 ]; then
     echo "Secondary private IP still not available status: $ip_status" >$tmp_msg_file
     return 1
@@ -200,52 +155,35 @@ function check_secondary_ip() {
     return 0
   fi
 }
-
 eip_assign() {
   [ -z "$PROVISION_COMMAND" ] && PROVISION_COMMAND="default_provision"
-  # the secondary VNIC can take a long time to appear in instance metadata
-  # (control-plane lag); the instance is useless without a public IP anyway,
-  # so wait up to ~35 minutes for it before giving up
   [ -z "$EIP_SECONDARY_IP_RETRIES" ] && EIP_SECONDARY_IP_RETRIES=30
-
   EIP_EXIT_CODE=0
   (retry check_secondary_ip $EIP_SECONDARY_IP_RETRIES) || EIP_EXIT_CODE=1
-
   if [ $EIP_EXIT_CODE -eq 0 ]; then
       switch_to_secondary_vnic || EIP_EXIT_CODE=1
-
       if [ $EIP_EXIT_CODE -eq 0 ]; then
           (retry assign_reserved_public_ip 15 || retry assign_ephemeral_public_ip) || EIP_EXIT_CODE=1
       fi
-
-      # only switch back if a switch was attempted; with no secondary VNIC
-      # there are no routes to restore and the route deletes would fail
       switch_to_primary_vnic || EIP_EXIT_CODE=1
   fi
-
   if [ $EIP_EXIT_CODE -eq 0 ]; then
       (retry add_ip_tags && retry $PROVISION_COMMAND) || EIP_EXIT_CODE=1
   fi
   return $EIP_EXIT_CODE
 }
-
 function eip_main() {
   EXIT_CODE=0
-
   [ -z "$PROVISION_COMMAND" ] && PROVISION_COMMAND="default_provision"
   [ -z "$CLEAN_CREDENTIALS" ] && CLEAN_CREDENTIALS="true"
-
   if [ $EXIT_CODE -eq 0 ]; then
     if should_assign_eip; then
       eip_assign || EXIT_CODE=1
     else
-        # we should not assign eip, therefore we assume we already have a public ip
         (retry check_private_ip && retry add_ip_tags && retry $PROVISION_COMMAND) || EXIT_CODE=1
     fi
   else
     echo "Failed to get private IP, no further provisioning possible.  This instance requires manual intervention"
   fi
-
   return $EXIT_CODE
 }
-# end of postinstall-eip-lib, this space intentionally left blank

--- a/terraform/lib/postinstall-footer.sh
+++ b/terraform/lib/postinstall-footer.sh
@@ -1,31 +1,18 @@
-
-# run main function implemented by specific role
 [ -z "$MAIN_COMMAND" ] && MAIN_COMMAND=default_main
 $MAIN_COMMAND
 EXIT_CODE=$?
 if [ ! $EXIT_CODE -eq 0 ]; then
-
   if [ -f $tmp_msg_file ]; then
     err_message=$(cat $tmp_msg_file)
   else
     err_message="unknown"
   fi
-
   echo "Unsuccessful postinstall, error message $err_message"
   [ -z "$DUMP_COMMAND" ] && DUMP_COMMAND=default_dump
   $DUMP_COMMAND
-
   if [ "$SKIP_TERMINATION" != "true" ]; then
     [ -z "$TERMINATE_INSTANCE_COMMAND" ] && TERMINATE_INSTANCE_COMMAND=default_terminate
-
     echo "Terminating is enabled, so running terminate command $TERMINATE_INSTANCE_COMMAND"
-
-    # retry in a loop rather than recursing: recursion eventually overflows the
-    # stack and segfaults, silently ending the retries. If the OCI API is
-    # unreachable (e.g. no public IP was ever attached), try to restore
-    # connectivity via a late-appearing secondary VNIC before each attempt.
-    # The instance is deliberately left RUNNING while retries continue so the
-    # autoscaler counts it as untracked and an operator can intervene.
     while true; do
       if ! oci_api_reachable; then
         restore_oci_connectivity
@@ -34,11 +21,9 @@ if [ ! $EXIT_CODE -eq 0 ]; then
       echo "Terminate command $TERMINATE_INSTANCE_COMMAND failed, sleeping 60 then retrying"
       sleep 60
     done
-
   else
     echo "Skipping termination of instance"
   fi
-
   exit $EXIT_CODE
 else
   echo "Successful postinstall"

--- a/terraform/lib/postinstall-lib.sh
+++ b/terraform/lib/postinstall-lib.sh
@@ -1,4 +1,3 @@
-
 BOOTSTRAP_DIRECTORY="/tmp/bootstrap"
 LOCAL_REPO_DIRECTORY="/opt/jitsi/bootstrap"
 function check_private_ip() {
@@ -27,17 +26,12 @@ function retry() {
   [ -z "$RETRIES" ] && RETRIES=10
   until [ $n -ge $RETRIES ]
   do
-    # call the function given as parameter
     $1
-    # check the result of the function
     if [ $? -eq 0 ]; then
-      # success
       > $tmp_msg_file
       break
     else
-      # failure, therefore retry
       n=$[$n+1]
-      # only sleep if we're not going to be done with the loop
       if [ $n -lt $RETRIES ]; then
         sleep 10
       fi
@@ -71,7 +65,6 @@ function add_ip_tags() {
       return 2
     fi
 }
-
 function next_device() { 
   DEVICE_PREFIX="/dev/oracleoci/oraclevd"
   ALPHA=( {a..z} ) 
@@ -83,7 +76,6 @@ function next_device() {
     fi
   done
 }
-
 function init_volume() {
   DEVICE=$1
   LABEL=$2
@@ -204,7 +196,6 @@ function set_hostname() {
   MY_HOSTNAME=$2
   MY_IP=`curl -s curl http://169.254.169.254/opc/v1/vnics/ | jq .[0].privateIp -r`
   if [ -z "$MY_HOSTNAME" ]; then
-    #clear domain if null
     [ "$DOMAIN" == "null" ] && DOMAIN=
     [ -z "$DOMAIN" ] && DOMAIN="oracle.jitsi.net"
     MY_COMPONENT_NUMBER="$(echo $MY_IP | awk -F. '{print $2"-"$3"-"$4}')"
@@ -296,10 +287,6 @@ function default_provision() {
 }
 VNIC_METADATA_LOG="/var/log/vnic-metadata-debug.log"
 function fetch_vnics_metadata() {
-  # fetch VNIC metadata, capturing the verbose exchange (request/response
-  # headers incl. X-Request-Id) to $VNIC_METADATA_LOG and stderr so it lands
-  # in cloud-init-output.log for correlation with OCI support; only the body
-  # goes to stdout for callers to parse
   local verbose_log=$(mktemp) body=$(mktemp)
   curl -sv --connect-timeout 10 http://169.254.169.254/opc/v1/vnics/ -o "$body" 2> "$verbose_log"
   {
@@ -311,7 +298,6 @@ function fetch_vnics_metadata() {
   cat "$body"
   rm -f "$verbose_log" "$body"
 }
-
 function oci_api_reachable() {
   local region=$(curl --connect-timeout 10 -s http://169.254.169.254/opc/v1/instance/ | jq -r .canonicalRegionName)
   local http_code=$(curl -s -m 10 -o /dev/null -w '%{http_code}' "https://auth.${region}.oraclecloud.com/v1/x509")
@@ -321,11 +307,7 @@ function oci_api_reachable() {
   fi
   return 0
 }
-
 function restore_oci_connectivity() {
-  # the OCI API is unreachable when the primary VNIC never received a public
-  # IP; a secondary VNIC can appear in instance metadata minutes late, so
-  # re-check for one and route through it if found
   local secondary_ip=$(fetch_vnics_metadata | jq -r '.[1].privateIp')
   if [ -z "$secondary_ip" ] || [ "$secondary_ip" == "null" ]; then
     echo "No secondary VNIC in metadata, unable to restore OCI API connectivity"
@@ -338,7 +320,6 @@ function restore_oci_connectivity() {
   echo "Secondary VNIC with IP $secondary_ip found, switching default route to it to reach the OCI API"
   switch_to_secondary_vnic
 }
-
 function configure_primary_source_routing() {
   local vnics=$(curl --connect-timeout 10 -s http://169.254.169.254/opc/v1/vnics/)
   [ "$(echo "$vnics" | jq -r length 2>/dev/null)" -ge 2 ] 2>/dev/null || return 0
@@ -374,11 +355,8 @@ function configure_primary_source_routing() {
   done
   return 0
 }
-
 function default_terminate() {
-  # single attempt; the footer retries in a loop with connectivity self-healing
   echo "Terminating the instance; we enable debug to have more details in case of oci cli failures"
   INSTANCE_ID=`curl --connect-timeout 10 -s http://169.254.169.254/opc/v1/instance/ | jq -r .id`
   sudo /usr/local/bin/oci compute instance terminate --debug --instance-id "$INSTANCE_ID" --preserve-boot-volume false --auth instance_principal --force
 }
-# end of postinstall-lib, this space intentionally left blank

--- a/terraform/nomad-instance-pool/nomad-instance-pool-stack.tf
+++ b/terraform/nomad-instance-pool/nomad-instance-pool-stack.tf
@@ -122,7 +122,7 @@ resource "oci_core_instance_configuration" "oci_instance_configuration_use_eip" 
       }
 
       metadata = {
-        user_data = base64encode(join("",[
+        user_data = base64gzip(join("",[
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-header.sh"), # load the header
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-lib.sh"), # load the lib
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-eip-lib.sh"), # load the EIP lib
@@ -189,7 +189,7 @@ resource "oci_core_instance_configuration" "oci_instance_configuration" {
       }
 
       metadata = {
-        user_data = base64encode(join("",[
+        user_data = base64gzip(join("",[
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-header.sh"), # load the header
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-lib.sh"), # load the lib
           "\nexport INFRA_CONFIGURATION_REPO=${var.infra_configuration_repo}\nexport INFRA_CUSTOMIZATIONS_REPO=${var.infra_customizations_repo}\n", #repo variables

--- a/terraform/nomad-pool/nomad-pool-stack.tf
+++ b/terraform/nomad-pool/nomad-pool-stack.tf
@@ -138,7 +138,7 @@ resource "oci_core_instance_configuration" "oci_instance_configuration" {
       }
 
       metadata = {
-        user_data = base64encode(join("",[
+        user_data = base64gzip(join("",[
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-header.sh"), # load the header
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-lib.sh"), # load the lib
           "\nexport INFRA_CONFIGURATION_REPO=${var.infra_configuration_repo}\nexport INFRA_CUSTOMIZATIONS_REPO=${var.infra_customizations_repo}\n", #repo variables

--- a/terraform/nomad-server/nomad-server-stack.tf
+++ b/terraform/nomad-server/nomad-server-stack.tf
@@ -96,7 +96,7 @@ resource "oci_core_instance_configuration" "oci_instance_configuration" {
       }
 
       metadata = {
-        user_data = base64encode(join("",[
+        user_data = base64gzip(join("",[
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-header.sh"), # load the header
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-lib.sh"), # load the lib
           "\nexport INFRA_CONFIGURATION_REPO=${var.infra_configuration_repo}\nexport INFRA_CUSTOMIZATIONS_REPO=${var.infra_customizations_repo}\n", #repo variables

--- a/terraform/ops-repo/create-ops-repo-oracle.tf
+++ b/terraform/ops-repo/create-ops-repo-oracle.tf
@@ -212,7 +212,7 @@ resource "oci_core_instance_configuration" "oci_instance_configuration" {
       }
 
       metadata = {
-        user_data = base64encode(join("",[
+        user_data = base64gzip(join("",[
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-header.sh"), # load the header
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-lib.sh"), # load the lib
           "\nexport INFRA_CONFIGURATION_REPO=${var.infra_configuration_repo}\nexport INFRA_CUSTOMIZATIONS_REPO=${var.infra_customizations_repo}\n", #repo variables

--- a/terraform/selenium-grid/instance-pool-nomad/instance-pool-nomad.tf
+++ b/terraform/selenium-grid/instance-pool-nomad/instance-pool-nomad.tf
@@ -111,7 +111,7 @@ resource "oci_core_instance_configuration" "oci_instance_configuration_node_arm"
       }
 
       metadata = {
-        user_data = base64encode(join("",[
+        user_data = base64gzip(join("",[
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-header.sh"), # load the header
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-lib.sh"), # load the lib
           "\nexport INFRA_CONFIGURATION_REPO=${var.infra_configuration_repo}\nexport INFRA_CUSTOMIZATIONS_REPO=${var.infra_customizations_repo}\n", #repo variables
@@ -167,7 +167,7 @@ resource "oci_core_instance_configuration" "oci_instance_configuration_node_x86"
       }
 
       metadata = {
-        user_data = base64encode(join("",[
+        user_data = base64gzip(join("",[
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-header.sh"), # load the header
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-lib.sh"), # load the lib
           "\nexport INFRA_CONFIGURATION_REPO=${var.infra_configuration_repo}\nexport INFRA_CUSTOMIZATIONS_REPO=${var.infra_customizations_repo}\n", #repo variables

--- a/terraform/selenium-grid/instance-pool/instance-pool.tf
+++ b/terraform/selenium-grid/instance-pool/instance-pool.tf
@@ -117,7 +117,7 @@ resource "oci_core_instance_configuration" "oci_instance_configuration_hub" {
       }
 
       metadata = {
-        user_data = base64encode(join("",[
+        user_data = base64gzip(join("",[
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-header.sh"), # load the header
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-lib.sh"), # load the lib
           "\nexport INFRA_CONFIGURATION_REPO=${var.infra_configuration_repo}\nexport INFRA_CUSTOMIZATIONS_REPO=${var.infra_customizations_repo}\n", #repo variables
@@ -171,7 +171,7 @@ resource "oci_core_instance_configuration" "oci_instance_configuration_node" {
       }
 
       metadata = {
-        user_data = base64encode(join("",[
+        user_data = base64gzip(join("",[
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-header.sh"), # load the header
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-lib.sh"), # load the lib
           "\nexport INFRA_CONFIGURATION_REPO=${var.infra_configuration_repo}\nexport INFRA_CUSTOMIZATIONS_REPO=${var.infra_customizations_repo}\n", #repo variables

--- a/terraform/shard-core/create-shard-core-oracle.tf
+++ b/terraform/shard-core/create-shard-core-oracle.tf
@@ -297,7 +297,7 @@ resource "oci_core_instance" "instance" {
     }
 
     metadata = {
-        user_data = base64encode(join("",[
+        user_data = base64gzip(join("",[
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-header.sh"), # load the header
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-lib.sh"), # load the lib
           "\nexport INFRA_CONFIGURATION_REPO=${var.infra_configuration_repo}\nexport INFRA_CUSTOMIZATIONS_REPO=${var.infra_customizations_repo}\n", #repo variables

--- a/terraform/standalone/create-standalone-server-oracle.tf
+++ b/terraform/standalone/create-standalone-server-oracle.tf
@@ -191,7 +191,7 @@ resource "oci_core_instance" "instance" {
     }
 
     metadata = {
-        user_data = base64encode(join("",[
+        user_data = base64gzip(join("",[
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-header.sh"), # load the header
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-lib.sh"), # load the lib
           file("${path.cwd}/${var.user_data_file}"), # load our customizations

--- a/terraform/wavefront-proxy/create-wavefront-proxy-oracle.tf
+++ b/terraform/wavefront-proxy/create-wavefront-proxy-oracle.tf
@@ -159,7 +159,7 @@ resource "oci_core_instance_configuration" "oci_instance_configuration" {
       }
 
       metadata = {
-        user_data = base64encode(join("",[
+        user_data = base64gzip(join("",[
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-header.sh"), # load the header
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-lib.sh"), # load the lib
           "\nINFRA_CONFIGURATION_REPO=${var.infra_configuration_repo}\nINFRA_CUSTOMIZATIONS_REPO=${var.infra_customizations_repo}\n", #repo variables


### PR DESCRIPTION
## Problem

Instance launches started failing on the stage-8x8 eu-frankfurt-1 coturn pool:

```
Metadata size is 37331 bytes and cannot be larger than 32000 bytes
```

The postinstall user-data (header + lib + eip-lib + runner + footer, plain base64) has grown past the OCI metadata cap. Measured on main: coturn assembles to **37,068 bytes** encoded; the JVB instance configuration to **~38,200** — so JVB (and nomad-instance-pool) would hit the same wall at their next instance-config rebuild. #1146 added the last ~2KB, but the payload was already over the limit before it; any rebuild from recent main would have failed.

## Fix

Two parts:

1. **`base64encode` → `base64gzip`** for all 22 `user_data` assembly sites (21 tf files). cloud-init transparently decompresses gzipped user data. Result: coturn **8,944 bytes**, JVB **9,224 bytes** — ~3.5x headroom. (firezone/jumpbox/thousandeyes deliver the script via SSH provisioner `content`, not metadata, and are deliberately untouched.)
2. **Strip comments and blank lines** from the shared lib files (`postinstall-lib.sh` −839B, `postinstall-eip-lib.sh` −1,296B, `postinstall-footer.sh` −508B). Deletions only — verified the diff removes no code lines.

Comment-stripping alone was measured insufficient (still 33–34KB encoded), which is why the gzip change is the load-bearing part.

## Verification

- all 23 assembled header+lib+eip-lib+runner+footer combinations pass `bash -n`
- every concatenated file ends with a trailing newline (the footer previously relied on a leading blank line as an accidental separator; that blank line is gone)
- gzip'd sizes measured with the exact assembly order the tf files use

Suggested first validation: rebuild the (currently broken) stage-8x8 eu-frankfurt-1 coturn instance config from this branch — it both fixes that pool and proves the gzip path end-to-end.

Tracking: [JIT-16318](https://agile.8x8.com/browse/JIT-16318)