### PR TITLE
feat(alerts): add WARN alert for haproxy consul-template reconfig fail

### DIFF
--- a/nomad/prometheus.hcl
+++ b/nomad/prometheus.hcl
@@ -819,6 +819,23 @@ groups:
         triggered.
       dashboard_url: ${var.grafana_url}
       alert_url: https://${var.prometheus_hostname}/alerts?search=haproxy_shard_unhealthy
+  - alert: HAProxy_Reconfig_Failed
+    expr: max_over_time(jitsi_config_haproxy_reconfig_failed{role="haproxy"}[5m]) > 0
+    for: 1m
+    labels:
+      service: jitsi
+      severity: warn
+    annotations:
+      summary: haproxy reconfiguration failed on {{ $labels.host }} in ${var.dc}
+      description: >-
+        consul-template failed to reload haproxy on {{ $labels.host }} in ${var.dc}.
+        This usually means the rendered haproxy.cfg failed validation (a template
+        bug or bad service metadata in consul), leaving haproxy running on a stale
+        config while shards come and go. Check /var/log/consul-template on the host
+        for the rejected *.invalid config and run 'haproxy -c -f <file>' against it
+        to see the fatal error.
+      dashboard_url: ${var.grafana_url}
+      alert_url: https://${var.prometheus_hostname}/alerts?search=haproxy_reconfig_failed
   - alert: HAProxy_LB_Bandwidth_High
     expr: oci_lbaas_peak_bandwidth{lb_name=~".*haproxy.*"} > 2400
     for: 2m


### PR DESCRIPTION
jitsi_config_haproxy_reconfig_failed is emitted by the haproxy configurator payload whenever consul-template fails to reload haproxy, most commonly because the rendered config failed haproxy's own validation (e.g. a use_backend with no matching backend block, as seen with the shard/standalone health-filter mismatch). A failed reconfig leaves haproxy running on a stale config, so it needs operator attention soon. Wrapped in max_over_time(5m) since the underlying metric is a statsd counter reset each telegraf flush, matching the existing Grafana panel's approach.

Follows jitsi/infra-configuration#949 — the haproxy template use_backend/backend health-filter fix that motivated this alert (merged).
