### PR TITLE
JIT-16092: fall back to github when the boot-time mirror cannot serve

### DIFF
--- a/terraform/lib/postinstall-lib.sh
+++ b/terraform/lib/postinstall-lib.sh
@@ -205,7 +205,49 @@ function set_hostname() {
   grep $MY_HOSTNAME /etc/hosts || echo "$MY_IP    $MY_HOSTNAME" >> /etc/hosts
   echo "$MY_HOSTNAME" > /etc/hostname
 }
+function loggable_git_url() {
+  echo "$1" | sed -E 's#(://)[^@/]*@#\1#'
+}
+function clone_repo_at_ref() {
+  local url="$1"
+  local target="$2"
+  local ref="$3"
+  [ -z "$url" ] && return 1
+  [ -z "$target" ] && return 1
+  rm -rf "$target"
+  git clone "$url" "$target" || return 1
+  git -C "$target" checkout "$ref" || return 1
+  git -C "$target" submodule update --init --recursive || return 1
+  git -C "$target" show-ref "heads/$ref" || git -C "$target" show-ref "tags/$ref" || return 1
+  return 0
+}
+function clone_repo_with_fallback() {
+  local name="$1"
+  local mirror_url="$2"
+  local origin_url="$3"
+  local target="$4"
+  local ref="$5"
+  if [ -n "$mirror_url" ]; then
+    echo "Cloning $name at $ref from the in-region mirror $(loggable_git_url "$mirror_url")"
+    if clone_repo_at_ref "$mirror_url" "$target" "$ref"; then
+      echo "Cloned $name at $ref from the in-region mirror"
+      return 0
+    fi
+    echo "Mirror clone of $name at $ref failed, falling back to github"
+  fi
+  echo "Cloning $name at $ref from $(loggable_git_url "$origin_url")"
+  if clone_repo_at_ref "$origin_url" "$target" "$ref"; then
+    echo "Cloned $name at $ref from github"
+    return 0
+  fi
+  echo "Failed to clone $name at $ref from github"
+  return 1
+}
 function checkout_repos() {
+  if [ -z "$BOOTSTRAP_DIRECTORY" ]; then
+    echo "No BOOTSTRAP_DIRECTORY set, refusing to check out repos"
+    return 1
+  fi
   [ -d $BOOTSTRAP_DIRECTORY/infra-configuration ] && rm -rf $BOOTSTRAP_DIRECTORY/infra-configuration
   [ -d $BOOTSTRAP_DIRECTORY/infra-customizations ] && rm -rf $BOOTSTRAP_DIRECTORY/infra-customizations
   if [ ! -n "$(grep "^github.com " ~/.ssh/known_hosts)" ]; then ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null; fi
@@ -214,18 +256,8 @@ function checkout_repos() {
     echo "Found local repo copies in $LOCAL_REPO_DIRECTORY, setting GIT_ALTERNATE_OBJECT_DIRECTORIES"
     export GIT_ALTERNATE_OBJECT_DIRECTORIES="$LOCAL_REPO_DIRECTORY/infra-configuration/.git/objects:$LOCAL_REPO_DIRECTORY/infra-customizations/.git/objects"
   fi
-  echo "Now cloning directly from github"
-  git clone $INFRA_CONFIGURATION_REPO $BOOTSTRAP_DIRECTORY/infra-configuration
-  git clone $INFRA_CUSTOMIZATIONS_REPO $BOOTSTRAP_DIRECTORY/infra-customizations
-  cd $BOOTSTRAP_DIRECTORY/infra-configuration
-  git checkout $GIT_BRANCH
-  git submodule update --init --recursive
-  git show-ref heads/$GIT_BRANCH || git show-ref tags/$GIT_BRANCH
-  cd /root
-  cd $BOOTSTRAP_DIRECTORY/infra-customizations
-  git checkout $GIT_BRANCH
-  git submodule update --init --recursive
-  git show-ref heads/$GIT_BRANCH || git show-ref tags/$GIT_BRANCH
+  clone_repo_with_fallback "infra-configuration" "$INFRA_CONFIGURATION_MIRROR_REPO" "$INFRA_CONFIGURATION_REPO" "$BOOTSTRAP_DIRECTORY/infra-configuration" "$GIT_BRANCH" || return 1
+  clone_repo_with_fallback "infra-customizations" "$INFRA_CUSTOMIZATIONS_MIRROR_REPO" "$INFRA_CUSTOMIZATIONS_REPO" "$BOOTSTRAP_DIRECTORY/infra-customizations" "$GIT_BRANCH" || return 1
   cp -a $BOOTSTRAP_DIRECTORY/infra-customizations/* $BOOTSTRAP_DIRECTORY/infra-configuration
   cd /root
 }
@@ -281,7 +313,10 @@ function default_provision() {
   if [ -z "$INFRA_CONFIGURATION_REPO" ]; then
     export INFRA_CONFIGURATION_REPO="https://github.com/jitsi/infra-configuration.git"
   fi
-  checkout_repos
+  if ! checkout_repos; then
+    echo "Failed to check out the infra repos from any source"
+    return 4
+  fi
   run_ansible_playbook "$ANSIBLE_PLAYBOOK"  "$ANSIBLE_VARS" || status_code=1
   return $status_code;
 }

--- a/terraform/lib/postinstall-lib.sh
+++ b/terraform/lib/postinstall-lib.sh
@@ -181,15 +181,73 @@ function mount_volumes() {
     fi
   fi
 }
+# In-region git mirror, opt-in per stack via GIT_MIRROR_HOST ("auto" derives it). JIT-16092
+function configure_mirror_repos() {
+  [ -z "$GIT_MIRROR_HOST" ] && return 0
+  if [ "$GIT_MIRROR_HOST" == "auto" ]; then
+    if [ -z "$ENVIRONMENT" ] || [ -z "$ORACLE_REGION" ]; then
+      echo "GIT_MIRROR_HOST=auto but ENVIRONMENT or ORACLE_REGION is unset, not using a mirror"
+      return 0
+    fi
+    [ -z "$GIT_MIRROR_DNS_ZONE" ] && GIT_MIRROR_DNS_ZONE="jitsi.net"
+    GIT_MIRROR_HOST="$ENVIRONMENT-$ORACLE_REGION-git.$GIT_MIRROR_DNS_ZONE"
+  fi
+  [ -z "$GIT_MIRROR_ORG" ] && GIT_MIRROR_ORG="jitsi"
+  if [ -z "$INFRA_CONFIGURATION_MIRROR_REPO" ] && [ -n "$INFRA_CONFIGURATION_REPO" ]; then
+    export INFRA_CONFIGURATION_MIRROR_REPO="https://$GIT_MIRROR_HOST/$GIT_MIRROR_ORG/$(basename "$INFRA_CONFIGURATION_REPO" .git).git"
+  fi
+  if [ -z "$INFRA_CUSTOMIZATIONS_MIRROR_REPO" ] && [ -n "$INFRA_CUSTOMIZATIONS_REPO" ]; then
+    export INFRA_CUSTOMIZATIONS_MIRROR_REPO="https://$GIT_MIRROR_HOST/$GIT_MIRROR_ORG/$(basename "$INFRA_CUSTOMIZATIONS_REPO" .git).git"
+  fi
+  echo "Using git mirror $GIT_MIRROR_HOST"
+}
+# Read-only mirror user for the private repo: bucket -> netrc, never a URL. No creds => github
+function fetch_mirror_credentials() {
+  [ -z "$INFRA_CUSTOMIZATIONS_MIRROR_REPO" ] && return 0
+  local bucket="jvb-bucket-${ENVIRONMENT}"
+  local creds_file="/root/.gitea-read-user.json"
+  local mirror_host
+  mirror_host=$(echo "$INFRA_CUSTOMIZATIONS_MIRROR_REPO" | sed -E 's#^[a-z]+://([^@/]*@)?([^/:]+).*#\2#')
+  if [ -z "$mirror_host" ]; then
+    echo "Could not read a hostname from the mirror URL, not fetching mirror credentials"
+    return 0
+  fi
+  if ! $OCI_BIN os object get -bn "$bucket" --name gitea-read-user --file "$creds_file" >/dev/null 2>&1; then
+    echo "No gitea-read-user in $bucket; the private repo will come from github"
+    rm -f "$creds_file"
+    return 0
+  fi
+  # keep the password out of the set -x trace
+  local xtrace=false
+  [[ $- == *x* ]] && xtrace=true
+  set +x
+  local username password
+  username=$(jq -r '.username // empty' "$creds_file")
+  password=$(jq -r '.password // empty' "$creds_file")
+  rm -f "$creds_file"
+  if [ -z "$username" ] || [ -z "$password" ]; then
+    [ "$xtrace" == "true" ] && set -x
+    echo "gitea-read-user in $bucket has no username or password; the private repo will come from github"
+    return 0
+  fi
+  (umask 077 && printf 'machine %s login %s password %s\n' "$mirror_host" "$username" "$password" > /root/.netrc)
+  chmod 600 /root/.netrc
+  [ "$xtrace" == "true" ] && set -x
+  echo "Installed mirror credentials for $username at $mirror_host"
+  return 0
+}
 function fetch_credentials() {
   ENVIRONMENT=$1
   BUCKET="jvb-bucket-${ENVIRONMENT}"
   $OCI_BIN os object get -bn $BUCKET --name vault-password --file /root/.vault-password
   $OCI_BIN os object get -bn $BUCKET --name id_rsa_jitsi_deployment --file /root/.ssh/id_rsa
   chmod 400 /root/.ssh/id_rsa
+  configure_mirror_repos
+  fetch_mirror_credentials
 }
 function clean_credentials() {
   rm /root/.vault-password /root/.ssh/id_rsa
+  rm -f /root/.netrc /root/.gitea-read-user.json
 }
 function set_hostname() {
   TYPE=$1
@@ -215,7 +273,8 @@ function clone_repo_at_ref() {
   [ -z "$url" ] && return 1
   [ -z "$target" ] && return 1
   rm -rf "$target"
-  git clone "$url" "$target" || return 1
+  # no terminal at boot: fail instead of waiting on a credential prompt
+  GIT_TERMINAL_PROMPT=0 git clone "$url" "$target" || return 1
   git -C "$target" checkout "$ref" || return 1
   git -C "$target" submodule update --init --recursive || return 1
   git -C "$target" show-ref "heads/$ref" || git -C "$target" show-ref "tags/$ref" || return 1

--- a/terraform/nomad-instance-pool/create-nomad-instance-pool-stack.sh
+++ b/terraform/nomad-instance-pool/create-nomad-instance-pool-stack.sh
@@ -246,6 +246,7 @@ terraform $TF_GLOBALS_CHDIR $ACTION \
   -var="vcn_name=$VCN_NAME" \
   -var "infra_configuration_repo=$INFRA_CONFIGURATION_REPO" \
   -var "infra_customizations_repo=$INFRA_CUSTOMIZATIONS_REPO" \
+  -var "git_mirror_host=$GIT_MIRROR_HOST" \
   -var "user_data_file=$POSTRUNNER_PATH" \
   -var="use_eip=$POOL_USE_EIP" \
   -var="secondary_vnic_name=$SECONDARY_VNIC_NAME" \

--- a/terraform/nomad-instance-pool/nomad-instance-pool-stack.tf
+++ b/terraform/nomad-instance-pool/nomad-instance-pool-stack.tf
@@ -41,6 +41,11 @@ variable "user_data_file" {
 }
 variable "infra_configuration_repo" {}
 variable "infra_customizations_repo" {}
+# In-region git mirror for boot-time clones (JIT-16092). Empty leaves boots on
+# github; "auto" derives <environment>-<region>-git.jitsi.net; or a hostname.
+variable "git_mirror_host" {
+  default = ""
+}
 variable "disk_in_gbs" {}
 variable "use_eip" {
   default = false
@@ -126,7 +131,7 @@ resource "oci_core_instance_configuration" "oci_instance_configuration_use_eip" 
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-header.sh"), # load the header
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-lib.sh"), # load the lib
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-eip-lib.sh"), # load the EIP lib
-          "\nexport INFRA_CONFIGURATION_REPO=${var.infra_configuration_repo}\nexport INFRA_CUSTOMIZATIONS_REPO=${var.infra_customizations_repo}\n", #repo variables
+          "\nexport INFRA_CONFIGURATION_REPO=${var.infra_configuration_repo}\nexport INFRA_CUSTOMIZATIONS_REPO=${var.infra_customizations_repo}\nexport GIT_MIRROR_HOST=${var.git_mirror_host}\n", #repo variables
           file("${path.cwd}/${var.user_data_file}"), # load our customizations
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-footer.sh") # load the footer
         ]))
@@ -192,7 +197,7 @@ resource "oci_core_instance_configuration" "oci_instance_configuration" {
         user_data = base64gzip(join("",[
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-header.sh"), # load the header
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-lib.sh"), # load the lib
-          "\nexport INFRA_CONFIGURATION_REPO=${var.infra_configuration_repo}\nexport INFRA_CUSTOMIZATIONS_REPO=${var.infra_customizations_repo}\n", #repo variables
+          "\nexport INFRA_CONFIGURATION_REPO=${var.infra_configuration_repo}\nexport INFRA_CUSTOMIZATIONS_REPO=${var.infra_customizations_repo}\nexport GIT_MIRROR_HOST=${var.git_mirror_host}\n", #repo variables
           file("${path.cwd}/${var.user_data_file}"), # load our customizations
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-footer.sh") # load the footer
         ]))


### PR DESCRIPTION
Groundwork for pointing VM boots at the in-region Gitea mirror (#1141), split
out because it changes the boot path rather than the mirror service.

**Inert as merged.** The mirror URLs are configured through two new variables,
`INFRA_CONFIGURATION_MIRROR_REPO` and `INFRA_CUSTOMIZATIONS_MIRROR_REPO`, and
nothing sets them yet. With no mirror URL, `checkout_repos` goes straight to
GitHub exactly as it does today.

**The principle.** The mirror only ever removes GitHub from the common path. It
must never be able to fail a boot on its own, so every mirror failure here is a
fallback rather than an error.

**The case worth reviewing.** Boots check out a specific branch or tag,
releases tag and then immediately provision, and mirrors pull on an interval —
so a boot can easily reach a replica that has not pulled the new tag yet. The
clone succeeds and only the checkout fails. `clone_repo_at_ref` therefore
treats a missing ref as a failure *of that source* and falls back, keeping the
existing `show-ref` check as the gate. Without that, pointing boots at the
mirror would introduce a failure mode that does not exist today.

The URLs are per-repo rather than derived from a single mirror host, so the
public repo can move to the mirror before the private repo's read credential
is solved (that credential is still an open design question on #1141).

**Two related fixes**

- The private repo's mirror URL will carry a credential, and cloud-init output
  lands in the console log and in boot dumps, so URLs are stripped of any
  `user:password@` before being logged.
- `default_provision` ignored `checkout_repos`' result entirely and ran ansible
  against a missing or partial checkout. It now returns 4, so the failure is
  attributable in a dump.

**Testing.** Verified against local git remotes, covering: no mirror
configured, healthy mirror, unreachable mirror, mirror reachable but missing
the tag, both sources failing (returns non-zero), and a credentialed URL
leaking nothing to the log.