### PR TITLE
JIT-16092: try github before falling back to main in jenkins checkouts

### DIFF
--- a/jenkins/groovy/Utils.groovy
+++ b/jenkins/groovy/Utils.groovy
@@ -77,6 +77,58 @@ def CheckSkipBuild(image_type, environment, force_build) {
     return (checkOutput == 1);
 }
 
+// Checks out one ref from one remote. Returns true on success, and false only
+// when that remote simply does not have the ref. Anything else (auth, network,
+// a broken workspace) is rethrown so the retry() around the caller can handle
+// it, since those are worth retrying and a missing ref is not.
+def TryCheckoutRef(url, ref, credentials, useSubmodules) {
+  try {
+    if (useSubmodules) {
+      checkout([$class: 'GitSCM', branches: [[name: "origin/${ref}"]], extensions: [[$class: 'SubmoduleOption', disableSubmodules: false, parentCredentials: false, recursiveSubmodules: true, reference: '', trackingSubmodules: false]], userRemoteConfigs: [[credentialsId: credentials, url: url]]])
+    } else {
+      git branch: ref, url: url, credentialsId: credentials
+    }
+    return true
+  } catch (hudson.AbortException e) {
+    if (e.toString().contains('Couldn\'t find any revision to build')) {
+      return false
+    }
+    throw e
+  }
+}
+
+// Checks out one infra repo, preferring the in-region mirror when one is
+// configured for it.
+//
+// The order matters. A mirror pulls from github on an interval, so it can be
+// missing a tag pushed moments earlier. Falling straight back to main there
+// would not fail the build, it would quietly build the wrong code -- which for
+// a job provisioning a release is worse than failing. So a ref the mirror does
+// not have is retried against github at the same ref, and only a ref github
+// does not have either falls back to main, which is the long-standing
+// behaviour for genuinely branch-less builds.
+//
+// Mirror URLs are HTTPS, so they need their own credential: the public repos
+// are served anonymously and the private one needs a Gitea user rather than
+// the github deploy key. INFRA_MIRROR_CREDENTIALS_ID overrides it.
+def CheckoutInfraRepo(repoName, branch, mirrorUrl, originUrl, useSubmodules) {
+  def mirrorCredentials = env.INFRA_MIRROR_CREDENTIALS_ID ?: 'video-infra'
+  if (mirrorUrl) {
+    echo "checking out ${repoName} at ${branch} from the in-region mirror"
+    if (TryCheckoutRef(mirrorUrl, branch, mirrorCredentials, useSubmodules)) {
+      return
+    }
+    echo "WARNING: ${branch} is not in the ${repoName} mirror yet, trying github"
+  }
+  if (TryCheckoutRef(originUrl, branch, 'video-infra', useSubmodules)) {
+    return
+  }
+  echo "WARNING: couldn't find branch ${branch} in ${repoName} repo, falling back to main"
+  if (!TryCheckoutRef(originUrl, 'main', 'video-infra', useSubmodules)) {
+    error("could not check out ${repoName} at ${branch} or at main")
+  }
+}
+
 def SetupRepos(branch) {
   sshagent (credentials: ['video-infra']) {
       def scmUrl = scm.getUserRemoteConfigs()[0].getUrl()
@@ -88,32 +140,14 @@ def SetupRepos(branch) {
       if (env.INFRA_CONFIGURATION_REPO) {
         dir('infra-configuration') {
             retry(count: 3) {
-                try {
-                    checkout([$class: 'GitSCM', branches: [[name: "origin/${branch}"]], extensions: [[$class: 'SubmoduleOption', disableSubmodules: false, parentCredentials: false, recursiveSubmodules: true, reference: '', trackingSubmodules: false]], userRemoteConfigs: [[credentialsId: 'video-infra', url: env.INFRA_CONFIGURATION_REPO]]])
-                } catch (hudson.AbortException e) {
-                    if (e.toString().contains('Couldn\'t find any revision to build')) {
-                        echo "WARNING: couldn't find branch ${branch} in infra-configuration repo, falling back to main"
-                        checkout([$class: 'GitSCM', branches: [[name: "origin/main"]], extensions: [[$class: 'SubmoduleOption', disableSubmodules: false, parentCredentials: false, recursiveSubmodules: true, reference: '', trackingSubmodules: false]], userRemoteConfigs: [[credentialsId: 'video-infra', url: env.INFRA_CONFIGURATION_REPO]]])
-                    } else {
-                        throw e
-                    }
-                }
+                CheckoutInfraRepo('infra-configuration', branch, env.INFRA_CONFIGURATION_MIRROR_REPO, env.INFRA_CONFIGURATION_REPO, true)
                 SetupAnsible()
             }
         }
       }
       dir('infra-customization') {
         retry(count: 3) {
-          try {
-            git branch: branch, url: env.INFRA_CUSTOMIZATIONS_REPO, credentialsId: 'video-infra'
-          } catch (hudson.AbortException e) {
-            if (e.toString().contains('Couldn\'t find any revision to build')) {
-                echo "WARNING: couldn't find branch ${branch} in infra-customization repo, falling back to main"
-                git branch: 'main', url: env.INFRA_CUSTOMIZATIONS_REPO, credentialsId: 'video-infra'
-            } else {
-                throw e
-            }
-          }
+          CheckoutInfraRepo('infra-customization', branch, env.INFRA_CUSTOMIZATIONS_MIRROR_REPO, env.INFRA_CUSTOMIZATIONS_REPO, false)
         }
       }
       if (env.INFRA_CONFIGURATION_REPO) {


### PR DESCRIPTION
Prerequisite for letting jenkins jobs fetch from the in-region Gitea mirror
(#1141). Split from the boot-path change (#1163) since it touches the jenkins
shared library.

**The hazard.** `SetupRepos` caught *"couldn't find any revision to build"* and
fell back to `main`, for both `infra-configuration` and `infra-customization`.
Against github that is harmless — the ref a job asks for is always there. It
stops being harmless the moment a job checks out from a mirror: mirrors pull on
an interval, so a tag pushed moments earlier can be missing, and the job would
not fail. It would quietly build `main`. For a job provisioning a release that
means deploying the wrong code.

**The order is now** mirror → github at the same ref → `main`. A ref github does
not have either still falls back to `main` (the long-standing behaviour for
branch-less builds), and if `main` is missing too it fails with a clear message
instead of a raw git error.

**Inert as merged.** Configured via `INFRA_CONFIGURATION_MIRROR_REPO` /
`INFRA_CUSTOMIZATIONS_MIRROR_REPO`, matching #1163, and unset everywhere. With
no mirror URL the attempt sequence is identical to today.

Both checkouts previously duplicated the same try/catch; that logic now lives
in `CheckoutInfraRepo`. `TryCheckoutRef` returns false *only* for a genuinely
absent ref and rethrows everything else, so the surrounding `retry(3)` still
covers transient failures. Both the submodule-enabled `GitSCM` form and the
plain `git` step are preserved.

Mirror URLs are HTTPS and need their own credential — public repos
anonymously, the private one via a Gitea user rather than the github deploy key
— overridable with `INFRA_MIRROR_CREDENTIALS_ID`.

**Testing.** Compiled `Utils.groovy` with `hudson.AbortException` stubbed, then
ran the extracted functions against stubbed `checkout`/`git` steps over six
cases:

| case | attempts |
|---|---|
| no mirror, ref on github | github@tag |
| no mirror, ref absent | github@tag → github@main |
| mirror has the ref | mirror@tag only |
| **mirror lags, github has it** | **mirror@tag → github@tag, main never touched** |
| ref nowhere | mirror@tag → github@tag → github@main |
| nothing anywhere | all three, then hard failure |

**Not covered here:** `infra-provisioning` itself is cloned from the pipeline's
own SCM url rather than a parameter, so it cannot be pointed at a mirror this
way. It has no `main` fallback either, so it carries none of this hazard.