### PR TITLE
fix(tempo): add OTLP ingest route so alloy can push traces to per-env Tempo

### DIFF
--- a/nomad/alloy-external.hcl
+++ b/nomad/alloy-external.hcl
@@ -217,10 +217,11 @@ otelcol.exporter.otlphttp "loki" {
   }
 }
 
-// Export traces to Tempo via internal LB
+// Export traces to Tempo via internal LB. Uses the -tempo-otlp hostname (Tempo's
+// OTLP ingest port 4318), NOT -tempo (the query API on 3200, which 404s on push).
 otelcol.exporter.otlphttp "tempo" {
   client {
-    endpoint = "https://[[ env "meta.environment" ]]-[[ env "meta.cloud_region" ]]-tempo.${var.top_level_domain}"
+    endpoint = "https://[[ env "meta.environment" ]]-[[ env "meta.cloud_region" ]]-tempo-otlp.${var.top_level_domain}"
   }
 }
 

--- a/nomad/alloy.hcl
+++ b/nomad/alloy.hcl
@@ -245,10 +245,11 @@ otelcol.exporter.otlphttp "loki" {
   }
 }
 
-// Export traces to Tempo via internal LB
+// Export traces to Tempo via internal LB. Uses the -tempo-otlp hostname (Tempo's
+// OTLP ingest port 4318), NOT -tempo (the query API on 3200, which 404s on push).
 otelcol.exporter.otlphttp "tempo" {
   client {
-    endpoint = "https://[[ env "meta.environment" ]]-[[ env "meta.cloud_region" ]]-tempo.${var.top_level_domain}"
+    endpoint = "https://[[ env "meta.environment" ]]-[[ env "meta.cloud_region" ]]-tempo-otlp.${var.top_level_domain}"
   }
 }
 

--- a/nomad/tempo.hcl
+++ b/nomad/tempo.hcl
@@ -6,6 +6,13 @@ variable "tempo_hostname" {
   type = string
 }
 
+# Hostname for the OTLP ingest route. Separate from tempo_hostname because fabio
+# routes a hostname to a single service port, and Tempo's OTLP receiver (4318) is
+# a different port from its query API (3200, used by tempo_hostname).
+variable "tempo_otlp_hostname" {
+  type = string
+}
+
 variable "oracle_s3_namespace" {
   type = string
 }
