### PR TITLE
fix: declare loop counters and pools with def across release Jenkinsfiles

### DIFF
--- a/jenkins/groovy/create-release-jibri/Jenkinsfile
+++ b/jenkins/groovy/create-release-jibri/Jenkinsfile
@@ -191,7 +191,7 @@ pipeline {				//indicate the job is written in Declarative Pipeline
                     def cloud_list = utils.SplitClouds(env.ENVIRONMENT,env.CLOUDS);
                     echo "cloud list ${cloud_list}";
                     def branches = [:]
-                    for(i = 0; i < cloud_list.size(); i++) {
+                    for (def i = 0; i < cloud_list.size(); i++) {
                         def curr = i
                         def oracle_region = utils.OracleRegionFromCloud(cloud_list[curr])
                         echo "pipeline branch ${curr} for shard ${cloud_list[curr]} ${oracle_region}";

--- a/jenkins/groovy/demote-release/Jenkinsfile
+++ b/jenkins/groovy/demote-release/Jenkinsfile
@@ -192,7 +192,7 @@ pipeline {
                                 def shard_base = utils.GetShardBase(env.ENVIRONMENT)
                                 echo "cloud list ${cloud_list}";
                                 def branches = [:]
-                                for(i = 0; i < cloud_list.size(); i++) {
+                                for (def i = 0; i < cloud_list.size(); i++) {
                                     def curr = i
                                     def oracle_region = utils.OracleRegionFromCloud(cloud_list[curr])
                                     def pool_name = "${shard_base}-${oracle_region}-global-${env.RELEASE_NUMBER}"
@@ -260,7 +260,7 @@ pipeline {
                             echo "Setting desired count to 0 for pools: ${poolsToDrain}"
                             
                             def branches = [:]
-                            for(i = 0; i < poolsToDrain.size(); i++) {
+                            for (def i = 0; i < poolsToDrain.size(); i++) {
                                 def pcurr = i
                                 branches["Scale down ${poolsToDrain[pcurr]}"] = {
                                     setPoolDesiredCount(env.ENVIRONMENT, poolsToDrain[pcurr], 0, 0, 0)
@@ -297,7 +297,7 @@ pipeline {
                             poolsToDelete.addAll(remotePools)
                             
                             if (poolsToDelete.size() > 0) {
-                                for(i = 0; i < poolsToDelete.size(); i++) {
+                                for (def i = 0; i < poolsToDelete.size(); i++) {
                                     def pcurr = i
                                     branches["Pool ${poolsToDelete[pcurr]}"] = {
                                         deleteJVBPool(
@@ -449,7 +449,7 @@ pipeline {
                             echo "Deleting ${shardsToDrain.size()} drained shards"
 
                             def branches = [:]
-                            for(i = 0; i < shardsToDrain.size(); i++) {
+                            for (def i = 0; i < shardsToDrain.size(); i++) {
                                 def scurr = i
                                 def shardName = shardsToDrain[scurr]
                                 branches["Delete ${shardName}"] = {

--- a/jenkins/groovy/destroy-release-core/Jenkinsfile
+++ b/jenkins/groovy/destroy-release-core/Jenkinsfile
@@ -1,6 +1,6 @@
 
 def listPools() {
-    pools=[:]
+    def pools = []
     def poolsStr = sh(
         returnStdout: true,
         script: """
@@ -171,7 +171,7 @@ pipeline {
                             def shards = listShards();
                             if ((pools.size() > 0) || (shards.size()>0)) {
                                 if (pools.size() > 0) {
-                                    for(i = 0; i < pools.size(); i++) {
+                                    for (def i = 0; i < pools.size(); i++) {
                                         def curr = i
 
                                         branches["Pool ${pools[curr]}"] = {
@@ -183,7 +183,7 @@ pipeline {
                                     }
                                 }
                                 if (shards.size() > 0) {
-                                    for(i = 0; i < shards.size(); i++) {
+                                    for (def i = 0; i < shards.size(); i++) {
                                         def scurr = i
                                         branches["Shard ${shards[scurr]}"] = {
                                             deleteShard(

--- a/jenkins/groovy/destroy-release-jvb-pool/Jenkinsfile
+++ b/jenkins/groovy/destroy-release-jvb-pool/Jenkinsfile
@@ -1,6 +1,6 @@
 
 def listPools() {
-    pools=[:]
+    def pools = []
     def poolsStr = sh(
         returnStdout: true,
         script: """
@@ -65,7 +65,7 @@ pipeline {
                         dir("infra-provisioning") {
                             def pools = listPools();
                             if (pools.size() > 0) {
-                                for(i = 0; i < pools.size(); i++) {
+                                for (def i = 0; i < pools.size(); i++) {
                                     def curr = i
 
                                     branches["Pool ${pools[curr]}"] = {

--- a/jenkins/groovy/expand-release-core/Jenkinsfile
+++ b/jenkins/groovy/expand-release-core/Jenkinsfile
@@ -103,7 +103,7 @@ pipeline {				//indicate the job is written in Declarative Pipeline
                             aws_shards_by_cloud = shards_by_cloud.awsShardsByCloud
                             def branches = [:]
                             def i = 0;
-                            for(i = 0; i < cloud_list.size(); i++) {
+                            for (def i = 0; i < cloud_list.size(); i++) {
                                 def curr = i
                                 echo "pipeline branch ${curr} for shard ${cloud_list[curr]}";
                                 if (aws_shards_by_cloud.containsKey(cloud_list[curr])) {
@@ -126,7 +126,7 @@ pipeline {				//indicate the job is written in Declarative Pipeline
                                     }
                                 }
                             }
-                            for(i = 0; i < cloud_list.size(); i++) {
+                            for (def i = 0; i < cloud_list.size(); i++) {
                                 def curr = i
                                 echo "pipeline branch ${curr} for shard ${cloud_list[curr]}";
                                 if (oracle_shards_by_cloud.containsKey(cloud_list[curr])) {
@@ -134,7 +134,7 @@ pipeline {				//indicate the job is written in Declarative Pipeline
                                     def oracle_shards = oracle_shards_by_cloud[cloud_list[curr]].split(' ')
                                     def shard_count = oracle_shards.size();
                                     echo "createShard ${env.ENVIRONMENT} ${cloud_list[curr]} ${shard_count.toString()} ${oracle_shards_by_cloud[cloud_list[curr]]} ${env.RELEASE_NUMBER} ${env.RELEASE_BRANCH} ${env.JVB_VERSION} ${env.SIGNAL_VERSION}"
-                                    for(j = 0; j < shard_count; j++) {
+                                    for (def j = 0; j < shard_count; j++) {
                                         def s = j
                                         branches["oracle ${cloud_list[curr]} ${j}"] = {
                                             createShard(env.ENVIRONMENT,

--- a/jenkins/groovy/provision-shard/Jenkinsfile
+++ b/jenkins/groovy/provision-shard/Jenkinsfile
@@ -322,12 +322,12 @@ pipeline {
                     def out_shard_pool_size_1_4_as_int = shardPropertiesOracle.OUT_SHARD_POOL_SIZE_1_4 as int
                     def jvb_autoscaler_enabled=shardPropertiesOracle.OUT_JVB_AUTOSCALER_ENABLED.toString()
 
-                    for(i = 0; i < stack_ids.size(); i++) {
+                    for (def i = 0; i < stack_ids.size(); i++) {
                         def curr = i
                         scale_to_size_per_shard[curr] = 0
                     }
 
-                    for(i = 0; i < stack_ids.size(); i++) {
+                    for (def i = 0; i < stack_ids.size(); i++) {
                         def curr = i
                         // Shards in new_shards.properties are in reverse order than the stacks
                         def shard_index = stack_ids.size() - curr - 1;

--- a/jenkins/groovy/recycle-release-core/Jenkinsfile
+++ b/jenkins/groovy/recycle-release-core/Jenkinsfile
@@ -158,7 +158,7 @@ pipeline {				//indicate the job is written in Declarative Pipeline
                 script {
                     def branches = [:]
                     if (oldShards.size() > 0) {
-                        for(i = 0; i < oldShards.size(); i++) {
+                        for (def i = 0; i < oldShards.size(); i++) {
                             def scurr = i
                             branches["Shard ${oldShards[scurr]}"] = {
                                 deleteShard(

--- a/jenkins/groovy/release-core/Jenkinsfile
+++ b/jenkins/groovy/release-core/Jenkinsfile
@@ -443,7 +443,7 @@ pipeline {
                                     ]
                                 }
                             }
-                            for(i = 0; i < cloud_list.size(); i++) {
+                            for (def i = 0; i < cloud_list.size(); i++) {
                                 def curr = i
                                 branches["JVB Pools ${cloud_list[curr]}"] = {
                                     releaseJVBPools(env.ENVIRONMENT,

--- a/jenkins/groovy/release-coturn/Jenkinsfile
+++ b/jenkins/groovy/release-coturn/Jenkinsfile
@@ -1,6 +1,6 @@
 def oracle_regions(cloud_list) {
     def oracle_regions=[]
-    for(i = 0; i < cloud_list.size(); i++) {
+    for (def i = 0; i < cloud_list.size(); i++) {
         oracle_regions[i] = sh(
             returnStdout: true,
             script: """#!/bin/bash
@@ -135,7 +135,7 @@ pipeline {				//indicate the job is written in Declarative Pipeline
                         def oracle_region = oracle_regions(cloud_list);
                         echo "cloud list ${cloud_list}";
                         def branches = [:]
-                        for(i = 0; i < cloud_list.size(); i++) {
+                        for (def i = 0; i < cloud_list.size(); i++) {
                             def curr = i
                             echo "pipeline branch ${curr} for stack in ${cloud_list[curr]}";
                             branches["Build ${cloud_list[curr]}"] = {

--- a/jenkins/groovy/release-haproxy/Jenkinsfile
+++ b/jenkins/groovy/release-haproxy/Jenkinsfile
@@ -1,6 +1,6 @@
 def oracle_regions(cloud_list) {
     def oracle_regions=[]
-    for(i = 0; i < cloud_list.size(); i++) {
+    for (def i = 0; i < cloud_list.size(); i++) {
         oracle_regions[i] = sh(
             returnStdout: true,
             script: """#!/bin/bash

--- a/jenkins/groovy/release-jigasi/Jenkinsfile
+++ b/jenkins/groovy/release-jigasi/Jenkinsfile
@@ -187,7 +187,7 @@ pipeline {				//indicate the job is written in Declarative Pipeline
                     def cloud_list = utils.SplitClouds(env.ENVIRONMENT,env.CLOUDS);
                     echo "cloud list ${cloud_list}";
                     def branches = [:]
-                    for(i = 0; i < cloud_list.size(); i++) {
+                    for (def i = 0; i < cloud_list.size(); i++) {
                         def curr = i
                         echo "pipeline branch ${curr} for shard ${cloud_list[curr]}";
                         branches["Build ${cloud_list[curr]}"] = {

--- a/jenkins/groovy/release-jvb-nomad-pools/Jenkinsfile
+++ b/jenkins/groovy/release-jvb-nomad-pools/Jenkinsfile
@@ -61,7 +61,7 @@ pipeline {
                         def cloud_list = utils.SplitClouds(env.ENVIRONMENT,env.CLOUDS);
                         echo "cloud list ${cloud_list}";
                         def branches = [:]
-                        for(i = 0; i < cloud_list.size(); i++) {
+                        for (def i = 0; i < cloud_list.size(); i++) {
                             def curr = i
                             branches["JVB Pools ${cloud_list[curr]}"] = {
                                 releaseJVBNomadPools(env.ENVIRONMENT,

--- a/jenkins/groovy/release-jvb-pools/Jenkinsfile
+++ b/jenkins/groovy/release-jvb-pools/Jenkinsfile
@@ -67,7 +67,7 @@ pipeline {
                     dir("infra-provisioning") {
                         def modes = poolModes();
                         if (modes.size() > 0) {
-                            for(i = 0; i < modes.size(); i++) {
+                            for (def i = 0; i < modes.size(); i++) {
                                 def curr = i
 
                                 branches["Pool ${modes[curr]}"] = {

--- a/jenkins/groovy/release-jvb/Jenkinsfile
+++ b/jenkins/groovy/release-jvb/Jenkinsfile
@@ -244,11 +244,11 @@ pipeline {
                         def cloud_list = utils.SplitClouds(env.ENVIRONMENT,env.CLOUDS);
                         echo "cloud list ${cloud_list}";
                         def branches = [:]
-                        for(i = 0; i < cloud_list.size(); i++) {
+                        for (def i = 0; i < cloud_list.size(); i++) {
                           def curr = i
                           if (skipShardJVBs == 'false') {
                             def shards = cloud_shards(env.ENVIRONMENT, cloud_list[curr])
-                            for(s = 0; s < shards.size(); s++) {
+                            for (def s = 0; s < shards.size(); s++) {
                                 def scurr=s
                                 if(shards[scurr]) {
                                     echo "pipeline branch ${curr} for shard ${shards[scurr]} cloud ${cloud_list[curr]}";
@@ -271,7 +271,7 @@ pipeline {
                             }
                           }
                             def pools = cloud_pools(env.ENVIRONMENT, cloud_list[curr])
-                            for(p = 0; p < pools.size(); p++) {
+                            for (def p = 0; p < pools.size(); p++) {
                                 def pcurr=p
                                 if(pools[pcurr]) {
                                     echo "pipeline branch ${pcurr} for pool ${pools[pcurr]} cloud ${cloud_list[curr]}";

--- a/jenkins/groovy/release-nomad-alert-emailer/Jenkinsfile
+++ b/jenkins/groovy/release-nomad-alert-emailer/Jenkinsfile
@@ -80,7 +80,7 @@ pipeline {
                     def region_list = utils.SplitNomadRegions(env.ENVIRONMENT,env.REGIONS);
                     echo "regions: ${region_list}";
                     def branches = [:]
-                    for(i = 0; i < region_list.size(); i++) {
+                    for (def i = 0; i < region_list.size(); i++) {
                         def oracle_region = region_list[i]
                         echo "pipeline branch ${i} for ${oracle_region}";
                         branches["Build alert-emailer-${oracle_region}"] = {

--- a/jenkins/groovy/release-nomad-alertmanager/Jenkinsfile
+++ b/jenkins/groovy/release-nomad-alertmanager/Jenkinsfile
@@ -80,7 +80,7 @@ pipeline {
                     def region_list = utils.SplitNomadRegions(env.ENVIRONMENT,env.REGIONS);
                     echo "regions: ${region_list}";
                     def branches = [:]
-                    for(i = 0; i < region_list.size(); i++) {
+                    for (def i = 0; i < region_list.size(); i++) {
                         def oracle_region = region_list[i]
                         echo "pipeline branch ${i} for ${oracle_region}";
                         branches["Build alertmanager-${oracle_region}"] = {

--- a/jenkins/groovy/release-nomad-autoscaler/Jenkinsfile
+++ b/jenkins/groovy/release-nomad-autoscaler/Jenkinsfile
@@ -83,7 +83,7 @@ pipeline {				//indicate the job is written in Declarative Pipeline
                     def cloud_list = utils.SplitClouds(env.ENVIRONMENT,env.CLOUDS);
                     echo "cloud list ${cloud_list}";
                     def branches = [:]
-                    for(i = 0; i < cloud_list.size(); i++) {
+                    for (def i = 0; i < cloud_list.size(); i++) {
                         def curr = i
                         def oracle_region = utils.OracleRegionFromCloud(cloud_list[curr])
                         echo "pipeline branch ${curr} for ${cloud_list[curr]} ${oracle_region}";

--- a/jenkins/groovy/release-nomad-cloudprober/Jenkinsfile
+++ b/jenkins/groovy/release-nomad-cloudprober/Jenkinsfile
@@ -80,7 +80,7 @@ pipeline {
                     def region_list = utils.SplitNomadRegions(env.ENVIRONMENT,env.REGIONS);
                     echo "region list ${region_list}";
                     def branches = [:]
-                    for(i = 0; i < region_list.size(); i++) {
+                    for (def i = 0; i < region_list.size(); i++) {
                         def oracle_region = region_list[i]
                         echo "pipeline branch ${i} for ${oracle_region}";
                         branches["Build cloudprober-${oracle_region}"] = {

--- a/jenkins/groovy/release-nomad-collectors/Jenkinsfile
+++ b/jenkins/groovy/release-nomad-collectors/Jenkinsfile
@@ -79,7 +79,7 @@ pipeline {
                     def region_list = utils.SplitNomadRegions(env.ENVIRONMENT,env.REGIONS);
                     echo "regions: ${region_list}";
                     def branches = [:]
-                    for(i = 0; i < region_list.size(); i++) {
+                    for (def i = 0; i < region_list.size(); i++) {
                         def oracle_region = region_list[i]
                         echo "pipeline branch ${i} for ${oracle_region}";
                         branches["Build vector-${oracle_region}"] = {

--- a/jenkins/groovy/release-nomad-fabio/Jenkinsfile
+++ b/jenkins/groovy/release-nomad-fabio/Jenkinsfile
@@ -80,7 +80,7 @@ pipeline {				//indicate the job is written in Declarative Pipeline
                     def cloud_list = utils.SplitClouds(env.ENVIRONMENT,env.CLOUDS);
                     echo "cloud list ${cloud_list}";
                     def branches = [:]
-                    for(i = 0; i < cloud_list.size(); i++) {
+                    for (def i = 0; i < cloud_list.size(); i++) {
                         def curr = i
                         def oracle_region = utils.OracleRegionFromCloud(cloud_list[curr])
                         echo "pipeline branch ${curr} for ${cloud_list[curr]} ${oracle_region}";

--- a/jenkins/groovy/release-nomad-job/Jenkinsfile
+++ b/jenkins/groovy/release-nomad-job/Jenkinsfile
@@ -114,7 +114,7 @@ pipeline {				//indicate the job is written in Declarative Pipeline
                     def region_list = utils.SplitNomadRegions(env.ENVIRONMENT,env.REGIONS);
                     echo "region list ${region_list}";
                     def branches = [:]
-                    for(i = 0; i < region_list.size(); i++) {
+                    for (def i = 0; i < region_list.size(); i++) {
                         def oracle_region = region_list[i]
                         echo "pipeline branch ${i} for ${oracle_region}";
                         branches["Build job-${oracle_region}"] = {

--- a/jenkins/groovy/release-nomad-loki/Jenkinsfile
+++ b/jenkins/groovy/release-nomad-loki/Jenkinsfile
@@ -79,7 +79,7 @@ pipeline {
                     def region_list = utils.SplitNomadRegions(env.ENVIRONMENT,env.REGIONS);
                     echo "regions: ${region_list}";
                     def branches = [:]
-                    for(i = 0; i < region_list.size(); i++) {
+                    for (def i = 0; i < region_list.size(); i++) {
                         def oracle_region = region_list[i]
                         echo "pipeline branch ${i} for ${oracle_region}";
                         branches["Build loki-${oracle_region}"] = {

--- a/jenkins/groovy/release-nomad-prometheus/Jenkinsfile
+++ b/jenkins/groovy/release-nomad-prometheus/Jenkinsfile
@@ -80,7 +80,7 @@ pipeline {
                     def region_list = utils.SplitNomadRegions(env.ENVIRONMENT,env.REGIONS);
                     echo "regions: ${region_list}";
                     def branches = [:]
-                    for(i = 0; i < region_list.size(); i++) {
+                    for (def i = 0; i < region_list.size(); i++) {
                         def oracle_region = region_list[i]
                         echo "pipeline branch ${i} for ${oracle_region}";
                         branches["Build prometheus-${oracle_region}"] = {

--- a/jenkins/groovy/release-nomad-shimmy/Jenkinsfile
+++ b/jenkins/groovy/release-nomad-shimmy/Jenkinsfile
@@ -80,7 +80,7 @@ pipeline {
                     def region_list = utils.SplitNomadRegions(env.ENVIRONMENT,env.REGIONS);
                     echo "regions: ${region_list}";
                     def branches = [:]
-                    for(i = 0; i < region_list.size(); i++) {
+                    for (def i = 0; i < region_list.size(); i++) {
                         def oracle_region = region_list[i]
                         echo "pipeline branch ${i} for ${oracle_region}";
                         branches["Build shimmy-${oracle_region}"] = {

--- a/jenkins/groovy/release-nomad-telegraf/Jenkinsfile
+++ b/jenkins/groovy/release-nomad-telegraf/Jenkinsfile
@@ -77,7 +77,7 @@ pipeline {
                     def region_list = utils.SplitNomadRegions(env.ENVIRONMENT,env.REGIONS);
                     echo "region list ${region_list}";
                     def branches = [:]
-                    for(i = 0; i < region_list.size(); i++) {
+                    for (def i = 0; i < region_list.size(); i++) {
                         def oracle_region = region_list[i]
                         echo "pipeline branch ${i} for ${oracle_region}";
                         branches["Build telegraf-${oracle_region}"] = {

--- a/jenkins/groovy/release-nomad-vector/Jenkinsfile
+++ b/jenkins/groovy/release-nomad-vector/Jenkinsfile
@@ -80,7 +80,7 @@ pipeline {				//indicate the job is written in Declarative Pipeline
                     def cloud_list = utils.SplitClouds(env.ENVIRONMENT,env.CLOUDS);
                     echo "cloud list ${cloud_list}";
                     def branches = [:]
-                    for(i = 0; i < cloud_list.size(); i++) {
+                    for (def i = 0; i < cloud_list.size(); i++) {
                         def curr = i
                         def oracle_region = utils.OracleRegionFromCloud(cloud_list[curr])
                         echo "pipeline branch ${curr} for ${cloud_list[curr]} ${oracle_region}";

--- a/jenkins/groovy/release-nomad-wavefront-proxy/Jenkinsfile
+++ b/jenkins/groovy/release-nomad-wavefront-proxy/Jenkinsfile
@@ -81,7 +81,7 @@ pipeline {				//indicate the job is written in Declarative Pipeline
                     def cloud_list = utils.SplitClouds(env.ENVIRONMENT,env.CLOUDS);
                     echo "cloud list ${cloud_list}";
                     def branches = [:]
-                    for(i = 0; i < cloud_list.size(); i++) {
+                    for (def i = 0; i < cloud_list.size(); i++) {
                         def curr = i
                         def oracle_region = utils.OracleRegionFromCloud(cloud_list[curr])
                         echo "pipeline branch ${curr} for ${cloud_list[curr]} ${oracle_region}";

--- a/jenkins/groovy/release-sip-jibri/Jenkinsfile
+++ b/jenkins/groovy/release-sip-jibri/Jenkinsfile
@@ -198,7 +198,7 @@ pipeline {				//indicate the job is written in Declarative Pipeline
                     def cloud_list = split_clouds(env.ENVIRONMENT,env.CLOUDS);
                     echo "cloud list ${cloud_list}";
                     def branches = [:]
-                    for(i = 0; i < cloud_list.size(); i++) {
+                    for (def i = 0; i < cloud_list.size(); i++) {
                         def curr = i
                         echo "pipeline branch ${curr} for shard ${cloud_list[curr]}";
                         branches["Build ${cloud_list[curr]}"] = {


### PR DESCRIPTION
## Summary
Follow-on to #1149, expanded to cover the whole `jenkins/groovy/` tree. Undeclared variables in WorkflowScripts bind as script fields and emit one "Did you forget the \`def\` keyword?" warning per iteration at runtime.

- **demote-release**: the four `for(i = 0; ...)` loops (provision global pool, scale-down pools, delete pools, delete drained shards) now declare the counter with `def`.
- **All other release/provision/destroy Jenkinsfiles** (27 files): same mechanical fix for every `for(<counter> = 0; ...)` loop (counters `i`, `j`, `s`, `p`), e.g. release-core, release-jvb, release-coturn, expand/recycle/destroy-release-core, provision-shard, create-release-jibri, release-jigasi, release-sip-jibri, and the release-nomad-* family.
- **destroy-release-core / destroy-release-jvb-pool**: their `listPools()` copies had the same `pools=[:]` field assignment fixed in #1149 for demote-release — now `def pools = []`.

Counters declared in a for-init are scoped to the loop in Groovy, so files with multiple sequential loops (provision-shard, destroy-release-core, expand-release-core) compile fine.

Purely mechanical — no behavior change.