### PR TITLE
scripts: print the autoscaler response body on failed requests

### DIFF
--- a/scripts/check-group-rotation-health.sh
+++ b/scripts/check-group-rotation-health.sh
@@ -92,6 +92,7 @@ while true; do
     echo "Group $GROUP_NAME has $HEALTHY_COUNT healthy new instances of $NEW_COUNT new total, waiting for $EXPECTED_COUNT"
   else
     echo "Failed to get group $GROUP_NAME report, status is $GROUP_REPORT_STATUS_CODE"
+    echo "Autoscaler response: $(sed '$ d' <<<"$instanceGroupGetResponse")"
   fi
 
   if [ $WAIT_TOTAL_SECONDS -lt $HEALTH_CHECK_TIMEOUT ]; then

--- a/scripts/check-jvb-count-custom-autoscaler-oracle.sh
+++ b/scripts/check-jvb-count-custom-autoscaler-oracle.sh
@@ -74,6 +74,7 @@ while true; do
     echo "Group $GROUP_NAME has expected count $EXPECTED_COUNT and checked count $COUNT_TO_CHECK, after checking with CHECK_SCALE_UP=$CHECK_SCALE_UP"
   else
     echo "Failed to get group $GROUP_NAME report, status is $GROUP_REPORT_STATUS_CODE"
+    echo "Autoscaler response: $(sed '$ d' <<<"$instanceGroupGetResponse")"
   fi
 
   # failure to either get report or condition not met

--- a/scripts/create-or-rotate-custom-jigasi-oracle.sh
+++ b/scripts/create-or-rotate-custom-jigasi-oracle.sh
@@ -249,6 +249,7 @@ if [ "$getGroupHttpCode" == 404 ]; then
     echo "Group $GROUP_NAME was created successfully"
   else
     echo "Error creating group $GROUP_NAME. AutoScaler response status code is $createGroupHttpCode"
+    echo "Autoscaler response: $(sed '$ d' <<<"$instanceGroupCreateResponse")"
     exit 205
   fi
 
@@ -317,6 +318,7 @@ elif [ "$getGroupHttpCode" == 200 ]; then
     echo "Successfully launched $PROTECTED_INSTANCES_COUNT instances in group $GROUP_NAME"
   else
     echo "Error launching $PROTECTED_INSTANCES_COUNT instances in group $GROUP_NAME. AutoScaler response status code is $launchGroupHttpCode"
+    echo "Autoscaler response: $(sed '$ d' <<<"$instanceGroupLaunchResponse")"
     exit 208
   fi
 
@@ -343,6 +345,7 @@ elif [ "$getGroupHttpCode" == 200 ]; then
         echo "Successfully restored previous instance configuration on group $GROUP_NAME"
       else
         echo "Error restoring previous instance configuration on group $GROUP_NAME. AutoScaler response status code is $restoreConfigHttpCode"
+        echo "Autoscaler response: $(sed '$ d' <<<"$restoreConfigResponse")"
       fi
       echo "The unhealthy protected instances will lose scale-down protection after $JIGASI_PROTECTED_TTL_SEC seconds and require manual cleanup"
       exit 223
@@ -380,10 +383,12 @@ elif [ "$getGroupHttpCode" == 200 ]; then
     fi
   else
     echo "Error scaling down to $PROTECTED_INSTANCES_COUNT instances in group $GROUP_NAME. AutoScaler response status code is $scaleDownGroupHttpCode"
+    echo "Autoscaler response: $(sed '$ d' <<<"$instanceGroupScaleDownResponse")"
     exit 209
   fi
 
 else
   echo "No group named $GROUP_NAME was found nor created. AutoScaler response status code is $getGroupHttpCode"
+  echo "Autoscaler response: $(sed '$ d' <<<"$instanceGroupGetResponse")"
   exit 210
 fi

--- a/scripts/create-or-rotate-custom-jvb-oracle.sh
+++ b/scripts/create-or-rotate-custom-jvb-oracle.sh
@@ -299,6 +299,7 @@ elif [ "$getGroupHttpCode" == 200 ]; then
 #    oci compute-management instance-configuration delete --instance-configuration-id "$EXISTING_INSTANCE_CONFIGURATION_ID" --region "$ORACLE_REGION" --force
   else
     echo "Error launching $PROTECTED_INSTANCES_COUNT instances in group $GROUP_NAME. AutoScaler response status code is $launchGroupHttpCode"
+    echo "Autoscaler response: $(sed '$ d' <<<"$instanceGroupLaunchResponse")"
     exit 208
   fi
 
