### PR TITLE
JIT-16092: read-only Gitea user for boots, created on every mirror replica

### DIFF
--- a/doc/git-mirror-bootstrap-plan.md
+++ b/doc/git-mirror-bootstrap-plan.md
@@ -95,8 +95,8 @@ Both changes ship with an **automatic fallback to the current mechanism**
 5. **Repo visibility in Gitea.** Public repos (`infra-configuration`,
    `infra-provisioning`, `jitsi-meet`) are served **anonymously** over the
    internal mirror — booting instances need no credential for them.
-   `infra-customizations-private` stays **private** in Gitea and requires a
-   read-only Gitea access token (see decision 6). This deliberately avoids
+   `infra-customizations-private` stays **private** in Gitea and requires the
+   read-only Gitea user (see decision 6, revised). This deliberately avoids
    exposing private source to the whole VCN via anonymous read.
 
 6. **Bootstrap credentials from Vault via OCI instance identity.** A new Vault
@@ -105,10 +105,57 @@ Both changes ship with an **automatic fallback to the current mechanism**
    role **`vm-bootstrap`** (covers *all* VM roles, not just JVB), bound to the
    VM compartment OCID / dynamic group, issues a short-lived token scoped by a
    policy that can read **only** two paths:
-   - `secret/data/default/gitea/read-token` — the Gitea read-only token for the
-     private repo mirror.
+   - `secret/data/default/gitea/read-user` — the read-only Gitea **user**
+     (username + password) for the private repo mirror. See the 2026-09-07
+     revision below for why this is a user and not a token.
    - `secret/data/default/<env>/ansible-vault-password` — the ansible-vault
      password (moved off the bucket).
+
+   **Revised 2026-09-07 (read-only credential is a user, not a token).** The
+   original wording had boots read a shared Gitea *access token* from Vault.
+   That cannot work with decision 3: each replica runs its own ephemeral
+   sqlite database and mints its own tokens, a token exists only in the
+   database that minted it, Gitea cannot be told a token's value, and Fabio
+   routes a boot to either replica. Demonstrated in ops-dev: a sync triggered
+   through the mirror hostname left the two replicas with different
+   `mirror_updated` values, so a shared token would have been rejected by about
+   half of boots. A user's password *can* be chosen, so the flow is inverted:
+
+   1. `scripts/seed-gitea-read-user.sh` seeds `secret/default/gitea/read-user`
+      (`username`, `password`) once per Vault. The password is alphanumeric
+      only, because it ends up in a netrc line and may end up in a URL.
+   2. Every replica's init task creates that user from the secret
+      (`gitea admin user create --restricted`, then
+      `admin user change-password` so an in-place restart or a rotation
+      converges), idempotently and identically on every replica.
+   3. The sync-gate grants the user `read` as a collaborator on each private
+      repo once it has synced, re-checking on every pass because the grant is
+      repo state and vanishes when a stub is dropped and re-migrated. `/ready`
+      for a private repo also requires the grant, so a replica is never routed
+      to until a boot could actually clone from it. Verified on Gitea 1.22:
+      git-over-HTTP basic auth works for a plain user (no token required), the
+      grant PUT is idempotent (204 twice), push is refused, and a restricted
+      user can still fetch public repos when it presents credentials.
+   4. Boots clone over HTTPS with the credential in `/root/.netrc` for the
+      mirror host (written by `fetch_mirror_credentials`, removed by
+      `clean_credentials`, written with tracing off since the boot runs under
+      `set -x`). git hands netrc credentials to a host only when challenged, so
+      they never appear in a URL, process list or boot log, and public repos
+      are still fetched anonymously.
+   5. **Transition source of the credential: the boot bucket.** Vault OCI
+      instance auth at boot (stage 3) is unbuilt, needs the `vault` CLI on the
+      images, and would add a Vault dependency to boot while the 2026-07-09
+      seal outage mitigations are still landing. So for now
+      `scripts/publish-gitea-read-user-bucket.sh` copies the secret into
+      `jvb-bucket-<env>` (per region) as `gitea-read-user`, next to the deploy
+      key and ansible-vault password boots already fetch with their instance
+      principal. When stage 3 lands, boots read `secret/default/gitea/read-user`
+      directly; the instance-policy grant for that path is in
+      `terraform/vault-oci-instance-auth-config` (renamed from `read-token`,
+      re-apply per environment as part of stage 3).
+   6. Nothing here can fail a boot: a missing credential, a mirror without the
+      user, or a wrong password all make the mirror clone of the private repo
+      fail, and `checkout_repos` falls back to github.
 
 7. **Fallback to bucket + GitHub during transition.** The boot path attempts
    Vault + regional mirror first; on any failure it falls back to the current