@@ -92,6 +99,31 @@ job "[JOB_NAME]" {
       port = "http"
       tags = [
         "int-urlprefix-${var.tempo_hostname}/",
+        "ip-${attr.unique.network.ip-address}"
+      ]
+      check {
+        name     = "Tempo healthcheck"
+        type     = "http"
+        port     = "http"
+        path     = "/ready"
+        interval = "20s"
+        timeout  = "5s"
+        check_restart {
+          limit           = 3
+          grace           = "60s"
+          ignore_warnings = false
+        }
+      }
+    }
+
+    # OTLP ingest route. alloy pushes traces here (OTLP HTTP on 4318). This is a
+    # separate fabio hostname from the query API above because a hostname maps to
+    # a single service port -- pushing OTLP to the query port (3200) 404s.
+    service {
+      name = "tempo-otlp"
+      port = "otlp-http"
+      tags = [
+        "int-urlprefix-${var.tempo_otlp_hostname}/",
         "ip-${attr.unique.network.ip-address}"
       ]
       check {

--- a/scripts/deploy-nomad-tempo.sh
+++ b/scripts/deploy-nomad-tempo.sh
@@ -25,10 +25,12 @@ if [ -z "$NOMAD_ADDR" ]; then
 fi
 
 [ -z "$TEMPO_HOSTNAME" ] && TEMPO_HOSTNAME="$ENVIRONMENT-$ORACLE_REGION-tempo.$TOP_LEVEL_DNS_ZONE_NAME"
+[ -z "$TEMPO_OTLP_HOSTNAME" ] && TEMPO_OTLP_HOSTNAME="$ENVIRONMENT-$ORACLE_REGION-tempo-otlp.$TOP_LEVEL_DNS_ZONE_NAME"
 
 NOMAD_JOB_PATH="$LOCAL_PATH/../nomad"
 NOMAD_DC="$ENVIRONMENT-$ORACLE_REGION"
 export NOMAD_VAR_tempo_hostname="${TEMPO_HOSTNAME}"
+export NOMAD_VAR_tempo_otlp_hostname="${TEMPO_OTLP_HOSTNAME}"
 export NOMAD_VAR_oracle_s3_namespace="$ORACLE_S3_NAMESPACE"
 JOB_NAME="tempo-$ORACLE_REGION"
 
@@ -42,6 +44,15 @@ fi
 export RESOURCE_NAME_ROOT="${ENVIRONMENT}-${ORACLE_REGION}-tempo"
 
 export CNAME_VALUE="$RESOURCE_NAME_ROOT"
+export STACK_NAME="${RESOURCE_NAME_ROOT}-cname"
+export UNIQUE_ID="${RESOURCE_NAME_ROOT}"
+export CNAME_TARGET="${ENVIRONMENT}-${ORACLE_REGION}-nomad-pool-general-internal.${DEFAULT_DNS_ZONE_NAME}"
+export CNAME_VALUE="${RESOURCE_NAME_ROOT}"
+$LOCAL_PATH/create-oracle-cname-stack.sh
+
+# Second CNAME for the OTLP ingest route (alloy pushes traces here; port 4318,
+# separate from the query API on the -tempo hostname/port 3200).
+export RESOURCE_NAME_ROOT="${ENVIRONMENT}-${ORACLE_REGION}-tempo-otlp"
 export STACK_NAME="${RESOURCE_NAME_ROOT}-cname"
 export UNIQUE_ID="${RESOURCE_NAME_ROOT}"
 export CNAME_TARGET="${ENVIRONMENT}-${ORACLE_REGION}-nomad-pool-general-internal.${DEFAULT_DNS_ZONE_NAME}"


### PR DESCRIPTION
## Problem

After deploying per-env Tempo on beta, alloy's **internal** trace exporter still dropped 100% of spans (`otelcol_exporter_send_failed_spans_total` climbing, `sent=0`).

Root cause is a **fabio port-routing mismatch**: the `tempo` job registers a single route — `int-urlprefix-<tempo_hostname>/` on the **`http` port (3200)**, which is Tempo's *query* API. Alloy pushes OTLP to `https://<env>-<region>-tempo.jitsi.net/v1/traces`, so the push lands on 3200 and **404s** — Tempo's OTLP receiver is on **4318**, which had no fabio route at all.

Proven on beta: `POST /v1/traces` to the `-tempo` host → **404**, while `/ready` → 200.

## Fix

Add a dedicated OTLP ingest hostname/route, mirroring how alloy itself separates `-otel` (OTLP) from `-loki` (push):

- **tempo.hcl**: new `tempo_otlp_hostname` variable + a second `tempo-otlp` service on the `otlp-http` port (4318) with its own `int-urlprefix-<tempo_otlp_hostname>/` tag.
- **deploy-nomad-tempo.sh**: derive/export `TEMPO_OTLP_HOSTNAME` and create its CNAME (same internal-LB target as `-tempo`).
- **alloy.hcl / alloy-external.hcl**: point the internal `tempo` exporter at `-tempo-otlp.<tld>` instead of `-tempo.<tld>`.

The `-tempo` hostname stays on 3200 for **querying** (Grafana datasource / TraceQL search), so nothing on the query side changes.

## Scope / rollout

- External Tempo export is unaffected (fixed in #1153; verified working — beta jicofo spans now land in the `meetings-oci-hosts-nonprod-01-oci-traces` tenant).
- After merge: redeploy Tempo (creates the new CNAME + service) **and** redeploy alloy (picks up the new exporter endpoint) on each env. Then internal per-env trace storage works too.

## Verification after deploy

`dig <env>-<region>-tempo-otlp.<tld>` resolves; `otelcol_exporter_sent_spans_total{exporter=~".*/tempo"}` climbs with `failed=0`; traces queryable against the per-env Tempo.