### PR TITLE
feat: optional OTLP distributed tracing for jitsi_meet_backend (docker-jitsi-meet#2303)

### DIFF
--- a/nomad/jitsi_packs/packs/jitsi_meet_backend/templates/_helpers.tpl
+++ b/nomad/jitsi_packs/packs/jitsi_meet_backend/templates/_helpers.tpl
@@ -143,6 +143,21 @@ block
       }
 [[- end ]]
 
+[[- /*
+
+## `tracing-otlp-base` helper
+
+Base URL of the OTLP receiver used for distributed tracing
+(docker-jitsi-meet#2303). Defaults to the regional alloy via the internal LB
+(deploy-nomad-alloy.sh registers <environment>-<region>-otel.<tld>); alloy
+forwards the spans on to Tempo (internal and Grafana Cloud).
+
+*/ -]]
+
+[[ define "tracing-otlp-base" -]]
+[[- or (env "CONFIG_tracing_otlp_endpoint") (print "https://" (env "CONFIG_environment") "-" (env "CONFIG_octo_region") "-otel.jitsi.net") -]]
+[[- end -]]
+
 [[ define "common-env" -]]
         ENABLE_JVB_XMPP_SERVER = "1"
         ENABLE_TRANSCRIPTIONS = "1"
@@ -196,4 +211,18 @@ block
         XMPP_RECORDER_DOMAIN = "recorder.[[ env "CONFIG_domain" ]]"
         XMPP_HIDDEN_DOMAIN = "recorder.[[ env "CONFIG_domain" ]]"
         JICOFO_OCTO_REGION = "[[ env "CONFIG_octo_region" ]]"
+[[- if eq (or (env "CONFIG_tracing_enabled") "false") "true" ]]
+[[- $tracingProtocol := or (env "CONFIG_tracing_protocol") "http" ]]
+        # Distributed tracing (docker-jitsi-meet#2303). Only the OTLP HTTP
+        # receiver (4318) is fabio-routed on the alloy job, so grpc only works
+        # with a custom endpoint. Image tags without the tracing templates
+        # ignore these vars, so this is safe to enable ahead of the images.
+        ENABLE_TRACING = "1"
+        # jicofo reads TRACING_ENDPOINT/TRACING_PROTOCOL; jicoco's HTTP OTLP
+        # exporter needs the full /v1/traces URL (it does not append a path).
+        TRACING_PROTOCOL = "[[ $tracingProtocol ]]"
+        TRACING_ENDPOINT = "[[ template "tracing-otlp-base" . ]][[ if eq $tracingProtocol "http" ]]/v1/traces[[ end ]]"
+        # prosody reads TRACING_HTTP_ENDPOINT and appends /v1/traces itself.
+        TRACING_HTTP_ENDPOINT = "[[ template "tracing-otlp-base" . ]]"
+[[- end ]]
 [[ end -]]

--- a/nomad/jitsi_packs/packs/jitsi_meet_backend/templates/jitsi_meet_backend.nomad.tpl
+++ b/nomad/jitsi_packs/packs/jitsi_meet_backend/templates/jitsi_meet_backend.nomad.tpl
@@ -855,6 +855,13 @@ EOH
         GLOBAL_MODULES = "admin_telnet,http_openmetrics,log_ringbuffer[[ if eq (env "CONFIG_prosody_mod_measure_stanza_counts") "true"]],measure_stanza_counts[[ end ]]"
         PROSODY_LOG_CONFIG="{level = \"debug\", to = \"ringbuffer\",size = [[ or (env "CONFIG_prosody_jvb_mod_log_ringbuffer_size") "1024*1024*4" ]], filename_template = \"traceback.txt\", event = \"debug_traceback/triggered\";};"
         TZ = "UTC"
+[[- if eq (or (env "CONFIG_tracing_enabled") "false") "true" ]]
+        # Distributed tracing (docker-jitsi-meet#2303); see common-env helper.
+        # The brewery prosody hosts no conference MUCs, so this emits little/no
+        # span data, but is kept for parity and is harmless when unused.
+        ENABLE_TRACING = "1"
+        TRACING_HTTP_ENDPOINT = "[[ template "tracing-otlp-base" . ]]"
+[[- end ]]
       }
 
       template {

--- a/scripts/deploy-nomad-shard-backend.sh
+++ b/scripts/deploy-nomad-shard-backend.sh
@@ -306,6 +306,12 @@ export CONFIG_signal_sidecar_tag="$SIGNAL_SIDECAR_IMAGE_TAG"
 [ -z "$CONFIG_visitors_count" ] && CONFIG_visitors_count=0
 [ -z "$CONFIG_nomad_enable_fabio_domain" ] && CONFIG_nomad_enable_fabio_domain="false"
 
+# optional distributed tracing (docker-jitsi-meet#2303); set tracing_enabled: true
+# in the environment yaml (exported as CONFIG_tracing_enabled by yamltoenv above).
+# Spans go over OTLP HTTP to the regional alloy, which forwards them to Tempo.
+[ -z "$CONFIG_tracing_enabled" ] && export CONFIG_tracing_enabled="false"
+[ -z "$CONFIG_tracing_otlp_endpoint" ] && export CONFIG_tracing_otlp_endpoint="https://$ENVIRONMENT-$ORACLE_REGION-otel.$TOP_LEVEL_DNS_ZONE_NAME"
+
 if [ -z "$CONFIG_force_pull" ]; then
     if [[ "$ENVIRONMENT_TYPE" == "prod" ]]; then
         export CONFIG_force_pull="false"


### PR DESCRIPTION
## What

Wires the distributed tracing added in [docker-jitsi-meet#2303](https://github.com/jitsi/docker-jitsi-meet/pull/2303) into the `jitsi_meet_backend` pack as an **opt-in**. jicofo, jvb, and prosody export OTLP spans to the existing regional **alloy** (`<env>-<region>-otel.<tld>`), which already forwards traces to internal Tempo and external Grafana Cloud Tempo — so no alloy changes are needed.

## How it works

- Gated on `CONFIG_tracing_enabled` (default **false**). Inert until an environment sets `tracing_enabled: true` in its site vars.
- New `tracing-otlp-base` helper defaults the endpoint to `<env>-<region>-otel.jitsi.net` (overridable via `CONFIG_tracing_otlp_endpoint`).
- `common-env` (prosody / prosody-vnode / jicofo) exports:
  - `ENABLE_TRACING=1`
  - `TRACING_PROTOCOL` + `TRACING_ENDPOINT` — consumed by jicofo/jvb (jicoco OTLP exporter). For `http` the endpoint includes the full `/v1/traces` path (the HTTP exporter does not append it).
  - `TRACING_HTTP_ENDPOINT` — consumed by prosody, which appends `/v1/traces` itself.
- Brewery `prosody-jvb` task gets the same gate (parity; emits little/no span data).
- Default protocol is **http** because only the OTLP HTTP receiver (4318) is fabio-routed on the alloy job; grpc needs a custom endpoint.

## Safety

Enabling the flag against image tags that predate the tracing templates is harmless — the env vars are ignored. Verified the current beta images (jicofo `1.0-1201-1`, jvb `2.3-312-...`, branded prosody `9416` ← `ghcr.io/jitsi/prosody:unstable`) all contain the tracing config templates + `jicoco-tracing`/OTLP jars.

## Testing

`nomad-pack render` verified for enabled / disabled / custom-endpoint(grpc) paths; disabled renders zero tracing vars. `bash -n` on the deploy script.

Companion PR in `infra-customizations-private` flips `tracing_enabled: true` for `beta-meet-jit-si`.