### PR TITLE
fix: report real curl exit code when an autoscaler is unreachable

### DIFF
--- a/jenkins/groovy/demote-release/Jenkinsfile
+++ b/jenkins/groovy/demote-release/Jenkinsfile
@@ -1,5 +1,5 @@
 def listJVBPools(release_number) {
-    pools=[:]
+    def pools = []
     def poolsStr = sh(
         returnStdout: true,
         script: """

--- a/scripts/custom-autoscaler-list-groups.sh
+++ b/scripts/custom-autoscaler-list-groups.sh
@@ -86,10 +86,11 @@ function AutoscalerRequest() {
     -H "Authorization: Bearer $TOKEN" \
     $BODY 2>/dev/null)
 
-  if [[ $? -eq 0 ]]; then
+  CURL_EXIT_CODE=$?
+  if [[ $CURL_EXIT_CODE -eq 0 ]]; then
       RESPONSE_HTTP_CODE=200
   else
-    RESPONSE_HTTP_CODE=500
+    RESPONSE_HTTP_CODE=0
   fi
   RESPONSE_BODY="$RESPONSE_BODY_AND_STATUS"
 #  echo "Received response code: $RESPONSE_HTTP_CODE, body: $RESPONSE_BODY"
@@ -128,8 +129,8 @@ for AUTOSCALER in $AUTOSCALER_LIST; do
       fi
     fi
   else
-      >&2 echo "Error from HTTP REQUEST code: $RESPONSE_HTTP_CODE"
-      >&2 echo $RESPONSE_BODY
+      >&2 echo "No HTTP response from $AUTOSCALER_URL: curl exit code $CURL_EXIT_CODE (autoscaler missing or unreachable), skipping"
+      [ -n "$RESPONSE_BODY" ] && >&2 echo $RESPONSE_BODY
   fi
 done
 


### PR DESCRIPTION
## Summary
- `scripts/custom-autoscaler-list-groups.sh` fabricated \`Error from HTTP REQUEST code: 500\` whenever curl itself exited non-zero, which made DNS failures for the (not yet existing) per-region prod autoscalers look like server-side HTTP 500s during `demote-release`. It now captures the curl exit code and reports `No HTTP response from <url>: curl exit code N (autoscaler missing or unreachable), skipping`, and only echoes the response body when non-empty. The per-region probing itself is kept, since regional autoscalers for prod are planned.
- `demote-release` Jenkinsfile: declare `pools` with `def` (as a list, matching the String[] it holds when non-empty) to silence the two "Did you forget the def keyword" pipeline warnings.

## Testing
Ran `TOKEN=dummy ENVIRONMENT=prod-8x8 RELEASE_NUMBER=6626 scripts/custom-autoscaler-list-groups.sh` locally: the 8 unresolvable `prod-8x8-<region>-autoscaler.jitsi.net` hosts now report `curl exit code 6` and are skipped, while the central pilot/prod autoscalers are queried as before.