@@ -296,6 +343,13 @@ today.
   before deploy: seed Vault `secret/default/gitea/admin` (username/password/email)
   and `secret/default/gitea/github` (a GitHub PAT with read access to
   `infra-customizations-private`).
+- **Read-only credential (2026-09-07):** built per the decision 6 revision.
+  `nomad/gitea-mirror.hcl` (init creates the user, gate grants read, `/ready`
+  requires it), `scripts/seed-gitea-read-user.sh`,
+  `scripts/publish-gitea-read-user-bucket.sh`, `fetch_mirror_credentials` +
+  `configure_mirror_repos` in `terraform/lib/postinstall-lib.sh`
+  (`GIT_MIRROR_HOST` opt-in per stack; plumbed into the nomad-instance-pool
+  stack first). Vault grants: infra-customizations-private #1098.
 - **Stage 2 (Vault, infra-customizations-private terraform):** the OCI auth
   method is **already enabled** (`terraform/vault-oci-auth-config` →
   `vault_auth_backend.oci`), and `terraform/vault-oci-instance-auth-config`
@@ -305,7 +359,7 @@ today.
   `secret/data/$ENVIRONMENT/*`**, so the ansible-vault password can move to
   `secret/data/$ENVIRONMENT/ansible-vault-password` and be read at boot with the
   *existing* role — no new role required for it. The only gap is the Gitea
-  read-token at `secret/data/default/gitea/read-token`, which is outside
+  read-user at `secret/data/default/gitea/read-user`, which is outside
   `secret/data/$ENVIRONMENT/*`; add a read grant for that path (either extend the
   instance policy, or add the dedicated least-privilege `bootstrap-read` policy +
   `vm-bootstrap` role per decision 6). This slots into the existing terraform

--- a/nomad/gitea-mirror.hcl
+++ b/nomad/gitea-mirror.hcl
@@ -50,6 +50,19 @@ variable "private_repos" {
   default = ["infra-customizations-private"]
 }
 
+# Vault KV path holding the read-only Gitea user that booting VMs use to clone
+# the private repo (decision 6, revised). Fields: username, password. Every
+# replica creates the same user from the same secret in its own database, so
+# the credential is valid whichever replica Fabio routes a boot to. A Gitea
+# access token cannot do this: tokens are minted by Gitea, exist only in the
+# database that minted them, and this job's databases are ephemeral and
+# per-replica. The Nomad workloads Vault policy must grant read on this path
+# (gitea_mirror_secret_paths in infra-customizations-private).
+variable "read_user_secret_path" {
+  type    = string
+  default = "secret/default/gitea/read-user"
+}
+
 # Disk the alloc dir may use, in MB. Nomad assumes 300MB when this is not
 # declared, which is badly wrong here: measured in ops-dev, the four repos take
 # ~1.05GB on disk (jitsi-meet alone ~890MB, infra-customizations-private