@@ -328,6 +329,7 @@ elif [ "$getGroupHttpCode" == 200 ]; then
             echo "Successfully restored previous instance configuration on group $GROUP_NAME"
           else
             echo "Error restoring previous instance configuration on group $GROUP_NAME. AutoScaler response status code is $restoreConfigHttpCode"
+            echo "Autoscaler response: $(sed '$ d' <<<"$restoreConfigResponse")"
           fi
         fi
         echo "The unhealthy protected instances will lose scale-down protection after $JVB_PROTECTED_TTL_SEC seconds and require manual cleanup"
@@ -349,6 +351,7 @@ elif [ "$getGroupHttpCode" == 200 ]; then
       echo "Successfully scaled down to $PROTECTED_INSTANCES_COUNT instances in group $GROUP_NAME"
     else
       echo "Error scaling down to $PROTECTED_INSTANCES_COUNT instances in group $GROUP_NAME. AutoScaler response status code is $scaleDownGroupHttpCode"
+      echo "Autoscaler response: $(sed '$ d' <<<"$instanceGroupScaleDownResponse")"
       exit 209
     fi
   else
@@ -357,5 +360,6 @@ elif [ "$getGroupHttpCode" == 200 ]; then
   fi
 else
   echo "No group named $GROUP_NAME was found nor created. AutoScaler response status code is $getGroupHttpCode"
+  echo "Autoscaler response: $(sed '$ d' <<<"$instanceGroupGetResponse")"
   exit 210
 fi

--- a/scripts/create-or-rotate-jibri-nomad.sh
+++ b/scripts/create-or-rotate-jibri-nomad.sh
@@ -170,6 +170,7 @@ if [ "$getGroupHttpCode" == 404 ]; then
     echo "Group $GROUP_NAME was created successfully"
   else
     echo "Error creating group $GROUP_NAME. AutoScaler response status code is $createGroupHttpCode"
+    echo "Autoscaler response: $(sed '$ d' <<<"$instanceGroupCreateResponse")"
     exit 205
   fi
 
@@ -218,6 +219,7 @@ elif [ "$getGroupHttpCode" == 200 ]; then
     echo "Successfully launched $PROTECTED_INSTANCES_COUNT instances in group $GROUP_NAME"
   else
     echo "Error launching $PROTECTED_INSTANCES_COUNT instances in group $GROUP_NAME. AutoScaler response status code is $launchGroupHttpCode"
+    echo "Autoscaler response: $(sed '$ d' <<<"$instanceGroupLaunchResponse")"
     exit 208
   fi
 
@@ -251,6 +253,7 @@ elif [ "$getGroupHttpCode" == 200 ]; then
     echo "Successfully scaled down to $PROTECTED_INSTANCES_COUNT instances in group $GROUP_NAME"
   else
     echo "Error scaling down to $PROTECTED_INSTANCES_COUNT instances in group $GROUP_NAME. AutoScaler response status code is $scaleDownGroupHttpCode"
+    echo "Autoscaler response: $(sed '$ d' <<<"$instanceGroupScaleDownResponse")"
     exit 209
   fi
 

--- a/scripts/create-or-rotate-jibri-oracle.sh
+++ b/scripts/create-or-rotate-jibri-oracle.sh
@@ -355,6 +355,7 @@ if [ "$getGroupHttpCode" == 404 ]; then
     echo "Group $GROUP_NAME was created successfully"
   else
     echo "Error creating group $GROUP_NAME. AutoScaler response status code is $createGroupHttpCode"
+    echo "Autoscaler response: $(sed '$ d' <<<"$instanceGroupCreateResponse")"
     exit 205
   fi
 
@@ -430,6 +431,7 @@ elif [ "$getGroupHttpCode" == 200 ]; then
     echo "Successfully launched $PROTECTED_INSTANCES_COUNT instances in group $GROUP_NAME"
   else
     echo "Error launching $PROTECTED_INSTANCES_COUNT instances in group $GROUP_NAME. AutoScaler response status code is $launchGroupHttpCode"
+    echo "Autoscaler response: $(sed '$ d' <<<"$instanceGroupLaunchResponse")"
     exit 208
   fi
 
@@ -456,6 +458,7 @@ elif [ "$getGroupHttpCode" == 200 ]; then
         echo "Successfully restored previous instance configuration on group $GROUP_NAME"
       else
         echo "Error restoring previous instance configuration on group $GROUP_NAME. AutoScaler response status code is $restoreConfigHttpCode"
