### PR TITLE
fix(alerts): raise JVB_CPU_High for: 5m→10m to reduce trigger-happy pages

### DIFF
--- a/nomad/prometheus.hcl
+++ b/nomad/prometheus.hcl
@@ -1051,17 +1051,17 @@ groups:
       alert_url: https://${var.prometheus_hostname}/alerts?search=baron
   %{ if var.environment_type == "prod" }- alert: JVB_CPU_High
     expr: 100 - cpu_usage_idle{role="JVB"} > %{ if var.production_alerts }90%{ else }95%{ endif }
-    for: %{ if var.production_alerts }5m%{ else }15m%{ endif }
+    for: %{ if var.production_alerts }10m%{ else }15m%{ endif }
     labels:
       service: jitsi
       severity: severe
       page: true
       scope: global
     annotations:
-      summary: a JVB in ${var.dc} has had extremely high CPU usage for %{ if var.production_alerts }5%{ else }15%{ endif } minutes
+      summary: a JVB in ${var.dc} has had extremely high CPU usage for %{ if var.production_alerts }10%{ else }15%{ endif } minutes
       description: >-
         A JVB in ${var.dc} has had a CPU running at over %{ if var.production_alerts }90%{ else }95%{ endif }%
-        in the last %{ if var.production_alerts }5%{ else }15%{ endif } minutes.
+        in the last %{ if var.production_alerts }10%{ else }15%{ endif } minutes.
         It was most recently at {{ $value | printf "%.2f" }}%.
       dashboard_url: ${var.grafana_url}
       alert_url: https://${var.prometheus_hostname}/alerts?search=jvb_cpu_high%{ endif }


### PR DESCRIPTION
## Summary

Raises the prod `for:` duration on the `JVB_CPU_High` alert from **5m → 10m**. Threshold (90%) and the non-prod branch (15m/95%) are unchanged.

## Motivation

Investigation of a `JVB_CPU_High` page in **prod-8x8 / ap-tokyo-1** on 2026-09-02 ~04:07 UTC:

- The page came from a **single bridge** (`jvb-71-115-40`) that was above 90% CPU for exactly **6 minutes** during a large multi-relay conference (`icsc-stream-prod`, 30+ participants) that landed on the release-6869 pool.
- Actual CPU and jicofo `correctedStress` were **decoupled** — only 1–2 of the 5 high-stress bridges ever crossed 90% CPU; the relay hub peaked at only ~69%.
- The autoscaler **did** scale up at 04:03:18 UTC, and CPU on all bridges receded to 41–53% by 04:15. The spike self-resolved ~1 minute after crossing the 5m `for:` mark.
- The autoscaler's full response cycle (~3–5 min to fire + ~3–5 min for jicofo to shift load onto new bridges) cannot beat a 5m `for:`, so the page fires on exactly the kind of transient spike the autoscaler is designed to absorb.

## Change

`for: 5m → 10m` (prod / `production_alerts` branch only), plus the annotation summary/description text updated to match. A `for: 10m` would have suppressed this page while still paging on a genuinely stuck bridge (sustained 90%+ for 10+ min, past a full autoscaler response cycle).

## Blast radius

This is a single templated rule with `scope: global` / `page: true`, rendered into **every prod DC's** Prometheus — the change is fleet-wide, which is intended (the trigger-happiness is not tokyo-specific). Non-prod is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)