### PR TITLE
fix(alerts): exclude coturn from Nomad_Job_CPU_Use_High off prod-8x8 (JIT-16323)

### DIFF
--- a/nomad/prometheus.hcl
+++ b/nomad/prometheus.hcl
@@ -443,8 +443,15 @@ groups:
         modifying the allocated memory and re-deploying the job.
       dashboard_url: ${var.grafana_url}
       alert_url: https://${var.prometheus_hostname}/alerts?search=nomad_job
+  # coturn is excluded only where production_alerts is off (meet-jit-si et al).
+  # Those pools are scaled down hard, so coturn routinely runs over its static
+  # cpu = 10000 reservation while the host still has plenty of headroom, which
+  # pages daily for nothing. prod-8x8 pools are sized so that crossing the
+  # reservation is worth knowing about, so the alert stays armed there.
+  # Host-level saturation is covered either way by System_CPU_Usage_High and
+  # Coturn_UDP_Errors_High.
   - alert: Nomad_Job_CPU_Use_High
-    expr: 100 * nomad_client_allocs_cpu_total_ticks / nomad_client_allocs_cpu_allocated > 85
+    expr: 100 * nomad_client_allocs_cpu_total_ticks%{ if ! var.production_alerts }{task!~"coturn"}%{ endif } / nomad_client_allocs_cpu_allocated%{ if ! var.production_alerts }{task!~"coturn"}%{ endif } > 85
     for: 10m
     labels:
       service: infra


### PR DESCRIPTION
## Problem

After scaling down the meet-jit-si coturn pools to save cost, `Nomad_Job_CPU_Use_High` fires daily during peak hours:

> Nomad_Job_CPU_Use_High in meet-jit-si-eu-frankfurt-1: cpu use for coturn-eu-frankfurt-1 in meet-jit-si-eu-frankfurt-1 is high

It's a false signal *there*. The alert measures usage against the Nomad CPU *reservation*, not against the machine.

## Evidence

At the same instant, alloc-relative CPU is over 100% while the host is only ~62% busy:

| host | alloc % | host CPU % |
|---|---|---|
| `meet-jit-si-eu-frankfurt-1-coturn-40-2-216` | 112.3 | 62.9 |
| `meet-jit-si-eu-frankfurt-1-coturn-40-2-252` | 106.8 | 62.2 |

24h history shows a reliable business-hours peak — 108/113/112% one day, 119/109% the next, single digits overnight — so this pages every working day.

## Root cause

`nomad/coturn.hcl` hardcodes `cpu = 10000` for every region and every shape. On the scaled-down meet-jit-si nodes that's only ~55% of the actual machine, so coturn crosses 85%-of-reservation long before the host is under real pressure.

## Approach

Rather than dropping coturn from this alert everywhere, the exclusion is gated on `production_alerts`, so **the alert stays armed on prod-8x8** and is suppressed on meet-jit-si:

```
expr: 100 * nomad_client_allocs_cpu_total_ticks%{ if ! var.production_alerts }{task!~"coturn"}%{ endif } / ... > 85
```

`production_alerts` is true only on prod-8x8 and ops-prod, and ops-prod runs no coturn — so this is exactly a meet-jit-si/prod-8x8 split. Confirmed against live data that only two environments run coturn at all (`meet-jit-si` 6 allocs, `prod-8x8` 20), so the change is a no-op for stage-8x8, beta-meet-jit-si, jitsi-net and lonely.

The file already uses `production_alerts` for this kind of per-environment alert tuning (`JVB_CPU_High`, `Jicofo_Participants_High`, `System_CPU_Usage_High`), and `%{ if ! var.x }` is already used in `nomad/wavefront-proxy.hcl`.

Raising the grant instead was considered and rejected: for a `system` job the reservation must still fit the node, so it can't be raised globally without knowing the smallest coturn shape in every environment, and it'd need re-tuning after each shape change.

## Verification

Rendered the job with `nomad job run -output` for both values and checked the result with real `promtool`:

| `production_alerts` | rendered expr | promtool |
|---|---|---|
| `true` (prod-8x8) | `...cpu_total_ticks / ...cpu_allocated > 85` | SUCCESS, 31 rules |
| `false` (meet-jit-si) | `...cpu_total_ticks{task!~"coturn"} / ...{task!~"coturn"} > 85` | SUCCESS, 31 rules |

The rule is not otherwise weakened — it still fires for non-coturn allocs on shared pools, e.g. `ocular-eu-frankfurt-1` at 1002% and `ocular-ap-sydney-1` at 106% on `pool_type=general`, which is exactly the case this alert exists for.

## Coverage retained

Host-level coturn saturation is still caught in **both** environments by `System_CPU_Usage_High` (70% smoke / 80% warn in prod), `Coturn_UDP_Errors_High` for relay overload, and `Coturn_Task_Missing` for placement failure.

## Deploy notes

- Takes effect only where `deploy-nomad-prometheus.sh` is re-run. It's per-environment, so each meet-jit-si region needs a redeploy to stop the pages; prod-8x8 needs one to pick up the (unchanged) armed rule.
- The Frankfurt boxes sit at ~62% host CPU at peak, against a 70% smoke threshold. Further coturn scale-down there will start firing `System_CPU_Usage_High` — and unlike this one, that would be reporting something real.
- prod-8x8 coturn currently runs 0.005–18% of reservation, so the armed rule will be quiet there today.
- Out of scope but worth a look separately: `ocular` at 1002% of its grant is under-reserved by an order of magnitude.

JIT-16323