### PR TITLE
fix(coturn): use existing instance pool size instead of defaulting to 2

### DIFF
--- a/terraform/create-coturn-stack/create-coturn-stack-oracle.sh
+++ b/terraform/create-coturn-stack/create-coturn-stack-oracle.sh
@@ -119,6 +119,16 @@ fi
 [ -z "$SCALE_IN_RULE_NAME" ] && SCALE_IN_RULE_NAME="${ENVIRONMENT}-${ORACLE_REGION}-scalingLowLoad"
 [ -z "$SCALE_OUT_RULE_NAME" ] && SCALE_OUT_RULE_NAME="${ENVIRONMENT}-${ORACLE_REGION}-scalingHighLoad"
 
+# look up instance pool. If it exists, find its current size and set DESIRED_CAPACITY appropriately
+INSTANCE_POOL_DETAILS="$(oci compute-management instance-pool list --region "$ORACLE_REGION" -c "$COMPARTMENT_OCID" --all --display-name "$INSTANCE_POOL_NAME" | jq '.data[0]')"
+
+if [ -z "$INSTANCE_POOL_DETAILS" ] || [ "$INSTANCE_POOL_DETAILS" == "null" ]; then
+  echo "No instance pool found with name $INSTANCE_POOL_NAME. Using default size $DESIRED_CAPACITY..."
+else
+  export DESIRED_CAPACITY=$(echo "$INSTANCE_POOL_DETAILS" | jq -r '.size')
+  echo "Found existing instance pool with name $INSTANCE_POOL_NAME.  Using existing size $DESIRED_CAPACITY"
+fi
+
 [ -z "$S3_PROFILE" ] && S3_PROFILE="oracle"
 [ -z "$S3_STATE_BUCKET" ] && S3_STATE_BUCKET="tf-state-$ENVIRONMENT"
 [ -z "$S3_ENDPOINT" ] && S3_ENDPOINT="https://$ORACLE_S3_NAMESPACE.compat.objectstorage.$ORACLE_REGION.oraclecloud.com"


### PR DESCRIPTION
## Problem

`provision-coturn` delegates to `create-coturn-stack-oracle.sh`, which set the instance pool size purely from a hardcoded default:

```sh
[ -z "$DESIRED_CAPACITY" ] && DESIRED_CAPACITY="2"
```

That value flows into terraform as `-var="instance_pool_size=$DESIRED_CAPACITY"`, so every provision run reset the pool to 2 — shrinking any coturn pool that had scaled larger. The rotate flow (`rotate-coturn-oracle.sh`) sources the same script and also never passed `DESIRED_CAPACITY`, so it hit the same default.

## Fix

Look up the existing instance pool by display name and, when present, reuse its current `.size` — mirroring the pattern already used by `provision-nomad-pool` (`create-nomad-pool-stack.sh`). The hardcoded `2` remains only as the first-create fallback when no pool exists.

```sh
INSTANCE_POOL_DETAILS="$(oci compute-management instance-pool list --region "$ORACLE_REGION" -c "$COMPARTMENT_OCID" --all --display-name "$INSTANCE_POOL_NAME" | jq '.data[0]')"
if [ -z "$INSTANCE_POOL_DETAILS" ] || [ "$INSTANCE_POOL_DETAILS" == "null" ]; then
  echo "No instance pool found with name $INSTANCE_POOL_NAME. Using default size $DESIRED_CAPACITY..."
else
  export DESIRED_CAPACITY=$(echo "$INSTANCE_POOL_DETAILS" | jq -r '.size')
  echo "Found existing instance pool with name $INSTANCE_POOL_NAME.  Using existing size $DESIRED_CAPACITY"
fi
```

## Notes

- All variables used (`ORACLE_REGION`, `COMPARTMENT_OCID`, `INSTANCE_POOL_NAME`) are already defined earlier in the script.
- Benefits both provision and rotate: rotation now regenerates the instance config at the live pool size instead of defaulting to 2.
- `bash -n` syntax-checked.