+        echo "Autoscaler response: $(sed '$ d' <<<"$restoreConfigResponse")"
       fi
       echo "The unhealthy protected instances will lose scale-down protection after $JIBRI_PROTECTED_TTL_SEC seconds and require manual cleanup"
       exit 223
@@ -493,10 +496,12 @@ elif [ "$getGroupHttpCode" == 200 ]; then
     fi
   else
     echo "Error scaling down to $PROTECTED_INSTANCES_COUNT instances in group $GROUP_NAME. AutoScaler response status code is $scaleDownGroupHttpCode"
+    echo "Autoscaler response: $(sed '$ d' <<<"$instanceGroupScaleDownResponse")"
     exit 209
   fi
 
 else
   echo "No group named $GROUP_NAME was found nor created. AutoScaler response status code is $getGroupHttpCode"
+  echo "Autoscaler response: $(sed '$ d' <<<"$instanceGroupGetResponse")"
   exit 210
 fi

--- a/scripts/create-or-rotate-transcriber-nomad.sh
+++ b/scripts/create-or-rotate-transcriber-nomad.sh
@@ -156,6 +156,7 @@ if [ "$getGroupHttpCode" == 404 ]; then
     echo "Group $GROUP_NAME was created successfully"
   else
     echo "Error creating group $GROUP_NAME. AutoScaler response status code is $createGroupHttpCode"
+    echo "Autoscaler response: $(sed '$ d' <<<"$instanceGroupCreateResponse")"
     exit 205
   fi
 
@@ -204,6 +205,7 @@ elif [ "$getGroupHttpCode" == 200 ]; then
     echo "Successfully launched $PROTECTED_INSTANCES_COUNT instances in group $GROUP_NAME"
   else
     echo "Error launching $PROTECTED_INSTANCES_COUNT instances in group $GROUP_NAME. AutoScaler response status code is $launchGroupHttpCode"
+    echo "Autoscaler response: $(sed '$ d' <<<"$instanceGroupLaunchResponse")"
     exit 208
   fi
 
@@ -237,6 +239,7 @@ elif [ "$getGroupHttpCode" == 200 ]; then
     echo "Successfully scaled down to $PROTECTED_INSTANCES_COUNT instances in group $GROUP_NAME"
   else
     echo "Error scaling down to $PROTECTED_INSTANCES_COUNT instances in group $GROUP_NAME. AutoScaler response status code is $scaleDownGroupHttpCode"
+    echo "Autoscaler response: $(sed '$ d' <<<"$instanceGroupScaleDownResponse")"
     exit 209
   fi
 

--- a/scripts/custom-autoscaler-create-group.sh
+++ b/scripts/custom-autoscaler-create-group.sh
@@ -260,5 +260,6 @@ if [ "$createGroupHttpCode" == 200 ]; then
   echo "Group $GROUP_NAME was created successfully"
 else
   echo "Error creating group $GROUP_NAME. AutoScaler response status code is $createGroupHttpCode"
+  echo "Autoscaler response: $(sed '$ d' <<<"$instanceGroupCreateResponse")"
   exit 205
 fi

--- a/scripts/custom-autoscaler-launch-protected.sh
+++ b/scripts/custom-autoscaler-launch-protected.sh
@@ -124,5 +124,6 @@ if [ "$launchGroupHttpCode" == 200 ]; then
     RET=0
 else
     echo "Error launching $PROTECTED_INSTANCES_COUNT instances in group $GROUP_NAME. AutoScaler response status code is $launchGroupHttpCode"
+    echo "Autoscaler response: $(sed '$ d' <<<"$instanceGroupLaunchResponse")"
     RET=208
 fi

--- a/scripts/custom-autoscaler-reconfigure-group.sh
+++ b/scripts/custom-autoscaler-reconfigure-group.sh
@@ -132,5 +132,6 @@ elif [ "$updateGroupHttpCode" == 404 ]; then
   exit 230
 else
   echo "Error triggering reconfiguration for group $GROUP_NAME. AutoScaler response status code is $updateGroupHttpCode"
+  echo "Autoscaler response: $(sed '$ d' <<<"$response")"
   exit 208
 fi

--- a/scripts/custom-autoscaler-rotate-group.sh
+++ b/scripts/custom-autoscaler-rotate-group.sh
@@ -40,6 +40,7 @@ if [[ "$SKIP_SCALE_DOWN" != "true" ]]; then
                     echo "Successfully restored previous instance configuration on group $GROUP_NAME"
                 else
                     echo "Error restoring previous instance configuration on group $GROUP_NAME. AutoScaler response status code is $restoreConfigHttpCode"
