### PR TITLE
fix: NPE after drain waits in demote-release (toInteger on sleep's return)

### DIFF
--- a/jenkins/groovy/demote-release/Jenkinsfile
+++ b/jenkins/groovy/demote-release/Jenkinsfile
@@ -279,7 +279,7 @@ pipeline {
                     steps {
                         script {
                             echo "Sleeping for ${env.POOL_DRAIN_WAIT_PERIOD} seconds to allow pools to drain"
-                            sleep (env.POOL_DRAIN_WAIT_PERIOD ?: '3600').toInteger()
+                            sleep((env.POOL_DRAIN_WAIT_PERIOD ?: '3600').toInteger())
                         }
                     }
                 }
@@ -434,7 +434,7 @@ pipeline {
                     steps {
                         script {
                             echo "Sleeping for ${env.DRAIN_WAIT_PERIOD} seconds to allow shards to drain"
-                            sleep (env.DRAIN_WAIT_PERIOD ?: '21600').toInteger()
+                            sleep((env.DRAIN_WAIT_PERIOD ?: '21600').toInteger())
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
Follow-on to #1151. The demote-release run failed with `java.lang.NullPointerException: Cannot invoke method toInteger() on null object` at WorkflowScript:282 — exactly one hour after the pools were scaled to 0.

Groovy parses `sleep (X).toInteger()` as `(sleep(X)).toInteger()`: the `sleep` step receives the raw string (which it coerces itself, so the wait actually works), returns `null`, and the `.toInteger()` then NPEs — failing the Demote Pools branch *after* the drain wait completes, before the pool deletion stage runs. The same bug was waiting in the shard-drain path (line 437, a 6-hour wait).

Both call sites now parenthesize the argument so `toInteger()` applies to the wait period, not sleep's return value:

```groovy
sleep((env.POOL_DRAIN_WAIT_PERIOD ?: '3600').toInteger())
sleep((env.DRAIN_WAIT_PERIOD ?: '21600').toInteger())
```

Checked the rest of jenkins/groovy/ — no other Jenkinsfile has this pattern.