@@ -202,6 +215,18 @@ EOF
       }
 
       template {
+        destination = "secrets/read-user.env"
+        env         = true
+        change_mode = "noop"
+        data        = <<EOF
+{{ with secret "${var.read_user_secret_path}" -}}
+GITEA_READ_USER={{ .Data.data.username }}
+GITEA_READ_PASSWORD={{ .Data.data.password }}
+{{ end -}}
+EOF
+      }
+
+      template {
         perms       = 755
         destination = "local/init.sh"
         data        = <<EOF
@@ -230,14 +255,44 @@ gitea -c "$CONF" admin user create \
   --must-change-password=false || true
 
 # Mint a fresh, uniquely-named token for the sync-gate to seed/inspect mirrors.
+# The pid keeps the name unique even if two runs land in the same second, since
+# a name clash is fatal under set -e and would fail the whole task.
 TOKEN=$(gitea -c "$CONF" admin user generate-access-token \
   --username "$GITEA_ADMIN_USER" \
-  --token-name "seed-$(date +%s)" \
+  --token-name "seed-$(date +%s)-$$" \
   --scopes "write:repository,write:organization,write:admin,read:user" \
   --raw)
 printf '%s' "$TOKEN" > /alloc/gitea-seed/token
 chmod 600 /alloc/gitea-seed/token
 echo "init: admin ensured and seed token written"
+
+# Read-only user that boots clone the private repo with. `create` refuses to
+# run twice, so `change-password` is what makes the password converge on an
+# in-place restart or after a rotation of the Vault secret. Restricted so it
+# sees only what it is explicitly granted; the sync-gate grants it read on the
+# private repos over the API once they exist. Never fatal: a mirror with no
+# read user still serves the public repos, and boots fall back to github for
+# the private one.
+rm -f /alloc/gitea-seed/read-user
+if [ -n "$GITEA_READ_USER" ] && [ -n "$GITEA_READ_PASSWORD" ]; then
+  gitea -c "$CONF" admin user create \
+    --username "$GITEA_READ_USER" \
+    --password "$GITEA_READ_PASSWORD" \
+    --email "$GITEA_READ_USER@mirror.invalid" \
+    --must-change-password=false \
+    --restricted || true
+  if gitea -c "$CONF" admin user change-password \
+      --username "$GITEA_READ_USER" \
+      --password "$GITEA_READ_PASSWORD" \
+      --must-change-password=false; then
+    printf '%s' "$GITEA_READ_USER" > /alloc/gitea-seed/read-user
+    echo "init: read-only user $GITEA_READ_USER ensured"
+  else
+    echo "init: WARN could not set the read-only user's password; private repos will not be readable by boots"
+  fi
+else
+  echo "init: WARN no read-only user in Vault; private repos will not be readable by boots"
+fi
 EOF
       }
 
@@ -397,9 +452,13 @@ EOF
 1. Waits for Gitea, using the seed token written by the init task.
 2. Ensures the target org exists and each required repo is migrated as a pull
    mirror from GitHub, retrying until that succeeds.
-3. Serves /ready on GATE_PORT: 503 until every required repo reports
-   "empty": false (first sync done), then 200, plus /metrics for Prometheus.
-4. On SIGHUP, asks Gitea to pull every repo immediately instead of waiting for
+3. Grants the read-only boot user (created by the init task) read on each
+   private repo, again on every pass, because the grant lives on the repo row
+   and disappears whenever a repo is deleted and migrated again.
+4. Serves /ready on GATE_PORT: 503 until every required repo reports
+   "empty": false (first sync done) and, for private repos, the boot user can
+   read it; then 200, plus /metrics for Prometheus.
+5. On SIGHUP, asks Gitea to pull every repo immediately instead of waiting for
    its next interval. Nomad raises that signal when the Consul key the task
    templates changes, which is how a release pushes fresh refs to every replica
    at once (see the template stanza in the job).
@@ -437,6 +496,10 @@ INTERVAL = os.environ.get("GITEA_MIRROR_INTERVAL", "10m")
 GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN", "")
 GATE_PORT = int(os.environ.get("GATE_PORT", "8080"))
 TOKEN_FILE = "/alloc/gitea-seed/token"
+# Written by the init task only when the read-only user exists with the
+# password from Vault. Absent => no user to grant, private repos stay
+# admin-only and /ready ignores read access.
+READ_USER_FILE = "/alloc/gitea-seed/read-user"
 
 # How long to let a migrate request run before giving up on the answer. Gitea
 # migrates synchronously, so a big repo can hold the connection for minutes.
@@ -450,6 +513,9 @@ RETRY_BACKOFF = int(os.environ.get("GATE_RETRY_BACKOFF", "60"))
 POLL_INTERVAL = int(os.environ.get("GATE_POLL_INTERVAL", "10"))
 
 _ready = threading.Event()
+
+# Set once in main() from READ_USER_FILE; "" when there is no read-only user.
+READ_USER = ""
 
 # Set by SIGHUP, consumed by the main loop. A bare flag rather than an Event on
 # purpose: it is the only thing safe to touch from a signal handler.
@@ -471,6 +537,9 @@ class RepoState(object):
     def __init__(self):
         self.attempted_at = None
         self.outcome = None
+        # Whether the read-only user is known to have read on this repo. Reset
+        # whenever the repo is dropped, since the grant goes with it.
+        self.granted = False
 
 
 def parse_timestamp(value):
