### PR TITLE
fix: call configure_primary_source_routing from the JVB runner (JIT-16318)

### DIFF
--- a/terraform/create-jvb-instance-configuration/user-data/postinstall-runner-oracle.sh
+++ b/terraform/create-jvb-instance-configuration/user-data/postinstall-runner-oracle.sh
@@ -12,7 +12,7 @@ if [[ "$NOMAD_FLAG" == "true" ]]; then
 
     export ANSIBLE_PLAYBOOK="nomad-client.yml"
     export ANSIBLE_VARS="hcv_environment=$ENVIRONMENT cloud_name=$CLOUD_NAME cloud_provider=oracle oracle_region=$ORACLE_REGION region=$ORACLE_REGION nomad_pool_type=$POOL_TYPE autoscaler_group=$CUSTOM_AUTO_SCALE_GROUP oracle_instance_id=$INSTANCE_ID autoscaler_server_host=$ENVIRONMENT-$ORACLE_REGION-autoscaler.jitsi.net nomad_enable_jitsi_autoscaler=true"
-    export PROVISION_COMMAND="default_provision"
+    export PROVISION_COMMAND="provisioning_nomad"
     export HOST_ROLE="jvb"
     MY_IP=`curl -s curl http://169.254.169.254/opc/v1/vnics/ | jq .[0].privateIp -r`
     MY_COMPONENT_NUMBER="$(echo $MY_IP | awk -F. '{print $2"-"$3"-"$4}')"
@@ -23,7 +23,13 @@ function dump() {
   sudo /usr/local/bin/dump-jvb.sh
 }
 
+function provisioning_nomad() {
+  configure_primary_source_routing
+  default_provision
+}
+
 function provisioning() {
+  configure_primary_source_routing
   local status_code=0
   sudo /usr/local/bin/postinstall-jvb-oracle.sh >>/var/log/bootstrap.log 2>&1 || status_code=1
   if [ $status_code -eq 1 ]; then


### PR DESCRIPTION
## Why

prod-8x8 JVBs are dual-homed with their secondary VNIC in the general private /18 — the same layout that made coturns unscrapeable (OCI anti-spoof drops replies that egress the secondary VNIC sourced from the primary IP).

JVBs are immune **today** only by accident of the image boot path: their current images get network config from the initramfs, so cloud-init leaves the secondary interface without an IPv4 address (no connected route → no asymmetry). The Noble image migration makes cloud-init fall back to IMDS, which configures **all** VNICs regardless of `configure_secondary_nics` — reintroducing the bug on first boot. (Full analysis in JIT-16318.)

## Change

Call the shared `configure_primary_source_routing` (added for coturn in #1146) from both JVB provision paths, after `eip_main` has restored primary routing:

- **nomad** pools (the dual-homed ones): new `provisioning_nomad` wrapper that runs the routing fix then `default_provision`, replacing the bare `PROVISION_COMMAND="default_provision"`.
- **classic** path: prepend the call to the existing `provisioning()`.

The function is metadata-driven and a clean no-op on any host whose secondary VNIC isn't configured, so this is **inert on today's JVBs** and simply pre-arms them for the image migration.

jigasi and jibri are not dual-homed, so their runners are unchanged.

## Verification

- assembled header+lib+eip-lib+runner+footer passes `bash -n`
- JVB instance-config user_data already uses `base64gzip`; assembled payload is 9,240 bytes (well under the 32KB metadata cap)
- no behavior change on current JVBs (routing function no-ops without a configured secondary VNIC — same code path already validated live across 20 prod-8x8 coturns)

Tracking: [JIT-16318](https://agile.8x8.com/browse/JIT-16318)