### PR TITLE
feat(jitsi-meet-web): wire audioTranslation duckedVolume and sending change events

### DIFF
--- a/nomad/jitsi_packs/packs/jitsi_meet_web/templates/_custom-config.js.tpl
+++ b/nomad/jitsi_packs/packs/jitsi_meet_web/templates/_custom-config.js.tpl
@@ -45,7 +45,9 @@ config.audioQuality.enableAdvancedAudioSettings=[[ or (env "CONFIG_jitsi_meet_en
 
 [[ if eq (env "CONFIG_jitsi_meet_enable_audio_translation") "true" -]]
 config.audioTranslation = {
-    enabled: true
+    enabled: true,
+    duckedVolume: [[ or (env "CONFIG_jitsi_meet_audio_translation_ducked_volume") "0.15" ]],
+    enableSendingChangeEvents: true
 };
 [[- end ]]
 


### PR DESCRIPTION
## Summary

Nomad-side counterpart: emits the two new `config.audioTranslation` sub-keys in the `jitsi_meet_web` pack.

```js
config.audioTranslation = {
    enabled: true,
    duckedVolume: [[ or (env "CONFIG_jitsi_meet_audio_translation_ducked_volume") "0.15" ]],
    enableSendingChangeEvents: true
};
```

`duckedVolume` falls back to `0.15` (the client default) when `CONFIG_jitsi_meet_audio_translation_ducked_volume` is unset, matching the ansible role default. The existing `CONFIG_jitsi_meet_enable_audio_translation` gate is unchanged, so the block still renders only when audio translation is on.

### Note

`yamltoenv` exports only `!!int` / `!!bool` / `!!str` from `vars.yml`. To override the ducking level on this path the value must be quoted (`jitsi_meet_audio_translation_ducked_volume: "0.2"`) — a bare `0.2` is a `!!float` and will not be exported, so the template default applies.

## Companion changes

- infra-configuration: https://github.com/jitsi/infra-configuration/pull/947
- infra-customizations-private: https://github.com/jitsi/infra-customizations-private/pull/1090
- docker-jitsi-meet (independent): https://github.com/jitsi/docker-jitsi-meet/pull/2315

## Test plan

- Render the `jitsi_meet_web` pack with `CONFIG_jitsi_meet_enable_audio_translation=true` and no ducked-volume var; confirm `duckedVolume: 0.15` and `enableSendingChangeEvents: true` appear.
- Render with `CONFIG_jitsi_meet_audio_translation_ducked_volume=0.3`; confirm `duckedVolume: 0.3`.
- Render with the enable gate unset; confirm the whole `config.audioTranslation` assignment is omitted.