@@ -485,10 +554,15 @@ def parse_timestamp(value):
 
 def record_repo(repo, body):
     with _metrics_lock:
-        _metrics[repo] = {
-            "synced": 1 if body.get("empty") is False else 0,
-            "last_sync": parse_timestamp(body.get("mirror_updated")),
-        }
+        entry = _metrics.setdefault(repo, {"read_access": None})
+        entry["synced"] = 1 if body.get("empty") is False else 0
+        entry["last_sync"] = parse_timestamp(body.get("mirror_updated"))
+
+
+def record_read_access(repo, ok):
+    with _metrics_lock:
+        entry = _metrics.setdefault(repo, {"synced": 0, "last_sync": None})
+        entry["read_access"] = 1 if ok else 0
 
 
 def render_metrics():
@@ -511,6 +585,12 @@ def render_metrics():
         # its first clone would otherwise read as infinitely stale.
         if ts is not None:
             out.append('gitea_mirror_last_sync_timestamp_seconds{repo="%s"} %.0f' % (repo, ts))
+    out.append("# HELP gitea_mirror_repo_read_access Whether the read-only boot user can read this private repo.")
+    out.append("# TYPE gitea_mirror_repo_read_access gauge")
+    for repo in sorted(snap):
+        # Only meaningful for private repos, and only once a read user exists.
+        if snap[repo].get("read_access") is not None:
+            out.append('gitea_mirror_repo_read_access{repo="%s"} %d' % (repo, snap[repo]["read_access"]))
     return "\n".join(out) + "\n"
 
 
@@ -525,6 +605,15 @@ def read_token():
             pass
         time.sleep(2)
     raise SystemExit("sync-gate: seed token never appeared at %s" % TOKEN_FILE)
+
+
+def read_user():
+    """Name of the read-only boot user, or "" when the init task made none."""
+    try:
+        with open(READ_USER_FILE) as fh:
+            return fh.read().strip()
+    except OSError:
+        return ""
 
 
 def api(method, path, token, body=None, timeout=30):
@@ -621,6 +710,8 @@ def start_migrate(token, repo, st):
     if private and GITHUB_TOKEN:
         body["auth_token"] = GITHUB_TOKEN
     st.attempted_at = time.monotonic()
+    # A migrate makes a new repo row, so any grant we knew about is gone.
+    st.granted = False
     status, resp = api("POST", "/api/v1/repos/migrate", token, body, timeout=MIGRATE_TIMEOUT)
     if status in (201, 409):
         st.outcome = "unknown"
@@ -635,12 +726,48 @@ def start_migrate(token, repo, st):
         print("sync-gate: WARN migrate %s failed: %s %s" % (repo, status, resp), flush=True)
 
 
+def ensure_read_access(token, repo, st):
+    """True once the read-only user can read this repo.
+
+    Public repos need nothing (anonymous read). Private ones get the user as a
+    read collaborator. The PUT is idempotent, but it is only sent when the
+    permission check says it is missing, so a healthy replica is not writing to
+    its database every poll. The grant is repo state, so a repo that is deleted
+    and migrated again comes back without it -- hence this runs on every pass
+    and st.granted is reset in drop_stub.
+    """
+    if repo not in PRIVATE or not READ_USER:
+        return True
+    if st.granted:
+        return True
+    status, body = api(
+        "GET", "/api/v1/repos/%s/%s/collaborators/%s/permission" % (GITEA_ORG, repo, READ_USER), token
+    )
+    if status == 200 and body.get("permission") == "read":
+        st.granted = True
+    elif status in (200, 404):
+        status, body = api(
+            "PUT", "/api/v1/repos/%s/%s/collaborators/%s" % (GITEA_ORG, repo, READ_USER), token,
+            {"permission": "read"},
+        )
+        if status == 204:
+            st.granted = True
+            print("sync-gate: granted %s read on %s" % (READ_USER, repo), flush=True)
+        else:
+            print("sync-gate: WARN could not grant %s read on %s: %s %s" % (READ_USER, repo, status, body), flush=True)
+    else:
+        print("sync-gate: WARN could not check %s access to %s: %s %s" % (READ_USER, repo, status, body), flush=True)
+    record_read_access(repo, st.granted)
+    return st.granted
+
+
 def drop_stub(token, repo, st, why):
     """Delete an empty repo so the next pass can migrate it again."""
     status, resp = api("DELETE", "/api/v1/repos/%s/%s" % (GITEA_ORG, repo), token)
     if status in (204, 404):
         # attempted_at is deliberately left alone: it paces the retry.
         st.outcome = None
