### PR TITLE
JIT-16092: clone the private repo from the mirror with the read-only user

### DIFF
--- a/terraform/lib/postinstall-lib.sh
+++ b/terraform/lib/postinstall-lib.sh
@@ -181,11 +181,7 @@ function mount_volumes() {
     fi
   fi
 }
-# Opt in to the in-region git mirror. A stack exports GIT_MIRROR_HOST in its
-# user_data; "auto" derives the hostname scripts/deploy-nomad-gitea-mirror.sh
-# registers for this environment and region. Explicit INFRA_*_MIRROR_REPO
-# values always win. Nothing here can fail a boot: without a mirror host the
-# clone goes straight to github as before.
+# In-region git mirror, opt-in per stack via GIT_MIRROR_HOST ("auto" derives it). JIT-16092
 function configure_mirror_repos() {
   [ -z "$GIT_MIRROR_HOST" ] && return 0
   if [ "$GIT_MIRROR_HOST" == "auto" ]; then
@@ -197,7 +193,6 @@ function configure_mirror_repos() {
     GIT_MIRROR_HOST="$ENVIRONMENT-$ORACLE_REGION-git.$GIT_MIRROR_DNS_ZONE"
   fi
   [ -z "$GIT_MIRROR_ORG" ] && GIT_MIRROR_ORG="jitsi"
-  # Same repo names as github; the mirror keeps them (nomad/gitea-mirror.hcl).
   if [ -z "$INFRA_CONFIGURATION_MIRROR_REPO" ] && [ -n "$INFRA_CONFIGURATION_REPO" ]; then
     export INFRA_CONFIGURATION_MIRROR_REPO="https://$GIT_MIRROR_HOST/$GIT_MIRROR_ORG/$(basename "$INFRA_CONFIGURATION_REPO" .git).git"
   fi
@@ -206,13 +201,7 @@ function configure_mirror_repos() {
   fi
   echo "Using git mirror $GIT_MIRROR_HOST"
 }
-# The private repo is private on the mirror too, so the clone needs the
-# read-only mirror user. Its username and password sit in the boot bucket as
-# gitea-read-user (published by scripts/publish-gitea-read-user-bucket.sh) and
-# go into /root/.netrc for the mirror host: git hands netrc credentials to a
-# host only when it asks for them, so they never appear in a URL, in a process
-# list, or in the boot log. Never fatal: with no credential the mirror clone of
-# the private repo fails and checkout_repos falls back to github.
+# Read-only mirror user for the private repo: bucket -> netrc, never a URL. No creds => github
 function fetch_mirror_credentials() {
   [ -z "$INFRA_CUSTOMIZATIONS_MIRROR_REPO" ] && return 0
   local bucket="jvb-bucket-${ENVIRONMENT}"
@@ -228,7 +217,7 @@ function fetch_mirror_credentials() {
     rm -f "$creds_file"
     return 0
   fi
-  # The boot runs under set -x; keep the password out of the trace.
+  # keep the password out of the set -x trace
   local xtrace=false
   [[ $- == *x* ]] && xtrace=true
   set +x
@@ -284,8 +273,7 @@ function clone_repo_at_ref() {
   [ -z "$url" ] && return 1
   [ -z "$target" ] && return 1
   rm -rf "$target"
-  # No terminal at boot, so a host that wants credentials we do not have must
-  # fail at once rather than wait on a prompt.
+  # no terminal at boot: fail instead of waiting on a credential prompt
   GIT_TERMINAL_PROMPT=0 git clone "$url" "$target" || return 1
   git -C "$target" checkout "$ref" || return 1
   git -C "$target" submodule update --init --recursive || return 1

--- a/terraform/lib/postinstall-lib.sh
+++ b/terraform/lib/postinstall-lib.sh
@@ -181,15 +181,84 @@ function mount_volumes() {
     fi
   fi
 }
+# Opt in to the in-region git mirror. A stack exports GIT_MIRROR_HOST in its
+# user_data; "auto" derives the hostname scripts/deploy-nomad-gitea-mirror.sh
+# registers for this environment and region. Explicit INFRA_*_MIRROR_REPO
+# values always win. Nothing here can fail a boot: without a mirror host the
+# clone goes straight to github as before.
+function configure_mirror_repos() {
+  [ -z "$GIT_MIRROR_HOST" ] && return 0
+  if [ "$GIT_MIRROR_HOST" == "auto" ]; then
+    if [ -z "$ENVIRONMENT" ] || [ -z "$ORACLE_REGION" ]; then
+      echo "GIT_MIRROR_HOST=auto but ENVIRONMENT or ORACLE_REGION is unset, not using a mirror"
+      return 0
+    fi
+    [ -z "$GIT_MIRROR_DNS_ZONE" ] && GIT_MIRROR_DNS_ZONE="jitsi.net"
+    GIT_MIRROR_HOST="$ENVIRONMENT-$ORACLE_REGION-git.$GIT_MIRROR_DNS_ZONE"
+  fi
+  [ -z "$GIT_MIRROR_ORG" ] && GIT_MIRROR_ORG="jitsi"
+  # Same repo names as github; the mirror keeps them (nomad/gitea-mirror.hcl).
+  if [ -z "$INFRA_CONFIGURATION_MIRROR_REPO" ] && [ -n "$INFRA_CONFIGURATION_REPO" ]; then
+    export INFRA_CONFIGURATION_MIRROR_REPO="https://$GIT_MIRROR_HOST/$GIT_MIRROR_ORG/$(basename "$INFRA_CONFIGURATION_REPO" .git).git"
+  fi
+  if [ -z "$INFRA_CUSTOMIZATIONS_MIRROR_REPO" ] && [ -n "$INFRA_CUSTOMIZATIONS_REPO" ]; then
+    export INFRA_CUSTOMIZATIONS_MIRROR_REPO="https://$GIT_MIRROR_HOST/$GIT_MIRROR_ORG/$(basename "$INFRA_CUSTOMIZATIONS_REPO" .git).git"
+  fi
+  echo "Using git mirror $GIT_MIRROR_HOST"
+}
+# The private repo is private on the mirror too, so the clone needs the
+# read-only mirror user. Its username and password sit in the boot bucket as
+# gitea-read-user (published by scripts/publish-gitea-read-user-bucket.sh) and
+# go into /root/.netrc for the mirror host: git hands netrc credentials to a
+# host only when it asks for them, so they never appear in a URL, in a process
+# list, or in the boot log. Never fatal: with no credential the mirror clone of
+# the private repo fails and checkout_repos falls back to github.
+function fetch_mirror_credentials() {
+  [ -z "$INFRA_CUSTOMIZATIONS_MIRROR_REPO" ] && return 0
+  local bucket="jvb-bucket-${ENVIRONMENT}"
+  local creds_file="/root/.gitea-read-user.json"
+  local mirror_host
+  mirror_host=$(echo "$INFRA_CUSTOMIZATIONS_MIRROR_REPO" | sed -E 's#^[a-z]+://([^@/]*@)?([^/:]+).*#\2#')
+  if [ -z "$mirror_host" ]; then
+    echo "Could not read a hostname from the mirror URL, not fetching mirror credentials"
+    return 0
+  fi
+  if ! $OCI_BIN os object get -bn "$bucket" --name gitea-read-user --file "$creds_file" >/dev/null 2>&1; then
+    echo "No gitea-read-user in $bucket; the private repo will come from github"
+    rm -f "$creds_file"
+    return 0
+  fi
+  # The boot runs under set -x; keep the password out of the trace.
+  local xtrace=false
+  [[ $- == *x* ]] && xtrace=true
+  set +x
+  local username password
+  username=$(jq -r '.username // empty' "$creds_file")
+  password=$(jq -r '.password // empty' "$creds_file")
+  rm -f "$creds_file"
+  if [ -z "$username" ] || [ -z "$password" ]; then
+    [ "$xtrace" == "true" ] && set -x
+    echo "gitea-read-user in $bucket has no username or password; the private repo will come from github"
+    return 0
+  fi
+  (umask 077 && printf 'machine %s login %s password %s\n' "$mirror_host" "$username" "$password" > /root/.netrc)
+  chmod 600 /root/.netrc
+  [ "$xtrace" == "true" ] && set -x
+  echo "Installed mirror credentials for $username at $mirror_host"
+  return 0
+}
 function fetch_credentials() {
   ENVIRONMENT=$1
   BUCKET="jvb-bucket-${ENVIRONMENT}"
   $OCI_BIN os object get -bn $BUCKET --name vault-password --file /root/.vault-password
   $OCI_BIN os object get -bn $BUCKET --name id_rsa_jitsi_deployment --file /root/.ssh/id_rsa
   chmod 400 /root/.ssh/id_rsa
+  configure_mirror_repos
+  fetch_mirror_credentials
 }
 function clean_credentials() {
   rm /root/.vault-password /root/.ssh/id_rsa
+  rm -f /root/.netrc /root/.gitea-read-user.json
 }
 function set_hostname() {
   TYPE=$1
@@ -215,7 +284,9 @@ function clone_repo_at_ref() {
   [ -z "$url" ] && return 1
   [ -z "$target" ] && return 1
   rm -rf "$target"
-  git clone "$url" "$target" || return 1
+  # No terminal at boot, so a host that wants credentials we do not have must
+  # fail at once rather than wait on a prompt.
+  GIT_TERMINAL_PROMPT=0 git clone "$url" "$target" || return 1
   git -C "$target" checkout "$ref" || return 1
   git -C "$target" submodule update --init --recursive || return 1
   git -C "$target" show-ref "heads/$ref" || git -C "$target" show-ref "tags/$ref" || return 1

--- a/terraform/nomad-instance-pool/create-nomad-instance-pool-stack.sh
+++ b/terraform/nomad-instance-pool/create-nomad-instance-pool-stack.sh
@@ -246,6 +246,7 @@ terraform $TF_GLOBALS_CHDIR $ACTION \
   -var="vcn_name=$VCN_NAME" \
   -var "infra_configuration_repo=$INFRA_CONFIGURATION_REPO" \
   -var "infra_customizations_repo=$INFRA_CUSTOMIZATIONS_REPO" \
+  -var "git_mirror_host=$GIT_MIRROR_HOST" \
   -var "user_data_file=$POSTRUNNER_PATH" \
   -var="use_eip=$POOL_USE_EIP" \
   -var="secondary_vnic_name=$SECONDARY_VNIC_NAME" \

--- a/terraform/nomad-instance-pool/nomad-instance-pool-stack.tf
+++ b/terraform/nomad-instance-pool/nomad-instance-pool-stack.tf
@@ -41,6 +41,11 @@ variable "user_data_file" {
 }
 variable "infra_configuration_repo" {}
 variable "infra_customizations_repo" {}
+# In-region git mirror for boot-time clones (JIT-16092). Empty leaves boots on
+# github; "auto" derives <environment>-<region>-git.jitsi.net; or a hostname.
+variable "git_mirror_host" {
+  default = ""
+}
 variable "disk_in_gbs" {}
 variable "use_eip" {
   default = false
@@ -126,7 +131,7 @@ resource "oci_core_instance_configuration" "oci_instance_configuration_use_eip" 
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-header.sh"), # load the header
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-lib.sh"), # load the lib
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-eip-lib.sh"), # load the EIP lib
-          "\nexport INFRA_CONFIGURATION_REPO=${var.infra_configuration_repo}\nexport INFRA_CUSTOMIZATIONS_REPO=${var.infra_customizations_repo}\n", #repo variables
+          "\nexport INFRA_CONFIGURATION_REPO=${var.infra_configuration_repo}\nexport INFRA_CUSTOMIZATIONS_REPO=${var.infra_customizations_repo}\nexport GIT_MIRROR_HOST=${var.git_mirror_host}\n", #repo variables
           file("${path.cwd}/${var.user_data_file}"), # load our customizations
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-footer.sh") # load the footer
         ]))
@@ -192,7 +197,7 @@ resource "oci_core_instance_configuration" "oci_instance_configuration" {
         user_data = base64gzip(join("",[
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-header.sh"), # load the header
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-lib.sh"), # load the lib
-          "\nexport INFRA_CONFIGURATION_REPO=${var.infra_configuration_repo}\nexport INFRA_CUSTOMIZATIONS_REPO=${var.infra_customizations_repo}\n", #repo variables
+          "\nexport INFRA_CONFIGURATION_REPO=${var.infra_configuration_repo}\nexport INFRA_CUSTOMIZATIONS_REPO=${var.infra_customizations_repo}\nexport GIT_MIRROR_HOST=${var.git_mirror_host}\n", #repo variables
           file("${path.cwd}/${var.user_data_file}"), # load our customizations
           file("${path.cwd}/${var.user_data_lib_path}/postinstall-footer.sh") # load the footer
         ]))


### PR DESCRIPTION
Stacked on #1163 (base is its branch; retargets to main when it merges).

## Summary

- `fetch_credentials` additionally fetches `gitea-read-user` (JSON `username`/`password`) from `jvb-bucket-<env>` and writes `/root/.netrc` for the mirror host. git only sends netrc credentials to a host that challenges, so public repos stay anonymous and the credential never lands in a URL, `ps`, or the boot log (`set -x` is suspended while the password is in a variable; verified in a container harness that the password does not appear in the xtrace).
- `clean_credentials` removes the netrc.
- `configure_mirror_repos`: a stack opts in with `GIT_MIRROR_HOST` in user_data; `auto` derives `<env>-<region>-git.jitsi.net`, the hostname `scripts/deploy-nomad-gitea-mirror.sh` registers. Explicit `INFRA_*_MIRROR_REPO` still wins.
- `GIT_TERMINAL_PROMPT=0` on the clone: no terminal at boot, fail at once instead of hanging.
- `nomad-instance-pool` stack: optional `git_mirror_host` var (default empty, so nothing changes until set). First consumer, used for the canary boot.

## Why bucket and not Vault at boot

Vault OCI instance auth at boot (plan stage 3) is unbuilt, needs the `vault` CLI on the images, and adds a Vault dependency to boot while the 2026-07-09 seal outage mitigations are still landing. The bucket is what boots already fetch the deploy key and ansible-vault password from with their instance principal. `scripts/publish-gitea-read-user-bucket.sh` (companion infra-provisioning PR) copies the secret from Vault into the bucket per region.

## Safety

Nothing in this change can fail a boot. Missing object, unparseable object, wrong password, mirror down: the mirror clone of the private repo fails and `checkout_repos` (from #1163) falls back to github.

Companion PRs: infra-customizations-private #1098 (Vault grants), infra-provisioning #1166 (Nomad job + seed scripts).