### PR TITLE
feat(tests): run e2e tests from jitsi-meet's tests/package.json when present

### DIFF
--- a/scripts/synthetic-dialin-test.sh
+++ b/scripts/synthetic-dialin-test.sh
@@ -83,7 +83,9 @@ function doTest {
   LOG_FILE=$6
   TEST_VIA_8x8=$7
 
-  TEST_TO_RUN="tests/specs/jaas/dial/dialin.spec.ts"
+  # Absolute - TESTS_DIR is set below, once, regardless of whether tests/ ends up being the CWD
+  # npm run is invoked from (see the tests/package.json note there).
+  TEST_TO_RUN="$TESTS_DIR/specs/jaas/dial/dialin.spec.ts"
 
   if [[ "$TEST_VIA_8x8" == "true" ]]; then
     # Let's create the conference mapper entry for this test
@@ -93,7 +95,7 @@ function doTest {
       --header 'Content-Type: application/json' \
       --data-raw "{\"url\":\"${ROOM_NAME}\"}"
       JWT_ACCESS_TOKEN=$JITSI_TOKEN
-      TEST_TO_RUN="tests/specs/misc/dialIn.spec.ts"
+      TEST_TO_RUN="$TESTS_DIR/specs/misc/dialIn.spec.ts"
       ADDR="${ADDR}/jitsi"
   fi
 
@@ -101,14 +103,14 @@ function doTest {
     GRID_HOST_URL=${SELENIUM_HUB_URL} \
     HEADLESS=true \
     DIAL_IN_REST_URL="https://api.voximplant.com/platform_api/StartScenarios/?account_id=${ACC_ID}&api_key=${API_KEY}&reference_ip=${REF_IP}&rule_id=${RULE_ID}&script_custom_data=%7B%22pin%22%3A%22{0}%22%7D" \
-    EXPECTATIONS="expectations.json" \
+    EXPECTATIONS="$EXPECTATIONS_FILE" \
     JWT_PRIVATE_KEY_PATH=$JAAS_SIGNING_KEY_FILE \
     JWT_KID=$JAAS_JWT_KID \
     JAAS_TENANT=$(echo "$JAAS_JWT_KID" | cut -f1 -d"/") \
     JWT_ACCESS_TOKEN=$JWT_ACCESS_TOKEN \
     ROOM_NAME_PREFIX="synthetic_" \
     BASE_URL=https://${ADDR}/ \
-  npm run test-grid-single ${TEST_TO_RUN} | tee -a ${LOG_FILE}
+  npm run test-grid-single -- "${TEST_TO_RUN}" | tee -a ${LOG_FILE}
 
   return ${PIPESTATUS[0]}
 }
@@ -122,6 +124,10 @@ cd ../jitsi-meet
 CURRENT_COMMIT=$(git log -1 --format="%H")
 echo "jitsi-meet commit is at ${CURRENT_COMMIT}"
 
+# Absolute, and computed once before the conditional cd below - see the tests/package.json note
+# there. Everything under tests/ (specs, expectations.json) is addressed via this from here on.
+TESTS_DIR="$(pwd)/tests"
+
 rm -rf test-results1 test-results2 test-results3 test-results4 test-results5 test-results6 test-results7 test-results8
 rm -f $TEST_OUTPUT_LOG_US
 rm -f $TEST_OUTPUT_LOG_EU
@@ -132,13 +138,27 @@ nvm use
 echo "node version:$(node -v)"
 echo "npm version:$(npm -v)"
 
+# tests/ has its own package.json (only the wdio-side runtime dependencies) on newer jitsi-meet
+# checkouts - installing there instead of at the jitsi-meet root is far smaller/faster than the
+# full monorepo install. Fall back to installing at the jitsi-meet root for older checkouts that
+# don't have it yet.
+UP=""
+if [ -f tests/package.json ]; then
+  cd tests
+  UP="../"
+fi
+
 npm install
 if [ $? -ne 0 ]; then
 	echo "Failure to install dependencies, retry will fix this"
  	exit 1;
 fi
 
-cat << EOF > expectations.json
+# Absolute, since this is read by whatever directory `npm run test-grid-single` happens to be
+# invoked from (jitsi-meet/ or jitsi-meet/tests/, depending on which one above) - see the note at
+# the top of jitsi-meet's tests/env.example.
+EXPECTATIONS_FILE="$TESTS_DIR/expectations.json"
+cat << EOF > "$EXPECTATIONS_FILE"
 {
   "dialIn": {
     "enabled": true,
@@ -156,7 +176,7 @@ echo "------------------------------------------------------------------------"
 echo ""
 doTest "$ACCOUNT_ID_US" "${VOX_API_KEY_US}" "400932" "$DOMAIN" "$(getRegionalIP "us-phoenix-1")" $TEST_OUTPUT_LOG_JAAS_US "false"
 SUCCESS=$?
-mv test-results test-results1
+mv test-results ${UP}test-results1
 
 # Only actually fail on two consecutive failures
 if [[ $SUCCESS -ne 0 ]]; then
@@ -164,7 +184,7 @@ if [[ $SUCCESS -ne 0 ]]; then
   sleep 120
   doTest "$ACCOUNT_ID_US" "${VOX_API_KEY_US}" "400932" "$DOMAIN" "$(getRegionalIP "us-phoenix-1")" $TEST_OUTPUT_LOG_JAAS_US "false"
   SUCCESS=$?
-  mv test-results test-results2
+  mv test-results ${UP}test-results2
 fi
 
 if [[ $SUCCESS == 0 ]]; then
@@ -185,7 +205,7 @@ if [[ $FAILED_VALUE == 0 ]]; then
     echo ""
     doTest "$ACCOUNT_ID_EU" "${VOX_API_KEY_EU}" "3460923" "frankfurt.$DOMAIN" "$(getRegionalIP "eu-frankfurt-1")" $TEST_OUTPUT_LOG_JAAS_EU "false"
     SUCCESS=$?
-    mv test-results test-results3
+    mv test-results ${UP}test-results3
 
     # Only actually fail on two consecutive failures
     if [[ $SUCCESS -ne 0 ]]; then
@@ -193,7 +213,7 @@ if [[ $FAILED_VALUE == 0 ]]; then
         sleep 90
         doTest "$ACCOUNT_ID_EU" "${VOX_API_KEY_EU}" "3460923" "frankfurt.$DOMAIN" "$(getRegionalIP "eu-frankfurt-1")" $TEST_OUTPUT_LOG_JAAS_EU "false"
         SUCCESS=$?
-        mv test-results test-results4
+        mv test-results ${UP}test-results4
     fi
 
     if [[ $SUCCESS == 0 ]]; then
@@ -215,7 +235,7 @@ echo ""
 
 doTest "$ACCOUNT_ID_US" "${VOX_API_KEY_US}" "400932" "$DOMAIN" "$(getRegionalIP "us-phoenix-1")" $TEST_OUTPUT_LOG_8x8_US "true"
 SUCCESS=$?
-mv test-results test-results5
+mv test-results ${UP}test-results5
 
 # Only actually fail on two consecutive failures
 if [[ $SUCCESS -ne 0 ]]; then
@@ -223,7 +243,7 @@ if [[ $SUCCESS -ne 0 ]]; then
   sleep 120
   doTest "$ACCOUNT_ID_US" "${VOX_API_KEY_US}" "400932" "$DOMAIN" "$(getRegionalIP "us-phoenix-1")" $TEST_OUTPUT_LOG_8x8_US "true"
   SUCCESS=$?
-  mv test-results test-results6
+  mv test-results ${UP}test-results6
 fi
 
 if [[ $SUCCESS == 0 ]]; then
@@ -244,7 +264,7 @@ if [[ $FAILED_VALUE == 0 ]]; then
     echo ""
     doTest "$ACCOUNT_ID_EU" "${VOX_API_KEY_EU}" "3460923" "frankfurt.$DOMAIN" "$(getRegionalIP "eu-frankfurt-1")" $TEST_OUTPUT_LOG_8x8_EU "true"
     SUCCESS=$?
-    mv test-results test-results7
+    mv test-results ${UP}test-results7
 
     # Only actually fail on two consecutive failures
     if [[ $SUCCESS -ne 0 ]]; then
@@ -252,7 +272,7 @@ if [[ $FAILED_VALUE == 0 ]]; then
         sleep 90
         doTest "$ACCOUNT_ID_EU" "${VOX_API_KEY_EU}" "3460923" "frankfurt.$DOMAIN" "$(getRegionalIP "eu-frankfurt-1")" $TEST_OUTPUT_LOG_8x8_EU "true"
         SUCCESS=$?
-        mv test-results test-results8
+        mv test-results ${UP}test-results8
     fi
 
     if [[ $SUCCESS == 0 ]]; then
@@ -269,6 +289,13 @@ fi
 
 
 rm $JAAS_SIGNING_KEY_FILE
+
+# When tests ran from tests/ (one directory deeper than jitsi-meet/, see UP above), copy the logs
+# up to jitsi-meet/ (checkLogs below still reads its own copy from here) so the Jenkinsfile's
+# archiveArtifacts still finds them at the jitsi-meet/test_log_*.txt paths it expects. Done
+# unconditionally, before the early `exit 0` on success below, since archiveArtifacts runs on
+# every build regardless of outcome.
+[ -n "$UP" ] && cp test_log_*.txt ${UP} 2>/dev/null || true
 
 # uncomment to disable paging; or set ENABLE_PAGE to default to "false" in the jenkins job configuraiton
 # ENABLE_PAGE="false"

--- a/scripts/validate-shard.sh
+++ b/scripts/validate-shard.sh
@@ -141,6 +141,32 @@ trap cleanup EXIT
 
 #set -x
 
+if [ -n "$JAAS_JWT_KID" ]; then
+  export IFRAME_TENANT="$(echo "${JAAS_JWT_KID}" | cut -d'/' -f1)"
+  export JWT_PRIVATE_KEY_PATH=$JAAS_SIGNING_KEY_FILE
+  export JWT_KID="${JAAS_JWT_KID}"
+  export WEBHOOKS_PROXY_URL="${WEBHOOKS_PROXY_URL}"
+  export WEBHOOKS_PROXY_SHARED_SECRET="${JAAS_WH_SHARED_SECRET}"
+fi
+
+[ -z "$LOCAL_REGION" ] && LOCAL_REGION="$OCI_LOCAL_REGION"
+[ -z "$LOCAL_REGION" ] && LOCAL_REGION="us-phoenix-1"
+
+SHARD_REGION=$(ENVIRONMENT="$ENVIRONMENT" SHARD="$SHARD" $LOCAL_PATH/shard.sh shard_region)
+# presume any shards with no region in the name are in the local region
+[ -z "$SHARD_REGION" ] && SHARD_REGION="$LOCAL_REGION"
+
+[ -e $LOCAL_PATH/../clouds/${SHARD_REGION}-${ENVIRONMENT}-oracle.sh ] && . $LOCAL_PATH/../clouds/${SHARD_REGION}-${ENVIRONMENT}-oracle.sh
+
+if [ -n "${VOX_ACCOUNT_ID}" ]; then
+  REF_IP="$(getRegionalIP "${JIGASI_DIAL_OUT_REGION}")"
+  export DIAL_IN_REST_URL="https://api.voximplant.com/platform_api/StartScenarios/?account_id=${VOX_ACCOUNT_ID}&api_key=${VOX_API_KEY}&reference_ip=${REF_IP}&rule_id=${VOX_HEALTH_CHECK_IN_RULE_ID}&script_custom_data=%7B%22pin%22%3A%22{0}%22%7D"
+  export DIAL_OUT_URL="${VOX_DIAL_OUT_URL}"
+  export SIP_JIBRI_DIAL_OUT_URL="${VIDEO_DIAL_OUT_URL}"
+  export YTUBE_TEST_STREAM_KEY="${TEST_YTUBE_TEST_STREAM_KEY}"
+  export YTUBE_TEST_BROADCAST_ID="${TEST_YTUBE_TEST_BROADCAST_ID}"
+fi
+
 pushd "$TMPDIR"
 
 git clone https://github.com/jitsi/jitsi-meet.git
@@ -161,48 +187,35 @@ else
   git checkout "${TORTURE_BRANCH}"
 fi
 
-if [ -n "$JAAS_JWT_KID" ]; then
-  export IFRAME_TENANT="$(echo "${JAAS_JWT_KID}" | cut -d'/' -f1)"
-  export JWT_PRIVATE_KEY_PATH=$JAAS_SIGNING_KEY_FILE
-  export JWT_KID="${JAAS_JWT_KID}"
-  export WEBHOOKS_PROXY_URL="${WEBHOOKS_PROXY_URL}"
-  export WEBHOOKS_PROXY_SHARED_SECRET="${JAAS_WH_SHARED_SECRET}"
-fi
-
 nvm install
 nvm use
 
 node -v
 npm -v
+
+# tests/ has its own package.json (only the wdio-side runtime dependencies) on newer jitsi-meet
+# checkouts - installing there instead of at the jitsi-meet root is far smaller/faster than the
+# full monorepo install. Fall back to installing at the jitsi-meet root for older checkouts that
+# don't have it yet.
+if [ -f tests/package.json ]; then
+  cd tests
+  RESULTS_SRC="$TMPDIR/jitsi-meet/tests/test-results"
+else
+  RESULTS_SRC="$TMPDIR/jitsi-meet/test-results"
+fi
+
 echo "Start npm install"
 npm install
 echo "Done npm install"
 
-[ -z "$LOCAL_REGION" ] && LOCAL_REGION="$OCI_LOCAL_REGION"
-[ -z "$LOCAL_REGION" ] && LOCAL_REGION="us-phoenix-1"
-
-SHARD_REGION=$(ENVIRONMENT="$ENVIRONMENT" SHARD="$SHARD" $LOCAL_PATH/shard.sh shard_region)
-# presume any shards with no region in the name are in the local region
-[ -z "$SHARD_REGION" ] && SHARD_REGION="$LOCAL_REGION"
-
-[ -e $LOCAL_PATH/../clouds/${SHARD_REGION}-${ENVIRONMENT}-oracle.sh ] && . $LOCAL_PATH/../clouds/${SHARD_REGION}-${ENVIRONMENT}-oracle.sh
-
-if [ -n "${VOX_ACCOUNT_ID}" ]; then
-  REF_IP="$(getRegionalIP "${JIGASI_DIAL_OUT_REGION}")"
-  export DIAL_IN_REST_URL="https://api.voximplant.com/platform_api/StartScenarios/?account_id=${VOX_ACCOUNT_ID}&api_key=${VOX_API_KEY}&reference_ip=${REF_IP}&rule_id=${VOX_HEALTH_CHECK_IN_RULE_ID}&script_custom_data=%7B%22pin%22%3A%22{0}%22%7D"
-  export DIAL_OUT_URL="${VOX_DIAL_OUT_URL}"
-  export SIP_JIBRI_DIAL_OUT_URL="${VIDEO_DIAL_OUT_URL}"
-  export YTUBE_TEST_STREAM_KEY="${TEST_YTUBE_TEST_STREAM_KEY}"
-  export YTUBE_TEST_BROADCAST_ID="${TEST_YTUBE_TEST_BROADCAST_ID}"
-fi
-
-# For the 8x8 environments, add the meeting-settings spec from the branding repo so the grid
-# run below includes it. The spec maps onto tests/specs/8x8/ and resolves the jitsi-meet test
-# framework via its relative imports.
+# For the 8x8 environments, add the meeting-settings spec from the branding repo so the grid run
+# below includes it. The spec maps onto tests/specs/8x8/ and resolves the jitsi-meet test
+# framework via its relative imports. Works the same whether we're sitting in tests/ or jitsi-meet/
+# above (specs/ is right here either way).
 if [ "$RUN_MEET_SETTINGS" = "true" ]; then
   if [ -d "$BRANDING_PATH/meet-8x8-com/tests/specs" ]; then
     echo "Adding 8x8 meeting-settings spec from $BRANDING_PATH"
-    cp -a "$BRANDING_PATH/meet-8x8-com/tests/specs/." tests/specs/
+    cp -a "$BRANDING_PATH/meet-8x8-com/tests/specs/." specs/
 
     # Settings page differs per environment type (stage -> pilot, prod -> prod); the spec
     # derives the API hosts from it.
@@ -236,7 +249,7 @@ echo "Done testing"
 popd
 popd
 
-mv $TMPDIR/jitsi-meet/test-results ../test-results/${SHARD}
+mv "$RESULTS_SRC" ../test-results/${SHARD}
 
 if [[ $SUCCESS == 0 ]]; then
   $LOCAL_PATH/set_shard_tested.py $ENVIRONMENT $SHARD passed $BUILD_NUMBER

--- a/scripts/validate-shard.sh
+++ b/scripts/validate-shard.sh
@@ -169,7 +169,13 @@ fi
 
 pushd "$TMPDIR"
 
-git clone https://github.com/jitsi/jitsi-meet.git
+# --no-single-branch keeps every remote branch/tag resolvable (needed below to check for
+# release-$TAG and to check out tags/$TAG), --shallow-since trims history instead of fetching the
+# whole repo since its creation, and --filter=blob:none defers downloading file contents until
+# something is actually checked out. Verified this combination checks out cleanly even for refs
+# from years before the cutoff (git fetches whatever objects that checkout actually needs on
+# demand) - the shallow-since window only limits history depth, not which refs are reachable.
+git clone --no-single-branch --shallow-since="6 months ago" --filter=blob:none https://github.com/jitsi/jitsi-meet.git
 
 JITSI_MEET_BRANCH="$(getJitsiMeetTag $SHARD)"
 


### PR DESCRIPTION
## Summary
Companion to [jitsi/jitsi-meet#17800](https://github.com/jitsi/jitsi-meet/pull/17800), which adds a standalone `tests/package.json` to jitsi-meet (only the wdio-side runtime dependencies, ~165MB vs. the full monorepo's ~1.2GB).

- Both `scripts/validate-shard.sh` and `scripts/synthetic-dialin-test.sh` now `cd` into `tests/` and install there when `tests/package.json` exists, falling back to installing at the jitsi-meet root exactly as before for older checkouts that don't have it yet. The actual test invocation (`npm run test-grid`, tag/branch resolution, vault/JAAS setup) is unchanged.
- `validate-shard.sh`: the `RUN_MEET_SETTINGS` (8x8 meeting-settings) branch no longer needs a separate code path - since tests still run from a normal checkout (not a compiled artifact), copying the branding repo's extra spec files into `specs/` before the run works the same regardless of whether that's `jitsi-meet/tests/specs/` or `jitsi-meet/specs/`.
- `synthetic-dialin-test.sh`: `TESTS_DIR` (absolute, computed once before the conditional `cd`) is used for the spec-file argument and `EXPECTATIONS`; a new `UP` variable tracks whether `test-results`/logs need copying up a level afterward to keep landing at the paths the Jenkinsfile already archives.

## Test plan
- [x] `bash -n` on both scripts
- [x] Traced both code paths (tests/package.json present vs. absent) by hand against the actual Jenkinsfile invocation context for each script
- [ ] Needs a real run against a shard/PR-test box to confirm end to end (depends on jitsi/jitsi-meet#17800 merging first - `tests/package.json` doesn't exist on `master` yet)