+        st.granted = False
         print("sync-gate: removed %s stub (%s), will migrate again" % (repo, why), flush=True)
     else:
         print("sync-gate: WARN could not remove %s stub: %s %s" % (repo, status, resp), flush=True)
@@ -656,11 +783,16 @@ def reconcile(token, repo, st):
 
     if status == 200 and body.get("empty") is False:
         st.outcome = None
-        return True
+        # Synced. For a private repo the replica is still not useful to a boot
+        # until the read-only user can actually clone it.
+        return ensure_read_access(token, repo, st)
 
     now = time.monotonic()
 
     if status == 404:
+        # Gone, however that happened (our drop_stub or someone else's delete),
+        # and the grant went with it.
+        st.granted = False
         if st.attempted_at is None or now - st.attempted_at >= RETRY_BACKOFF:
             start_migrate(token, repo, st)
         return False
@@ -711,7 +843,7 @@ def serve():
 
 
 def main():
-    global _sync_requested
+    global _sync_requested, READ_USER
 
     # Serve /ready (503) immediately so the health check has an endpoint while
     # the mirrors are still being seeded.
@@ -719,6 +851,11 @@ def main():
     signal.signal(signal.SIGHUP, request_sync)
 
     token = read_token()
+    READ_USER = read_user()
+    if READ_USER:
+        print("sync-gate: will grant %s read on private repos" % READ_USER, flush=True)
+    else:
+        print("sync-gate: WARN no read-only user; private repos will not be readable by boots", flush=True)
     wait_for_gitea(token)
 
     state = dict((repo, RepoState()) for repo in REQUIRED)

--- a/scripts/deploy-nomad-gitea-mirror.sh
+++ b/scripts/deploy-nomad-gitea-mirror.sh
@@ -3,6 +3,13 @@
 # Deploys the per-region Gitea mirror (nomad/gitea-mirror.hcl). Modeled on
 # deploy-nomad-ops-repo.sh: dc = $ENVIRONMENT-$ORACLE_REGION, served internal-only
 # via a Fabio int-urlprefix tag on the mirror hostname. See JIT-16092.
+#
+# Vault prerequisites (in the vault this environment's nomad uses), all read by
+# the job and granted via gitea_mirror_secret_paths in infra-customizations-private:
+#   secret/default/gitea/admin      username, password, email of the site admin
+#   secret/default/gitea/github     token: a GitHub PAT that can read the private repo
+#   secret/default/gitea/read-user  username, password of the read-only boot user
+#                                   (scripts/seed-gitea-read-user.sh)
 
 if [ -z "$ENVIRONMENT" ]; then
     echo "No ENVIRONMENT set, exiting"

