### PR TITLE
fix(jvb): render tracing{} in jvb.conf (the #1155 env-var approach was a no-op)

### DIFF
--- a/nomad/jitsi_packs/packs/jitsi_meet_jvb/templates/_jvb.conf.tpl
+++ b/nomad/jitsi_packs/packs/jitsi_meet_jvb/templates/_jvb.conf.tpl
@@ -272,6 +272,21 @@ ice4j {
 }
 
 include "xmpp.conf"
+
+[[ if eq (or (env "CONFIG_tracing_enabled") "false") "true" -]]
+# Distributed tracing (docker-jitsi-meet#2303). Rendered here rather than driven
+# by the image's ENABLE_TRACING template, because this pack bind-mounts its own
+# jvb.conf over /defaults/jvb.conf. Spans go over OTLP to the regional alloy
+# (-otel), which forwards to Tempo. Default protocol is http (only the OTLP HTTP
+# receiver is fabio-routed on alloy); the jicoco HTTP exporter needs the full
+# /v1/traces URL, grpc takes host:port with no path.
+[[- $tracingProtocol := or (env "CONFIG_tracing_protocol") "http" ]]
+tracing {
+  enabled = true
+  otlp-protocol = "[[ $tracingProtocol ]]"
+  otlp-endpoint = "[[ template "tracing-otlp-base" . ]][[ if eq $tracingProtocol "http" ]]/v1/traces[[ end ]]"
+}
+[[ end -]]
 [[ end -]]
 
 [[ define "xmpp-config" ]]

--- a/nomad/jitsi_packs/packs/jitsi_meet_jvb/templates/jitsi_meet_jvb.nomad.tpl
+++ b/nomad/jitsi_packs/packs/jitsi_meet_jvb/templates/jitsi_meet_jvb.nomad.tpl
@@ -237,16 +237,10 @@ EOF
         JVB_ADDRESS = "http://127.0.0.1:8080"
         RTCSTATS_SERVER="[[ env "CONFIG_jvb_rtcstats_push_rtcstats_server" ]]"
 #        CHROMIUM_FLAGS="--start-maximized,--kiosk,--enabled,--autoplay-policy=no-user-gesture-required,--use-fake-ui-for-media-stream,--enable-logging,--v=1"
-[[- if eq (or (env "CONFIG_tracing_enabled") "false") "true" ]]
-[[- $tracingProtocol := or (env "CONFIG_tracing_protocol") "http" ]]
-        # Distributed tracing (docker-jitsi-meet#2303). Spans go over OTLP to the
-        # regional alloy (-otel), which forwards to Tempo. Only the OTLP HTTP
-        # receiver (4318) is fabio-routed on alloy, so grpc needs a custom
-        # endpoint. jvb (jicoco OTLP HTTP exporter) needs the full /v1/traces URL.
-        ENABLE_TRACING = "1"
-        TRACING_PROTOCOL = "[[ $tracingProtocol ]]"
-        TRACING_ENDPOINT = "[[ template "tracing-otlp-base" . ]][[ if eq $tracingProtocol "http" ]]/v1/traces[[ end ]]"
-[[- end ]]
+        # NOTE: distributed tracing (docker-jitsi-meet#2303) is NOT driven by
+        # ENABLE_TRACING here -- this pack bind-mounts its own jvb.conf over
+        # /defaults/jvb.conf, so the image's ENABLE_TRACING template is bypassed.
+        # The tracing {} block is rendered directly in _jvb.conf.tpl instead.
       }
 
       # Download the rtcstats-push zip as-is (no Nomad-side decompression): the


### PR DESCRIPTION
## Problem

#1155 wired `ENABLE_TRACING`/`TRACING_ENDPOINT`/`TRACING_PROTOCOL` into the jvb task env, mirroring jicofo. But **it never took effect** — the jvb pack **bind-mounts its own rendered `jvb.conf` over `/defaults/jvb.conf`** (`local/jvb.conf:/defaults/jvb.conf`), so the image's env-driven tracing template (docker-jitsi-meet#2303) is bypassed entirely. jicofo works because it uses the image's stock `/defaults/jicofo.conf`.

### Confirmed on beta (uk-london-1, 7029 pool)
- jvb alloc had `ENABLE_TRACING=1` and received colibri2 requests carrying `<traceparent xmlns="jitsi:opentelemetry" … trace_flags="01"/>` from jicofo — so **context propagation works**.
- But zero `service.name=jvb` spans in Tempo, and no OTLP export activity in jvb logs. Only jicofo spans landed.

## Fix

Render the `tracing {}` block **directly in `_jvb.conf.tpl`** (the `jvb-config` define), gated on `CONFIG_tracing_enabled` — the same top-level HOCON jicoco reads (`tracing.enabled` / `otlp-protocol` / `otlp-endpoint`) that docker-jitsi-meet#2303 produces:

```hocon
tracing {
  enabled = true
  otlp-protocol = "http"
  otlp-endpoint = "https://<env>-<region>-otel.jitsi.net/v1/traces"
}
```

Uses the existing `tracing-otlp-base` helper; `http` → full `/v1/traces` URL (jicoco `OtlpHttpSpanExporter`), `grpc` → host:port. The now-dead task env vars from #1155 are removed, with a comment explaining why tracing is configured in the conf template instead.

## Testing

`nomad-pack render`: enabled → the `tracing {}` block appears in `jvb.conf` with the right endpoint; disabled → no block; no stray `ENABLE_TRACING` env remains.

## Rollout

JVB pools pick this up on next deploy/rotation (beta already has `tracing_enabled: true`). Then `service.name=jvb` spans (bridge side of `colibri.allocate`, ICE, etc.) join the jicofo trace already flowing to internal + external Tempo.