### PR TITLE
feat: optional OTLP distributed tracing for jitsi_meet_jvb (docker-jitsi-meet#2303)

### DIFF
--- a/nomad/jitsi_packs/packs/jitsi_meet_jvb/templates/_helpers.tpl
+++ b/nomad/jitsi_packs/packs/jitsi_meet_jvb/templates/_helpers.tpl
@@ -24,6 +24,21 @@ metadata when that value is set to a default of "".
 
 [[- /*
 
+## `tracing-otlp-base` helper
+
+Base URL of the OTLP receiver used for distributed tracing
+(docker-jitsi-meet#2303). Defaults to the regional alloy via the internal LB
+(deploy-nomad-alloy.sh registers <environment>-<region>-otel.<tld>); alloy
+forwards the spans on to Tempo (internal and Grafana Cloud).
+
+*/ -]]
+
+[[ define "tracing-otlp-base" -]]
+[[- or (env "CONFIG_tracing_otlp_endpoint") (print "https://" (env "CONFIG_environment") "-" (env "CONFIG_octo_region") "-otel.jitsi.net") -]]
+[[- end -]]
+
+[[- /*
+
 ## `region` helper
 
 This helper demonstrates conditional element rendering. If your pack specifies

--- a/nomad/jitsi_packs/packs/jitsi_meet_jvb/templates/jitsi_meet_jvb.nomad.tpl
+++ b/nomad/jitsi_packs/packs/jitsi_meet_jvb/templates/jitsi_meet_jvb.nomad.tpl
@@ -237,6 +237,16 @@ EOF
         JVB_ADDRESS = "http://127.0.0.1:8080"
         RTCSTATS_SERVER="[[ env "CONFIG_jvb_rtcstats_push_rtcstats_server" ]]"
 #        CHROMIUM_FLAGS="--start-maximized,--kiosk,--enabled,--autoplay-policy=no-user-gesture-required,--use-fake-ui-for-media-stream,--enable-logging,--v=1"
+[[- if eq (or (env "CONFIG_tracing_enabled") "false") "true" ]]
+[[- $tracingProtocol := or (env "CONFIG_tracing_protocol") "http" ]]
+        # Distributed tracing (docker-jitsi-meet#2303). Spans go over OTLP to the
+        # regional alloy (-otel), which forwards to Tempo. Only the OTLP HTTP
+        # receiver (4318) is fabio-routed on alloy, so grpc needs a custom
+        # endpoint. jvb (jicoco OTLP HTTP exporter) needs the full /v1/traces URL.
+        ENABLE_TRACING = "1"
+        TRACING_PROTOCOL = "[[ $tracingProtocol ]]"
+        TRACING_ENDPOINT = "[[ template "tracing-otlp-base" . ]][[ if eq $tracingProtocol "http" ]]/v1/traces[[ end ]]"
+[[- end ]]
       }
 
       # Download the rtcstats-push zip as-is (no Nomad-side decompression): the

--- a/scripts/deploy-nomad-jvb.sh
+++ b/scripts/deploy-nomad-jvb.sh
@@ -99,6 +99,13 @@ export CONFIG_environment_type="${ENVIRONMENT_TYPE}"
 export CONFIG_domain="$DOMAIN"
 export CONFIG_shard="$SHARD"
 export CONFIG_octo_region="$ORACLE_REGION"
+
+# optional distributed tracing (docker-jitsi-meet#2303); set tracing_enabled: true
+# in the environment yaml (exported as CONFIG_tracing_enabled by yamltoenv above).
+# Spans go over OTLP HTTP to the regional alloy, which forwards them to Tempo.
+[ -z "$CONFIG_tracing_enabled" ] && export CONFIG_tracing_enabled="false"
+[ -z "$CONFIG_tracing_otlp_endpoint" ] && export CONFIG_tracing_otlp_endpoint="https://$ENVIRONMENT-$ORACLE_REGION-otel.$TOP_LEVEL_DNS_ZONE_NAME"
+
 # [ -n "$SHARD_STATE" ] && export CONFIG_shard_state="$SHARD_STATE"
 export CONFIG_release_number="$RELEASE_NUMBER"
 export CONFIG_jvb_version="$JVB_VERSION"


### PR DESCRIPTION
## What

Extends the opt-in distributed tracing from the backend pack (#1150) to the **JVB** pack, so bridge-side spans (`colibri.allocate`, etc.) are emitted. Completes coverage — jicofo + prosody landed in #1150; this adds jvb.

## How

- Gated on `CONFIG_tracing_enabled` (default **false**), same as the backend. JVB exports OTLP to the regional **alloy** (`<env>-<region>-otel.<tld>`), which forwards to Tempo (internal via #1154, external via #1153).
- `_helpers.tpl`: adds the same `tracing-otlp-base` helper (endpoint defaults to `<env>-<region>-otel.jitsi.net`, overridable via `CONFIG_tracing_otlp_endpoint`).
- `jitsi_meet_jvb.nomad.tpl`: gated `ENABLE_TRACING` + `TRACING_PROTOCOL` + `TRACING_ENDPOINT` in the jvb task env. Protocol defaults to `http`; the jicoco OTLP HTTP exporter needs the full `/v1/traces` path.
- `deploy-nomad-jvb.sh`: defaults `CONFIG_tracing_enabled=false` and derives the endpoint (the deploy already runs `yamltoenv` + sets `CONFIG_octo_region`/`CONFIG_environment`, so `tracing_enabled: true` in site vars flows through automatically).

## Testing

`nomad-pack render` verified: enabled →
```
ENABLE_TRACING="1"
TRACING_PROTOCOL="http"
TRACING_ENDPOINT="https://beta-meet-jit-si-us-phoenix-1-otel.jitsi.net/v1/traces"
```
disabled → zero tracing vars. `bash -n` on the deploy script.

## Rollout

Beta already has `tracing_enabled: true`, so JVB pools pick this up on their next deploy. Enabling against image tags without the tracing templates is harmless (vars ignored) — beta's jvb tag `jvb-2.3-312-ga29d97d13-1` already ships the jicoco-tracing + OTLP jars.