--- a/scripts/publish-gitea-read-user-bucket.sh
+++ b/scripts/publish-gitea-read-user-bucket.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# Publishes the read-only Gitea mirror user from Vault into an environment's
+# boot bucket (jvb-bucket-<env>, one per region), as the object gitea-read-user
+# (JSON: username, password). Booting VMs read it with their instance principal
+# in fetch_credentials (terraform/lib/postinstall-lib.sh), exactly like the
+# ansible-vault password and deploy key already there, and write it to a netrc
+# for the mirror host. See JIT-16092.
+#
+# This is the transition path: the plan's end state has boots read the secret
+# straight from Vault via OCI instance auth, which is not built yet. The bucket
+# is per environment while the secret is per Vault, so run this once per
+# environment, after scripts/seed-gitea-read-user.sh against that
+# environment's Vault, and again after any rotation.
+#
+# Usage: ENVIRONMENT=stage-8x8 scripts/publish-gitea-read-user-bucket.sh
+#   REGIONS      defaults to the environment's NOMAD_REGIONS (where mirrors run)
+#   SECRET_PATH  default secret/default/gitea/read-user
+#   OBJECT_NAME  default gitea-read-user
+#   DELETE=true  remove the object instead (boots then fall back to github for
+#                the private repo; the public repos still come from the mirror)
+
+[ -e ./stack-env.sh ] && . ./stack-env.sh
+
+if [ -z "$ENVIRONMENT" ]; then
+  echo "No ENVIRONMENT found. Exiting..."
+  exit 203
+fi
+
+[ -e ./sites/$ENVIRONMENT/stack-env.sh ] && . ./sites/$ENVIRONMENT/stack-env.sh
+
+LOCAL_PATH=$(dirname "${BASH_SOURCE[0]}")
+[ -e "$LOCAL_PATH/../clouds/all.sh" ] && . "$LOCAL_PATH/../clouds/all.sh"
+[ -e "$LOCAL_PATH/../clouds/oracle.sh" ] && . "$LOCAL_PATH/../clouds/oracle.sh"
+
+[ -z "$SECRET_PATH" ] && SECRET_PATH="secret/default/gitea/read-user"
+[ -z "$OBJECT_NAME" ] && OBJECT_NAME="gitea-read-user"
+[ -z "$BUCKET_NAME" ] && BUCKET_NAME="jvb-bucket-${ENVIRONMENT}"
+[ -z "$REGIONS" ] && REGIONS="$NOMAD_REGIONS"
+if [ -z "$REGIONS" ]; then
+  echo "No REGIONS or NOMAD_REGIONS set, exiting"
+  exit 1
+fi
+
+FINAL_RET=0
+if [ "$DELETE" == "true" ]; then
+  for REGION in $REGIONS; do
+    if oci os object delete --force --region "$REGION" --bucket-name "$BUCKET_NAME" --name "$OBJECT_NAME"; then
+      echo "deleted $OBJECT_NAME from $BUCKET_NAME in $REGION"
+    else
+      echo "WARNING: could not delete $OBJECT_NAME from $BUCKET_NAME in $REGION"
+      FINAL_RET=1
+    fi
+  done
+  exit $FINAL_RET
+fi
+
+if ! vault token lookup >/dev/null 2>&1; then
+  echo "Not logged in to vault at ${VAULT_ADDR:-<unset>}; run scripts/vault-login.sh from infra-customizations-private first"
+  exit 203
+fi
+
+# Written to a private temp file, never passed on a command line.
+CREDS_FILE=$(mktemp)
+trap 'rm -f "$CREDS_FILE"' EXIT
+chmod 600 "$CREDS_FILE"
+if ! vault kv get -format=json "$SECRET_PATH" | jq -e '.data.data | {username, password} | select(.username != null and .password != null)' > "$CREDS_FILE"; then
+  echo "Could not read username and password from $SECRET_PATH in $VAULT_ADDR; run scripts/seed-gitea-read-user.sh first"
+  exit 1
+fi
+
+for REGION in $REGIONS; do
+  if oci os object put --force --region "$REGION" --bucket-name "$BUCKET_NAME" --name "$OBJECT_NAME" --file "$CREDS_FILE" >/dev/null; then
+    echo "published $OBJECT_NAME to $BUCKET_NAME in $REGION"
+  else
+    echo "WARNING: could not publish $OBJECT_NAME to $BUCKET_NAME in $REGION"
+    FINAL_RET=1
+  fi
+done
+
+exit $FINAL_RET