+                    echo "Autoscaler response: $(sed '$ d' <<<"$restoreConfigResponse")"
                 fi
             fi
             echo "The unhealthy protected instances will lose scale-down protection after $PROTECTED_TTL_SEC seconds and require manual cleanup"

--- a/scripts/custom-autoscaler-update-desired-values.sh
+++ b/scripts/custom-autoscaler-update-desired-values.sh
@@ -139,5 +139,6 @@ elif [ "$updateGroupHttpCode" == 404 ]; then
   exit 230
 else
   echo "Error updating desired values for group $GROUP_NAME. AutoScaler response status code is $updateGroupHttpCode"
+  echo "Autoscaler response: $(sed '$ d' <<<"$response")"
   exit 208
 fi

--- a/scripts/custom-autoscaler-update-instance-configuration.sh
+++ b/scripts/custom-autoscaler-update-instance-configuration.sh
@@ -81,5 +81,6 @@ if [ "$updateGroupHttpCode" == 200 ]; then
   echo "Successfully updated instance configuration id for group $GROUP_NAME"
 else
   echo "Error updating instance configuration id for group $GROUP_NAME. AutoScaler response status code is $updateGroupHttpCode"
+  echo "Autoscaler response: $(sed '$ d' <<<"$response")"
   exit 208
 fi

--- a/scripts/custom-autoscaler-update-scaling-activities.sh
+++ b/scripts/custom-autoscaler-update-scaling-activities.sh
@@ -146,5 +146,6 @@ if [ "$updateGroupHttpCode" == 200 ]; then
   echo "Successfully updated scaling activities for group $GROUP_NAME"
 else
   echo "Error updating scaling activities for group $GROUP_NAME. AutoScaler response status code is $updateGroupHttpCode"
+  echo "Autoscaler response: $(sed '$ d' <<<"$response")"
   exit 208
 fi

--- a/scripts/custom-autoscaler-update-scaling-options.sh
+++ b/scripts/custom-autoscaler-update-scaling-options.sh
@@ -125,5 +125,6 @@ if [ "$updateGroupHttpCode" == 200 ]; then
   echo "Successfully updated scaling options for group $GROUP_NAME"
 else
   echo "Error updating scaling options for group $GROUP_NAME. AutoScaler response status code is $updateGroupHttpCode"
+  echo "Autoscaler response: $(sed '$ d' <<<"$response")"
   exit 208
 fi

--- a/scripts/custom-autoscaler-update-scheduled-scaling.sh
+++ b/scripts/custom-autoscaler-update-scheduled-scaling.sh
@@ -81,6 +81,7 @@ if [ "$ACTION" == "delete" ]; then
     echo "Successfully deleted scheduled scaling config for group $GROUP_NAME"
   else
     echo "Error deleting scheduled scaling config for group $GROUP_NAME. AutoScaler response status code is $httpCode"
+    echo "Autoscaler response: $(sed '$ d' <<<"$response")"
     exit 208
   fi
 elif [ "$ACTION" == "put" ]; then
@@ -109,6 +110,7 @@ elif [ "$ACTION" == "put" ]; then
     echo "Successfully updated scheduled scaling config for group $GROUP_NAME"
   else
     echo "Error updating scheduled scaling config for group $GROUP_NAME. AutoScaler response status code is $httpCode"
+    echo "Autoscaler response: $(sed '$ d' <<<"$response")"
     exit 208
   fi
 elif [ "$ACTION" == "enable" ] || [ "$ACTION" == "disable" ]; then
@@ -128,6 +130,7 @@ elif [ "$ACTION" == "enable" ] || [ "$ACTION" == "disable" ]; then
 
   if [ "$getHttpCode" != 200 ]; then
     echo "Error fetching scheduled scaling config for group $GROUP_NAME. AutoScaler response status code is $getHttpCode"
+    echo "Autoscaler response: $(sed '$ d' <<<"$getResponse")"
     exit 208
   fi
 
@@ -159,6 +162,7 @@ elif [ "$ACTION" == "enable" ] || [ "$ACTION" == "disable" ]; then
     echo "Successfully set scheduled scaling enabled=$TARGET_ENABLED for group $GROUP_NAME"
   else
     echo "Error updating scheduled scaling config for group $GROUP_NAME. AutoScaler response status code is $httpCode"
+    echo "Autoscaler response: $(sed '$ d' <<<"$response")"
     exit 208
   fi
 else

