### PR TITLE
fix: open nomad dynamic ports on the coturn NSG for telegraf scrapes (JIT-16318)

### DIFF
--- a/terraform/create-coturn-stack/create-coturn-stack-oracle.tf
+++ b/terraform/create-coturn-stack/create-coturn-stack-oracle.tf
@@ -191,6 +191,22 @@ resource "oci_core_network_security_group_security_rule" "nsg_rule_ingress_consu
   }
 }
 
+resource "oci_core_network_security_group_security_rule" "nsg_rule_ingress_nomad_dynamic_tcp" {
+  network_security_group_id = oci_core_network_security_group.coturn_network_security_group.id
+  direction = "INGRESS"
+  protocol = "6"
+  source = data.oci_core_vcns.vcns.virtual_networks[0].cidr_block
+  stateless = false
+  description = "nomad dynamic ports, including telegraf prometheus scrapes"
+
+  tcp_options {
+    destination_port_range {
+      min = 20000
+      max = 32000
+    }
+  }
+}
+
 
 // ============ COTURN INSTANCE POOL ============
 


### PR DESCRIPTION
## Problem

The nomad telegraf job on coturn nodes serves prometheus metrics on a **Nomad dynamic port** (20000-32000 range), but no coturn security rule allows that range from inside the VCN:

- coturn NSG: 22, 443 tcp/udp, 4646-4647, 8301 only
- per-env subnet security lists: 9126 only (the legacy host-telegraf port)

meet-jit-si scrapes work **by coincidence** — its coturn subnet opens TCP 20000-30000 for TURN relay, which happens to cover the dynamic ports. Environments serving TURN on 443 only (e.g. stage-8x8) have no working scrape path at all.

Verified on `stage-8x8-eu-frankfurt-1-coturn-79-2-227` (freshly launched with the policy-routing + gzip fixes, both working): telegraf listens on `*:24178`, local scrape returns 200, host iptables allows 20000-32000/tcp — but the scrape from the consul subnet is silently dropped at the cloud layer.

## Fix

One NSG ingress rule on the coturn network security group: **TCP 20000-32000 from the VCN CIDR**, same source pattern as the existing 8301 serf rule, matching the range host iptables already opens on nomad clients. Applies to every environment uniformly on next stack apply; VCN-internal only.

Tracking: [JIT-16318](https://agile.8x8.com/browse/JIT-16318) (rollout plan + prior PRs #1146 routing fix, #1147 user-data gzip)