--- a/scripts/seed-gitea-read-user.sh
+++ b/scripts/seed-gitea-read-user.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# Seeds the read-only Gitea user that booting VMs use to clone the private repo
+# from the per-region Gitea mirror (JIT-16092). Writes username + password to
+# Vault at secret/default/gitea/read-user; every mirror replica's init task
+# creates the same user from it, so the credential works whichever replica a
+# boot lands on. See doc/git-mirror-bootstrap-plan.md, decision 6 (revised).
+#
+# Run once per Vault (ops-dev, ops-prod), not per environment. Afterwards the
+# mirrors have to be redeployed to pick the user up, and the credential has to
+# be published to each environment's boot bucket with
+# scripts/publish-gitea-read-user-bucket.sh.
+#
+# Usage: (vault login first, e.g. VAULT_ENVIRONMENT=ops-dev \
+#           ../infra-customizations-private/scripts/vault-login.sh)
+#   scripts/seed-gitea-read-user.sh
+#     GITEA_READ_USER   username, default mirror-reader
+#     ROTATE=true       overwrite an existing secret with a new password. The
+#                       mirrors converge on their next deploy or restart; until
+#                       every one has, boots on the old password fall back to
+#                       github for the private repo.
+#     SECRET_PATH       default secret/default/gitea/read-user
+
+set -e
+
+[ -z "$GITEA_READ_USER" ] && GITEA_READ_USER="mirror-reader"
+[ -z "$SECRET_PATH" ] && SECRET_PATH="secret/default/gitea/read-user"
+
+if ! vault token lookup >/dev/null 2>&1; then
+  echo "Not logged in to vault at ${VAULT_ADDR:-<unset>}; run scripts/vault-login.sh from infra-customizations-private first"
+  exit 203
+fi
+
+if vault kv get "$SECRET_PATH" >/dev/null 2>&1; then
+  if [ "$ROTATE" != "true" ]; then
+    echo "$SECRET_PATH already exists in $VAULT_ADDR; set ROTATE=true to replace the password"
+    echo "username: $(vault kv get -field=username "$SECRET_PATH")"
+    exit 0
+  fi
+  echo "Rotating the password in $SECRET_PATH"
+fi
+
+# Alphanumeric only, on purpose: the password ends up in a netrc line and may
+# end up in a URL, and neither has a portable way to quote anything else.
+# 40 alphanumeric characters is ~238 bits, far more than the hash needs.
+PASSWORD=$(LC_ALL=C tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 40)
+if [ "${#PASSWORD}" -ne 40 ]; then
+  echo "Failed to generate a password"
+  exit 1
+fi
+
+vault kv put "$SECRET_PATH" username="$GITEA_READ_USER" password="$PASSWORD" >/dev/null
+echo "Wrote $SECRET_PATH (username $GITEA_READ_USER) to $VAULT_ADDR"
+echo "Next: redeploy the gitea mirrors that use this vault, then publish to the boot buckets with scripts/publish-gitea-read-user-bucket.sh"


### PR DESCRIPTION
## Problem

Plan decision 6 had boots read a shared Gitea access token from Vault. With the mirror's deliberate ephemeral per-replica state (decision 3) that cannot work: a token exists only in the sqlite database that minted it, Gitea will not accept a chosen token value, and Fabio routes a boot to either replica. Roughly half of boots would have been rejected.

## Design (decision 6 revised, in `doc/git-mirror-bootstrap-plan.md`)

A Gitea user's password *can* be chosen, so the flow is inverted:

1. `scripts/seed-gitea-read-user.sh` seeds `secret/default/gitea/read-user` (`username`, `password`) once per Vault. Alphanumeric password: it ends up in a netrc line.
2. Every replica's init task creates that user (`admin user create --restricted`, then `admin user change-password` so restarts and rotations converge). A missing secret only loses the private repo; public repos still serve.
3. The sync-gate grants the user `read` as a collaborator on each private repo once synced, re-checking every pass (the grant is repo state; a dropped or re-migrated repo loses it). `/ready` for a private repo also requires the grant. New metric `gitea_mirror_repo_read_access{repo}`.
4. Boots clone over HTTPS with the credential in `/root/.netrc` (infra-provisioning #1165, stacked on #1163).
5. Transition: `scripts/publish-gitea-read-user-bucket.sh` copies the secret into `jvb-bucket-<env>` per region; boots fetch it with their instance principal like the deploy key. Vault-at-boot stays stage 3.

## Verified locally against `gitea/gitea:1.22`

- `admin user create` refuses a second run; `change-password` converges (old password rejected, new accepted).
- git-over-HTTP basic auth works for a plain user, no token needed. Push refused.
- Collaborator `PUT` is idempotent (204 twice); the grant disappears when the repo is recreated, and the gate re-grants (caught a missing flag reset in the first cut).
- Anonymous clone of the private repo refused; netrc credentials are only sent to a host that challenges, so public repos stay anonymous.
- Restricted user can still fetch public repos when it presents credentials.
- Init task second run in the same second used to die on a seed-token name clash under `set -e`; token name now includes the pid.

## Deploy order (ops-dev first)

1. infra-customizations-private #1098 applied to the ops-dev Vault (adds the read path to `nomad-workloads-policy-ops-dev`). **Without it the init template fails to render and the deployment auto-reverts.**
2. Secret seeded in ops-dev Vault and published to `jvb-bucket-ops-dev` (done).
3. `ENVIRONMENT=ops-dev ORACLE_REGION=us-phoenix-1 scripts/deploy-nomad-gitea-mirror.sh`, then verify against **each replica directly**, reschedule one, confirm anonymous still 404.

Companions: infra-customizations-private #1098 (Vault grants), infra-provisioning #1165 (boot path), #1163, #1164.