--- a/scripts/delete-custom-jibri-pool-oracle.sh
+++ b/scripts/delete-custom-jibri-pool-oracle.sh
@@ -118,6 +118,7 @@ if [ "$RESULT" -eq 0 ]; then
     done
   else
     echo "Failed to get remaining group report instances. Please retry the script"
+    echo "Autoscaler response: $(sed '$ d' <<<"$instanceGroupGetResponse")"
     exit 220
   fi
 
@@ -136,6 +137,7 @@ if [ "$RESULT" -eq 0 ]; then
     echo "Successfully deleted the group $GROUP_NAME"
   else
     echo "Failed deleting the group $GROUP_NAME. Exiting"
+    echo "Autoscaler response: $(sed '$ d' <<<"$groupDeleteResponse")"
     exit 222
   fi
 

--- a/scripts/delete-custom-jigasi-pool-oracle.sh
+++ b/scripts/delete-custom-jigasi-pool-oracle.sh
@@ -122,6 +122,7 @@ if [ "$RESULT" -eq 0 ]; then
       done
     else
       echo "Failed to get remaining group report instances. Please retry the script"
+      echo "Autoscaler response: $(sed '$ d' <<<"$instanceGroupGetResponse")"
       exit 220
     fi
   fi
@@ -140,6 +141,7 @@ if [ "$RESULT" -eq 0 ]; then
     echo "Successfully deleted the group $GROUP_NAME"
   else
     echo "Failed deleting the group $GROUP_NAME. Exiting"
+    echo "Autoscaler response: $(sed '$ d' <<<"$groupDeleteResponse")"
     exit 222
   fi
 

--- a/scripts/delete-shard-custom-jvbs-oracle.sh
+++ b/scripts/delete-shard-custom-jvbs-oracle.sh
@@ -121,6 +121,7 @@ function delGroup() {
     return 0
   else
     echo "Failed deleting the group $GROUP_NAME. Returning"
+    echo "Autoscaler response: $(sed '$ d' <<<"$groupDeleteResponse")"
     return 222
   fi  
 }
@@ -164,6 +165,7 @@ if [ "$GROUP_NOT_FOUND" != "true" ]; then
       done
     else
       echo "Failed to get remaining group report instances. Please retry the script"
+      echo "Autoscaler response: $(sed '$ d' <<<"$instanceGroupGetResponse")"
       exit 220
     fi
 

--- a/scripts/destroy-autoscaler-group.sh
+++ b/scripts/destroy-autoscaler-group.sh
@@ -145,6 +145,7 @@ function delGroup() {
     return 0
   else
     echo "Failed deleting the group $GROUP_NAME (status $GROUP_DELETE_STATUS_CODE). Returning"
+    echo "Autoscaler response: $(sed '$ d' <<<"$groupDeleteResponse")"
     return 222
   fi
 }
@@ -191,6 +192,7 @@ if [ "$RESULT" -eq 0 ]; then
     done
   else
     echo "Failed to get remaining group report instances. Please retry the script"
+    echo "Autoscaler response: $(sed '$ d' <<<"$instanceGroupGetResponse")"
     exit 220
   fi
 

--- a/scripts/scale-jvbs-custom-autoscaler-oracle.sh
+++ b/scripts/scale-jvbs-custom-autoscaler-oracle.sh
@@ -116,6 +116,7 @@ if [ "$GET_GROUP_STATUS_CODE" == 200 ]; then
   echo "Retrieved existing instance group size $EXISTING_INSTANCE_GROUP_SIZE"
 else
   echo "Failed to get group report $CUSTOM_GROUP_NAME, status is $GET_GROUP_STATUS_CODE"
+  echo "Autoscaler response: $(sed '$ d' <<<"$instanceGroupGetResponse")"
   exit 211
 fi
 


### PR DESCRIPTION
The autoscaler (jitsi/jitsi-autoscaler `review-findings-fixes`) now validates request bodies more strictly and answers rejected requests with a 400 carrying an `errors` array naming the offending field. Our scripts only echoed the status code, which made those failures hard to diagnose from Jenkins output.

## Changes
Every autoscaler error branch (43 across 26 scripts) now echoes `Autoscaler response: <body>` on the line after the existing status-code message. The body is taken from the same curl response the status code came from; scripts that reuse one status variable for two calls (the delete/destroy scripts) print the right body for each.

No behaviour change otherwise; all scripts pass `bash -n`. Safe to merge independently of the autoscaler change.