### PR TITLE
fix(alloy): send X-Scope-OrgID on external Tempo trace export

### DIFF
--- a/nomad/alloy-external.hcl
+++ b/nomad/alloy-external.hcl
@@ -263,6 +263,12 @@ otelcol.exporter.otlphttp "external_tempo" {
   client {
     endpoint = "[[ index .Data.data "${var.environment_type}-01-oci-traces-url" | regexReplaceAll "/v1/traces$" "" ]]"
     auth     = otelcol.auth.basic.external_tempo.handler
+    // The OCI o11y Tempo gateway is multi-tenant and rejects pushes without a
+    // tenant header ("no org id" 503). Same convention as prometheus.hcl:
+    // X-Scope-OrgID == the OCI username.
+    headers = {
+      "X-Scope-OrgID" = "[[ index .Data.data "meetings-oci-hosts-${var.environment_type}-01-oci-traces-username" ]]",
+    }
   }
 }
 

--- a/nomad/alloy.hcl
+++ b/nomad/alloy.hcl
@@ -295,6 +295,12 @@ otelcol.exporter.otlphttp "external_tempo" {
   client {
     endpoint = "[[ index .Data.data "${var.environment_type}-01-oci-traces-url" | regexReplaceAll "/v1/traces$" "" ]]"
     auth     = otelcol.auth.basic.external_tempo.handler
+    // The OCI o11y Tempo gateway is multi-tenant and rejects pushes without a
+    // tenant header ("no org id" 503). Same convention as prometheus.hcl:
+    // X-Scope-OrgID == the OCI username.
+    headers = {
+      "X-Scope-OrgID" = "[[ index .Data.data "meetings-oci-hosts-${var.environment_type}-01-oci-traces-username" ]]",
+    }
   }
 }
 


### PR DESCRIPTION
## Problem

Beta is the first environment to actually emit backend distributed traces (docker-jitsi-meet#2303, wired up in #1150). As soon as it did, **100% of spans were dropped on export** — `otelcol_exporter_send_failed_spans_total` == received, `sent` == 0.

Alloy logs show the external Tempo exporter failing:
```
otelcol.exporter.otlphttp.external_tempo ... request to
https://tempo-nonprod01-iad-ext.o11y-nonprod.oci.infra8.8x8cloud.net/v1/traces
responded with HTTP Status Code 503, Message=no org id
```

The OCI o11y Tempo gateway is **multi-tenant** and requires an `X-Scope-OrgID` header. The `external_tempo` exporter only sent basic auth, so every push was rejected. (The matching Grafana datasource `meetings-oci-hosts-*-oci-traces` authenticates the same way — `jsonData.httpHeaderName1 = X-Scope-OrgID`.)

## Fix

Add the tenant header to the `external_tempo` OTLP exporter in both `alloy.hcl` and `alloy-external.hcl`, using the OCI traces username as the org id — the same convention already used for Prometheus in [prometheus.hcl](nomad/prometheus.hcl#L234) (`X-Scope-OrgID == username`).

```hcl
headers = {
  "X-Scope-OrgID" = "[[ index .Data.data "meetings-oci-hosts-${var.environment_type}-01-oci-traces-username" ]]",
}
```

## Scope / notes

- Only touches the **external** Tempo exporter. The internal per-env `tempo` exporter also drops on beta (no Tempo deployed there / `-tempo` CNAME NXDOMAIN) — being handled separately by deploying per-env Tempo, so left as-is here.
- Latent bug: external trace export has never worked; it just wasn't exercised until now. Logs/metrics external export are unaffected.

## Verification after deploy

Redeploy alloy on beta, hold a test conference, then confirm `otelcol_exporter_sent_spans_total{exporter="otlphttp/external_tempo"}` climbs and traces appear in the `meetings-oci-hosts-nonprod-01-oci-traces` Tempo datasource (e.g. `{ name =~ "conference.*|colibri.*" }`).