### PR TITLE
JIT-16016: Mimir cluster to replace regional Prometheus (phases 0-5, flags default off)

### DIFF
--- a/doc/mimir-cluster-plan.md
+++ b/doc/mimir-cluster-plan.md
@@ -1,12 +1,18 @@
 # Plan: Production-Grade Mimir Cluster to Replace Regional Prometheus
 
-Status: PROPOSED (not yet implemented)
+Status: IMPLEMENTED IN CODE (branch `JIT-16016-mimir-cluster`), NOT YET DEPLOYED.
+Phases 0–5 are in the repo behind flags; rollout follows §9. Operations:
+[mimir-runbook.md](mimir-runbook.md).
 Tracking: JIT-16016 (this plan) / JIT-16017 (alert-catalog → ruler + Mimir HA alertmanager follow-up)
-Author: generated 2026-07-08
+Author: generated 2026-07-08; risk review + fixes 2026-09-07 (see "Review" below)
 
 ## Pinned decisions (2026-07-08)
 
-1. **Mimir version: `3.1.2`** (latest stable, released 2026-06-24). Mimir 3.x
+1. **Mimir version: `3.1.5`** (latest 3.1 patch; `3.1.2` was current when this
+   was written, three patch releases followed, and `3.2.0` shipped 2026-08-19).
+   Start on the latest 3.1 patch, move to 3.2 after the lonely soak via the
+   normal N→N+1 path (3.2 turns on query sharding and remote execution by
+   default — read its notes first). Mimir 3.x
    still supports the classic architecture (distributor → ingester direct; the
    Kafka "ingest storage" path is optional) and monolithic `-target=all` mode —
    only the experimental read-write deployment mode was removed. Fresh-deploy
@@ -34,14 +40,40 @@ Author: generated 2026-07-08
    cutover — old prometheus becomes a purely local alert evaluator. No new
    `prometheus-agent.hcl`, no Prometheus remote-write code path anywhere.
    HA dedup via Mimir's HA tracker (both alloys scrape everything with
-   `cluster`/`__replica__` labels); verify the external 8x8 Mimir tenant has
-   HA dedup enabled for the same labels before enabling the second replica's
-   external write.
+   `cluster`/`__replica__` labels). **Correction (2026-09-07):** alloy already
+   writes to the external 8x8 Mimir (`prometheus.remote_write "external"`,
+   credentials in `secret/default/alloy/external-auth`) — that writer is
+   reused; the `secret/default/prometheus/remote_write/<env_type>` secret is
+   *not* moved. Scraped streams get their own HA-labelled writers (see Review
+   R1/R2) and reach the external tenant in `primary` mode (one replica, no HA
+   labels) until that tenant is confirmed to dedup on `cluster`/`__replica__`.
 5. **Stable Mimir ring identity + rotation health gates.** Each group pins
    `-ingester.ring.instance-id=mimir-<N>` with `tokens_file_path` on its host
    volume, so consul-node rotations and alloc reschedules rejoin the ring as
    the *same* member (no unhealthy squatters, no token churn). The
    rotate-consul path gains Mimir/Loki-aware health gates (see §5a).
+
+## Review (2026-09-07): risks found in the plan and how the implementation handles them
+
+| # | Risk in the original plan | Fix (in code) |
+|---|---|---|
+| R1 | **HA tracker would drop OTLP and alloy self metrics.** Mimir decides per push *request* from the first series' labels: with `cluster`/`__replica__` as remote_write external labels, every OTLP-relayed stream (each client sends to ONE alloy, so half of them arrive via the non-elected replica) and both alloys' own metrics would be discarded as "non-elected replica"; mixed batches would be dropped wholesale or stored with a stray `__replica__`. | `alloy.hcl` has two writers per destination: `mimir` (OTLP + self, no HA labels) and `mimir_ha` (consul-SD scrape targets, `cluster`/`__replica__` as external labels). Separate components = separate WALs = never a mixed request. `limits.accept_ha_samples: true` (the plan omitted it — without it the labels are stored verbatim and every scraped series is doubled). |
+| R2 | **External 8x8 Mimir tenant may not dedup.** "Only one alloy forwards until confirmed" is not expressible with two identical allocs. | `external_scrape_forward` = `primary` (default: only `NOMAD_ALLOC_INDEX` 0 forwards scraped streams, no HA labels; ~30 s gap on reschedule) / `ha` (both, with labels; enable only after the tenant is confirmed) / `none`. Implemented as a relabel gate in front of `prometheus.remote_write "external_ha"`. |
+| R3 | **prometheus.hcl remote_write removal could drop scraped metrics from the external stack.** Alloy's external writer uses a *different* Vault secret than prometheus.hcl's; nothing proved they are the same tenant. | The removal (Phase 2 step 4) is **gated on confirming both secrets resolve to the same tenant/endpoint** (compare `endpoint`+`username` in `secret/default/prometheus/remote_write/<env_type>` with `<env_type>-01-oci-metrics-url`/`-username` in `secret/default/alloy/external-auth`). Until then prometheus.hcl keeps its remote_write; alloy's external_ha writer runs alongside. Mimir's HA tracker is irrelevant there because prometheus.hcl's streams carry no `cluster` label. |
+| R4 | **Ingester restart loop.** The plan copied loki's `check_restart` (grace 60 s). A Mimir ingester replays its WAL before `/ready` goes 200; a large WAL takes minutes, so Nomad would kill it every minute forever. | `check_restart.grace = "10m"`, `healthy_deadline 10m`, `progress_deadline 15m`. |
+| R5 | **Wrong 3.x config paths in the sketch.** `compactor.blocks_retention_period` and `ruler.alertmanager_url` are per-tenant limits in 3.x (`limits.compactor_blocks_retention_period`, `limits.ruler_alertmanager_client_config.alertmanager_url`); a `tokens_file_path` under a non-existent directory fails because Mimir does not create parent dirs; OCI S3-compat needs `bucket_lookup_type: path`. | Config written from the 3.1.5 configuration reference (`cmd/mimir/config-descriptor.json`); tokens files at the volume root (`/mimir/ingester-tokens`, `/mimir/store-gateway-tokens`); `bucket_lookup_type: path`; `query_scheduler.service_discovery_mode: ring` so all frontends see all schedulers; `usage_stats.enabled: false`; `activity_tracker.filepath` on the volume. |
+| R6 | **Vault/consul-template `change_mode = restart` would bounce all three ingesters at once** on a credential rotation or on any alertmanager alloc move (the ruler URL is templated from consul). | Both `vault` and `template` use `change_mode = "noop"`; config and credential changes ship as a new job version, which rolls one zone at a time. Runbook documents the credential-rotation procedure. JIT-16017 must revisit the alertmanager target list (static render at alloc start). |
+| R7 | **Rotation gates had a chicken-and-egg problem and no fail-closed behaviour.** The first consul rotation (the one that attaches the volumes) runs before mimir exists; a nomad API error must not read as "healthy". | `consul-metrics-health-gate.sh` skips a job that is *not deployed* (`No job(s) with prefix or ID`) but exits non-zero on any other nomad/API failure; pre-detach gate aborts before draining; post-attach gate replaces the blind sleep (also after pool c). `HEALTH_GATE=false` is the documented DR override. |
+| R8 | **Memberlist port only half-opened.** The loki NSG rule is TCP-only; memberlist probes over UDP. | `consul_nsg_rule_mimir_gossip_tcp` + `_udp` for 7947; `memberlist.cluster_label = mimir-<dc>` so a stray loki/mimir packet is rejected rather than merging rings. |
+| R9 | **Default limits would silently discard.** Mimir defaults: 150 k series, 10 k samples/s, 30 labels/series — below a region's telegraf fleet. | Job variables `max_global_series_per_user` (1 M), `ingestion_rate` (250 k/s), `ingestion_burst_size` (1 M), `max_label_names_per_series: 60`, `out_of_order_time_window: 5m`; overridable per env (`MIMIR_*` in stack-env.sh). Still not unlimited: the series cap is what protects 3 GB / 8 GB of ingester memory. |
+| R10 | **`Mimir_Down` = `absent(up{job="mimir"})` would page every region that has no Mimir yet.** | Scrape job and `mimir_alerts` group are behind `var.mimir_alerts` (`PROMETHEUS_MIMIR_ALERTS=true` per environment). |
+| R11 | **HA-tracker KV in consul assumed no ACLs; `custom_relabels` are Prometheus YAML, not Alloy.** | Phase 0 checklist gains "consul KV writable from consul nodes without token". Alloy takes `alloy_custom_relabel_rules` / `alloy_custom_external_labels` (Alloy syntax) from `config/vars.yml`, which lives in **infra-customizations-private** — that repo needs the companion edit (translation of the four `eght_component` rules, PR in that repo). |
+| R13 | **Interface auto-detection would fail on OCI hosts.** Found by booting 3.1.5 against the rendered config: the 3.x querier has its own lifecycler, and any ring member without an explicit `instance_addr` auto-detects from interfaces `eth0`/`en0` and refuses to start when the NIC is named differently (OCI Ubuntu: `ens3`/`enp*`). | Every ring (`ingester`, `distributor`, `store_gateway`, `compactor`, `ruler`, `querier`, `query_scheduler`, `frontend.address`) gets `instance_addr` from `NOMAD_IP_grpc`. Config validated by starting Mimir 3.1.5 on it: strict-YAML parse clean, all modules initialise up to the object-storage sanity check (dummy creds). |
+| R12 | **Memberlist `node_name` pinning would break rotations.** Pinning the gossip node name to `mimir-N` (tempting for symmetry with the ring id) makes the replacement node's join a "conflicting address" for the still-remembered dead member. | Only the *ring* `instance_id` is pinned; memberlist node names stay host-unique (hostname). `rejoin_interval: 1m` heals splits after DNS seeds move. |
+
+Not changed by the review: monolithic mode, RF=3 + zone awareness, one bucket
+with three prefixes, HA-dedup over Alloy clustering, Phase 3/6 deferral to
+JIT-16017, the rollout order.
 
 ## Scope changes (2026-07-08)
 
@@ -222,10 +254,13 @@ New/changed files:
   `distinct_hosts`/AD spread implicit via volume placement.
 - Image `grafana/mimir:3.1.2` (`mimir_version` variable like
   `prometheus_version` today).
-- Config template highlights:
+- Config template highlights (the real thing is the job file; paths are 3.x):
 
 ```yaml
+target: all
 multitenancy_enabled: false
+usage_stats: { enabled: false }
+activity_tracker: { filepath: /mimir/metrics-activity.log }
 server:
   http_listen_port: {{ env "NOMAD_HOST_PORT_http" }}
   grpc_listen_port: {{ env "NOMAD_HOST_PORT_grpc" }}
@@ -236,50 +271,67 @@ common:
     s3: # OCI S3-compat endpoint, same shape as loki/tempo
       endpoint: <ns>.compat.objectstorage.<region>.oraclecloud.com:443
       bucket_name: mimir-<environment>
+      bucket_lookup_type: path            # OCI needs path-style
+      access_key_id / secret_access_key:  {{ with secret "secret/default/mimir/s3" }}
 blocks_storage:
   storage_prefix: blocks
-  tsdb: { dir: /mimir/tsdb }          # host volume
+  tsdb: { dir: /mimir/tsdb }              # host volume
   bucket_store: { sync_dir: /mimir/tsdb-sync }
-ruler_storage:  { storage_prefix: ruler }
+ruler_storage:        { storage_prefix: ruler }
+alertmanager_storage: { storage_prefix: alertmanager }
 memberlist:
-  advertise_addr: {{ env "NOMAD_IP_grpc" }}
-  bind_port: 7947
+  cluster_label: mimir-<dc>               # never merge with loki's ring
+  bind_port / advertise_port: 7947
+  advertise_addr: {{ env "NOMAD_IP_gossip" }}
+  rejoin_interval: 1m
   join_members: [<dc>-consul-{a,b,c}.<zone>:7947]
 ingester:
   ring:
     replication_factor: 3
     zone_awareness_enabled: true
     instance_availability_zone: zone-${group.key}
-    instance_id: mimir-${group.key}   # stable identity across node rotations
-    tokens_file_path: /mimir/tokens   # on the host volume — tokens survive too
-    unregister_on_shutdown: false     # rolling restarts don't reshard
-    final_sleep: 0s
-store_gateway:
-  sharding_ring: { replication_factor: 3, zone_awareness_enabled: true, ... }
+    instance_id: mimir-${group.key}       # stable identity across node rotations
+    tokens_file_path: /mimir/ingester-tokens   # volume ROOT: mimir won't mkdir
+    unregister_on_shutdown: false         # rolling restarts don't reshard
 distributor:
   ha_tracker:
     enable_ha_tracker: true
-    kvstore: { store: consul, consul: { host: <node>:8500 } }
-compactor:
-  data_dir: /mimir/compactor
-  blocks_retention_period: ${var.retention_period}   # default e.g. 2160h/90d
-ruler:
-  rule_path: /mimir/ruler
-  alertmanager_url: consul-SD equivalent (static list templated from consul
-    service via consul-template `{{ range service "alertmanager" }}`)
+    kvstore: { store: consul, prefix: mimir/ha-tracker/, consul: { host: <node>:8500 } }
+store_gateway:
+  sharding_ring: { replication_factor: 3, zone_awareness_enabled: true,
+                   instance_id: mimir-${group.key}, tokens_file_path: /mimir/store-gateway-tokens,
+                   unregister_on_shutdown: false, wait_stability_min_duration: 1m }
+compactor: { data_dir: /mimir/compactor, sharding_ring: { instance_id: mimir-${group.key} } }
+ruler:     { rule_path: /mimir/ruler,    ring:          { instance_id: mimir-${group.key} } }
+querier:   { ring: { instance_id: mimir-${group.key}, instance_addr: <NOMAD_IP_grpc> } }  # R13
+query_scheduler: { service_discovery_mode: ring, ring: { instance_id: mimir-${group.key} } }
 limits:
-  max_global_series_per_user: 0 or sized cap
-  ingestion_rate: sized
-  out_of_order_time_window: 5m       # tolerate agent replay after restarts
+  accept_ha_samples: true                 # REQUIRED for the HA tracker to act
+  ha_cluster_label: cluster
+  ha_replica_label: __replica__
+  max_global_series_per_user: ${var.max_global_series_per_user}   # 1M default
+  ingestion_rate: ${var.ingestion_rate}                           # 250k/s
+  ingestion_burst_size: ${var.ingestion_burst_size}
+  max_label_names_per_series: 60
+  out_of_order_time_window: 5m            # tolerate agent replay after restarts
+  compactor_blocks_retention_period: ${var.retention_period}      # 2160h/90d
+  ruler_alertmanager_client_config:
+    alertmanager_url: {{ range service "alertmanager" }}http://addr:port,{{ end }}
 ```
 
 - `update` stanza (zero-downtime rolling — see §5).
 - Service `mimir` with `int-urlprefix-${var.mimir_hostname}/` tag, health check
-  `GET /ready`, `check_restart` like loki.
+  `GET /ready`, `check_restart` with **`grace = "10m"`** (not loki's 60 s: WAL
+  replay must finish before `/ready` is 200, see Review R4).
+- `vault { change_mode = "noop" }` and template `change_mode = "noop"` (Review R6).
+- Resources `%{ if prod }2000 MHz / 8 GB%{ else }1000 MHz / 3 GB%{ endif }`.
 
-`scripts/deploy-nomad-mimir.sh` — copy of deploy-nomad-loki.sh: renders
-`[JOB_NAME]` → `mimir-$ORACLE_REGION`, exports hostname/namespace/creds vars,
-runs the job, then `create-oracle-cname-stack.sh` for
+`scripts/deploy-nomad-mimir.sh` — copy of deploy-nomad-loki.sh minus the
+ansible-vault credential lookup (creds come from Vault inside the job): renders
+`[JOB_NAME]` → `mimir-$ORACLE_REGION`, exports hostname/namespace/env-type and
+the optional `MIMIR_VERSION` / `MIMIR_RETENTION_PERIOD` /
+`MIMIR_MAX_GLOBAL_SERIES` / `MIMIR_INGESTION_RATE` / `MIMIR_INGESTION_BURST_SIZE`
+overrides, runs the job, then `create-oracle-cname-stack.sh` for
 `<env>-<region>-mimir.<tld>`.
 
 Jenkins (in this repo's `jenkins/jobs/` + reuse of the generic
@@ -297,33 +349,44 @@ Validate the whole phase on **lonely** first (established pattern).
 All changes land in `nomad/alloy.hcl` (pinned decision #4 — no new scraper
 job, no Prometheus-agent remote-write in the picture):
 
-1. **Scrape components**: add `discovery.consul` + `prometheus.scrape` blocks
-   replicating today's prometheus.hcl scrape jobs — `alertmanager`,
-   `cloudprober`, `telegraf` (30s interval), **plus new `mimir` and `alloy`
-   self jobs** — with the same `service` metric-relabels and the
-   `custom_relabels` var equivalents.
-2. **Labels for HA dedup**: `external_labels` carry
-   `datacenter/environment/region` (as prometheus does today) plus
-   `cluster: <env>-<region>` and `__replica__: <alloc-id>` so both alloy
-   replicas can scrape everything and each Mimir keeps exactly one copy.
-   Prerequisite: confirm the external 8x8 Mimir tenant has HA dedup enabled
-   for these labels; until confirmed, only one alloy replica forwards to the
-   external endpoint.
-3. **Two write destinations, one writer**: every stream (scraped + OTLP)
-   forwards to (a) the local Mimir at
-   `https://<env>-<region>-mimir.<tld>/api/v1/push` — replacing the current
-   `prometheus.remote_write "default"` that points at old prometheus — and
-   (b) a new `prometheus.remote_write "external_8x8"` built from the
-   `secret/default/prometheus/remote_write/<env_type>` Vault secret
-   (endpoint, basic auth, `X-Scope-OrgID` header), which is the external
-   8x8-hosted Mimir that prometheus.hcl writes to today.
-4. **prometheus.hcl loses its `remote_write` block in this phase** — Alloy is
-   now the only writer to the external Mimir, and old prometheus becomes a
-   purely local scrape-and-evaluate alert engine until the ruler ticket
-   retires it. No Prometheus remote-write code path remains anywhere.
-5. **Resources**: bump the alloy task from 256 MHz / 512 MB (sized as an OTLP
-   relay) to cover the scrape + WAL load — start at 512 MHz / 1.5 GB and let
-   the alloy-monitor dashboard calibrate.
+All of it is behind job variables set from the environment's stack-env.sh by
+`deploy-nomad-alloy.sh`: `ALLOY_ENABLE_MIMIR_WRITE` (default false),
+`ALLOY_ENABLE_SCRAPE` (false), `ALLOY_ENABLE_LEGACY_PROMETHEUS_WRITE` (true),
+`ALLOY_EXTERNAL_SCRAPE_FORWARD` (`primary`). Rendered configs for every switch
+combination were validated with `alloy validate` (3.x image) before merge.
+
+1. **Scrape components** (`enable_scrape`): a `discovery.consul` +
+   `prometheus.scrape` + `prometheus.relabel` trio per job, generated from a
+   `scrape_jobs` map — `alertmanager` (15s), `cloudprober` (10s), `telegraf`
+   (30s), `opus-transcriber-proxy-monitor` (30s), `gitea-mirror` (60s), **plus
+   the new `mimir` job** (15s) — with the same `service` metric-relabels as
+   prometheus.hcl, then a shared `scrape_common` relabel that appends
+   `alloy_custom_relabel_rules` (Alloy-syntax translation of
+   `prometheus_custom_relabels`, from config/vars.yml). Alloy's own metrics
+   keep the existing `integrations/self` job.
+2. **Labels for HA dedup — on separate writers (Review R1)**: the shared scrape
+   targets go to `prometheus.remote_write "mimir_ha"` whose `external_labels`
+   carry `datacenter/environment/region` plus `cluster: <env>-<region>` and
+   `__replica__: alloy-<NOMAD_ALLOC_INDEX>`; OTLP relays and self metrics go
+   to `prometheus.remote_write "mimir"` with the same labels **minus** the HA
+   pair. Mimir gets `accept_ha_samples: true`.
+3. **Write destinations**: (a) the local Mimir at
+   `https://<env>-<region>-mimir.<tld>/api/v1/push` (`enable_mimir_write`),
+   (b) the legacy prometheus remote-write receiver (`enable_legacy_prometheus_write`,
+   OTLP streams only, kept during the soak, off at Phase 5), (c) the **existing**
+   `prometheus.remote_write "external"` (OTLP + self) and the new
+   `external_ha` for scraped streams, both from `secret/default/alloy/external-auth`.
+   The external_ha path runs in `primary` mode (only alloc index 0 forwards, no
+   HA labels) until the external tenant's HA dedup is confirmed, then `ha`
+   (Review R2).
+4. **prometheus.hcl loses its `remote_write` block once R3 is confirmed** — i.e.
+   once the two Vault secrets are shown to address the same external tenant.
+   Then old prometheus is a purely local scrape-and-evaluate alert engine
+   until the ruler ticket retires it. (Not done in this branch: it is a
+   one-line deletion gated on that check.)
+5. **Resources**: alloy task bumped from 256 MHz / 512 MB to 512 MHz / 1.5 GB
+   (up to four remote-write WALs); calibrate with the alloy-monitor dashboard's
+   new remote-write and scrape rows.
 
 ### Phase 3 — Alert rules on the ruler [MOVED TO JIT-16017]
 
@@ -346,10 +409,12 @@ Until that ticket lands, prometheus.hcl keeps running as the alert evaluator
 (scraping + rule evaluation only; its storage/query duties end at Phase 4-5).
 
 The Mimir *self*-monitoring alerts in §6 are NOT deferred — they ship with
-this plan, added to the existing prometheus.hcl alert template (a small
+this plan, added to the existing prometheus.hcl alert template (a
 `mimir_alerts` group) plus a consul-SD scrape job for the `mimir` service in
-prometheus.hcl, so the current evaluator watches the new cluster from day
-one. They migrate to the ruler with everything else later.
+prometheus.hcl, both behind `var.mimir_alerts` (`PROMETHEUS_MIMIR_ALERTS=true`
+in the environment's stack-env.sh once Mimir is deployed there — Review R10),
+so the current evaluator watches the new cluster from day one. They migrate to
+the ruler with everything else later.
 
 ### Phase 4 — Query path
 
@@ -463,17 +528,19 @@ healthy):
    `cortex_ring_members` via the query API) and require 3 ACTIVE / 0
    unhealthy ingesters, plus loki `/ready` on all three. If the cluster is
    already degraded, **abort the rotation** instead of making it worse.
-3. **Post-attach gate** (new `scripts/consul-metrics-health-gate.sh`, called
-   from `rotate-consul-oracle.sh` in place of the blind sleep): poll until
-   (a) the new node registers in Nomad with its `mimir-N`/`loki-N` host
-   volumes, (b) the mimir-N and loki-N allocs are running, (c) mimir `/ready`
-   returns 200 and the ring is back to 3 ACTIVE / 0 unhealthy, (d) loki
-   `/ready` returns 200. Configurable timeout (default 15m); on timeout the
-   pipeline **fails loudly** rather than rolling on to the next pool.
-4. **Jenkinsfile**: add `HEALTH_GATE` (default `true`; escape hatch for
-   disaster recovery when the gate can never pass) and
-   `HEALTH_GATE_TIMEOUT_MINUTES` parameters, and echo gate progress so the
-   rotation log shows what it waited on.
+3. **Post-attach gate** (`scripts/consul-metrics-health-gate.sh post`, called
+   from `rotate-consul-oracle.sh` in place of the blind sleep, after every
+   pool including c): poll until (a) 3 mimir-N / loki-N allocs are running,
+   (b) `/ready` returns 200 three times in a row through Fabio, (c) the
+   ingester ring (`/ingester/ring`, JSON via `Accept: application/json`) is
+   3 ACTIVE / 0 not-active, (d) same for loki `/ready` + `/ring`. Timeout
+   default 15m; on timeout the pipeline **fails loudly** rather than rolling on
+   to the next pool. A job that is not deployed in the region is skipped
+   (first rotation, before mimir exists); a nomad API failure fails closed
+   (Review R7).
+4. **Jenkinsfile**: `HEALTH_GATE` (default `true`; escape hatch for disaster
+   recovery when the gate can never pass) and `HEALTH_GATE_TIMEOUT_MINUTES`
+   (15) parameters on `rotate-consul`; the gate echoes what it is waiting on.
 
 ## 6. Monitoring the monitor
 
@@ -486,35 +553,40 @@ solves "who watches the watcher": if the regional Mimir is down, its absence
 still alerts from the external stack (mirrors the existing global-alertmanager
 design).
 
-### New alert rules (evaluated by the existing prometheus.hcl initially, migrating to the ruler with the follow-up ticket; starred ones also mirrored to the external stack)
+### New alert rules (`mimir_alerts` group in prometheus.hcl, behind `var.mimir_alerts`; migrating to the ruler with the follow-up ticket; starred ones also reach the external stack through alloy)
 
-| Alert | Expr sketch | Severity |
+| Alert | Expr (as implemented) | Severity |
 |---|---|---|
-| *Mimir_Down | `absent(up{job="mimir"})` | severe/page |
+| *Mimir_Down | `absent(up{job="mimir"})` 5m | severe |
 | Mimir_Instance_Down | `count(up{job="mimir"} == 1) < 3` | warn (5m) / severe (30m) |
-| Mimir_Ring_Unhealthy | `cortex_ring_members{state="Unhealthy"} > 0` | severe |
-| Mimir_Ingestion_Discards | `rate(cortex_discarded_samples_total[5m]) > 0` sustained | warn |
-| Mimir_HA_Dedup_Flapping | `rate(cortex_ha_tracker_replicas_cleanup_total[10m])` anomaly | smoke |
-| Mimir_Compactor_Stalled | `time() - cortex_compactor_last_successful_run_timestamp_seconds > 4h` | severe |
-| Mimir_StoreGateway_Sync_Failing | `rate(cortex_bucket_stores_blocks_sync_failures_total[10m]) > 0` | warn |
-| Mimir_Object_Storage_Errors | `rate(thanos_objstore_bucket_operation_failures_total[5m]) > 0` | warn→severe |
-| Mimir_Query_Latency_High | p99 `cortex_request_duration_seconds` (query path) > 10s | warn |
-| Mimir_Write_Latency_High | p99 push duration > 1s | warn |
-| Mimir_Ruler_Failing | `rate(cortex_ruler_rule_evaluation_failures_total[5m]) > 0` | severe (rule evals ARE our alerting) |
-| *Alloy_Scrape_Down | `absent(up{job="alloy"})` or `count(up{job="alloy"}) < 2` | severe |
-| Alloy_RemoteWrite_Backlog | `prometheus_remote_storage_highest_timestamp_in_seconds - prometheus_remote_storage_queue_highest_sent_timestamp_seconds > 60` per endpoint | warn→severe |
-| Mimir_Memory_High | existing Nomad_Job_Memory_Use_High covers it — remove the `task!~"prometheus"` exclusion carve-out decision for mimir deliberately |
+| Mimir_Ring_Unhealthy | `max(cortex_ring_members{job="mimir", state="Unhealthy"}) > 0` 5m | severe |
+| Mimir_Ingestion_Discards | `sum by (reason) (rate(cortex_discarded_samples_total[5m])) > 10` 15m | warn |
+| Mimir_HA_Dedup_Flapping | `sum(increase(cortex_ha_tracker_elected_replica_changes_total[10m])) > 3` 15m | smoke |
+| Mimir_Compactor_Stalled | `time() - max(cortex_compactor_last_successful_run_timestamp_seconds) > 4h` (guarded by `> 0`) | warn (4h) / severe (24h) |
+| Mimir_StoreGateway_Sync_Failing | `sum(rate(cortex_bucket_stores_blocks_sync_failures_total[10m])) > 0` 15m | warn |
+| Mimir_Object_Storage_Errors | failure ratio per `operation` > 5% for 15m | warn |
+| Mimir_Query_Latency_High | p99 `cortex_request_duration_seconds` route `prometheus_api_v1_query.*` > 10s | warn |
+| Mimir_Write_Latency_High | p99 route `api_v1_push.*` > 2.5s (mixin threshold; 1s was noise-prone) | warn |
+| Mimir_Ruler_Failing | `sum(rate(cortex_prometheus_rule_evaluation_failures_total[5m])) > 0` 10m | severe (rule evals ARE our alerting) |
+| *Alloy_Scrape_Down | `count(up{job="integrations/self", alloy_type="internal"} == 1) < 2` 10m (alloy's existing self job, not a new `alloy` job) | severe |
+| Alloy_RemoteWrite_Backlog | highest ts − highest sent ts `> 120s` per (instance, component_id, url) for 10m | warn |
+| Mimir_Memory_High | existing Nomad_Job_Memory_Use_High covers it — mimir is deliberately NOT added to the `task!~"prometheus"` exclusion |
 
-Also: a **cloudprober http probe** against `https://<mimir_hostname>/ready` and
-a synthetic **query probe** (instant query `vector(1)` via
-`/prometheus/api/v1/query`) — end-to-end read-path checking, matching how other
-services are probed here.
+`job="mimir"` requires the prometheus.hcl `mimir` scrape job (same flag). In
+nonprod `severe` is downgraded to `warn` by the existing relabel.
+
+Also: a **cloudprober http probe** `mimir` against `https://<mimir_hostname>/ready`
+and a synthetic **query probe** `mimir-query` (instant query `vector(1)` via
+`/prometheus/api/v1/query`, validated on 2xx + `"status":"success"`) — end-to-end
+read-path checking. Both in the `jitsi_cloudprober` pack behind `enable_mimir`
+(`CLOUDPROBER_ENABLE_MIMIR=true` in stack-env.sh).
 
 ### Grafana dashboards (new JSONs in `grafana/dashboards/`)
 
-Base them on the upstream **mimir-mixin** (compiled, then trimmed to
-single-tenant/monolithic reality), following the style of the existing
-`alloy-monitor.json`:
+Hand-built from the mimir-mixin's key queries, trimmed to single-tenant
+monolithic reality (no jsonnet toolchain in this repo), following the style of
+the existing `alloy-monitor.json` (datasource / environment / region variables,
+`job="mimir"` selector, cross-linked via the `mimir` tag):
 
 1. `mimir-overview.json` — cluster up-count, ingestion rate (samples/s),
    active series, in/out bytes, ring status, per-instance memory/CPU (from
@@ -548,12 +620,21 @@ via the existing grafana flow).
   today we effectively have ~15d locally + the external 8x8 Mimir), documented per env.
 - [ ] **Consul-pool capacity** re-validated per env; instance shapes bumped if
   loki+mimir co-tenancy pushes memory > 70%.
+- [ ] **Consul KV writable** from the consul nodes without an ACL token (HA
+  tracker state lives at `mimir/ha-tracker/`); **Vault policy** for nomad
+  workloads covers `secret/default/mimir/s3` (tempo's `secret/default/tempo/s3`
+  works the same way, so this should already hold).
+- [ ] **External tenant HA dedup confirmed** before switching
+  `ALLOY_EXTERNAL_SCRAPE_FORWARD` from `primary` to `ha`; **same-tenant check**
+  of the two Vault secrets before deleting prometheus.hcl's `remote_write`
+  (Review R2/R3).
 - [ ] **Bucket security**: dedicated S3 credential (`secret/default/mimir/s3`),
   scoped IAM policy to only the mimir bucket (follow the ops-repo-test
   compartment/IAM lessons), no versioning (compactor churns objects),
   no lifecycle rule (compactor owns deletes).
-- [ ] **Gossip port 7947** allowed in the consul-pool security list (verify
-  the same rule that opened 7946 for loki; extend it).
+- [x] **Gossip port 7947** allowed in the consul NSG, TCP **and UDP**
+  (`consul_nsg_rule_mimir_gossip_*` in terraform/consul-server; applied on the
+  next consul-server terraform run, which the volume-attaching rotation does).
 - [ ] **Backpressure tested**: kill 1 and 2 mimir instances in lonely under
   load; verify alloy buffers + recovers with no gaps (2-instance loss = expected
   partial write failure with RF=3 — verify alerting catches it).
@@ -571,22 +652,33 @@ via the existing grafana flow).
 
 ## 8. File-by-file change list
 
-| File | Action |
-|---|---|
-| `nomad/mimir-cluster.hcl` | NEW — 3-group monolithic Mimir cluster |
-| `nomad/alloy.hcl` | EDIT — consul-SD scrape components, HA-dedup labels, writes to local mimir `/api/v1/push` + external 8x8 mimir (vault secret moves here), resource bump |
-| `nomad/prometheus.hcl` | EDIT — add `mimir` scrape job + `mimir_alerts` group; DELETE later in Phase 6 (gated on ruler ticket) |
-| `scripts/deploy-nomad-mimir.sh` | NEW — job deploy + CNAME (`mimirtool rules sync` added by follow-up ticket) |
-| `scripts/create-buckets-oracle.sh` | EDIT — add `mimir-$ENVIRONMENT` bucket |
-| `terraform/volumes-mimir/` | NEW — 3× 100 GB block volumes, consul role, indexed |
-| `jenkins/jobs/provision-nomad-mimir.yaml` | NEW (generic provision-nomad-job Jenkinsfile) |
-| `jenkins/jobs/release-nomad-mimir.yaml` + groovy pipeline | NEW — clone of release-nomad-prometheus |
-| `grafana/dashboards/mimir-*.json` (×4) | NEW; `alloy-monitor.json` EDIT (remote-write/scrape panels) |
-| `doc/mimir-runbook.md` | NEW |
-| sites/*/vars & stack-env | EDIT — retention/sizing overrides per env as needed |
+| File | Action | Status |
+|---|---|---|
+| `nomad/mimir-cluster.hcl` | NEW — 3-group monolithic Mimir cluster | done |
+| `nomad/alloy.hcl` | EDIT — consul-SD scrape components, split direct/HA writers to local mimir + external 8x8 mimir, external forward modes, resource bump | done (flags default off) |
+| `nomad/prometheus.hcl` | EDIT — `mimir` scrape job + `mimir_alerts` group behind `var.mimir_alerts`; `remote_write` deletion gated on R3; DELETE job in Phase 6 | done |
+| `scripts/deploy-nomad-mimir.sh` | NEW — job deploy + CNAME (`mimirtool rules sync` added by follow-up ticket) | done |
+| `scripts/deploy-nomad-alloy.sh` / `deploy-nomad-prometheus.sh` / `deploy-nomad-cloudprober.sh` | EDIT — env flags (`ALLOY_*`, `PROMETHEUS_MIMIR_ALERTS`, `CLOUDPROBER_ENABLE_MIMIR`) | done |
+| `scripts/consul-metrics-health-gate.sh` | NEW — pre/post rotation gate | done |
+| `scripts/rotate-consul-oracle.sh`, `rotate-consul-pre-detach.sh`, `jenkins/groovy/rotate-consul/Jenkinsfile`, `jenkins/jobs/rotate-consul.yaml` | EDIT — gates replace the blind sleep; `HEALTH_GATE*` params | done |
+| `scripts/create-buckets-oracle.sh` | EDIT — add `mimir-$ENVIRONMENT` bucket | done |
+| `terraform/volumes-mimir/` | NEW — 3× 100 GB block volumes, consul role, indexed | done |
+| `terraform/consul-server/create-consul-server-oracle.tf` | EDIT — NSG rules 7947 tcp+udp | done |
+| `nomad/jitsi_packs/packs/jitsi_cloudprober` | EDIT — `enable_mimir` probes | done |
+| `jenkins/jobs/provision-nomad-mimir.yaml` | NEW (generic provision-nomad-job Jenkinsfile) | done |
+| `jenkins/jobs/release-nomad-mimir.yaml` + `jenkins/groovy/release-nomad-mimir/Jenkinsfile` | NEW — clone of release-nomad-prometheus | done |
+| `grafana/dashboards/mimir-*.json` (×4) | NEW; `alloy-monitor.json` EDIT (scrape + per-endpoint remote-write rows) | done |
+| `doc/mimir-runbook.md` | NEW | done |
+| **infra-customizations-private** `config/vars.yml` | EDIT — add `alloy_custom_relabel_rules` / `alloy_custom_external_labels` (Alloy translation of the `eght_*` relabels; see deploy-nomad-alloy.sh) | **companion PR needed** |
+| **infra-customizations-private** `sites/*/stack-env.sh` | EDIT per env at each phase: `ALLOY_ENABLE_MIMIR_WRITE`, `ALLOY_ENABLE_SCRAPE`, `PROMETHEUS_MIMIR_ALERTS`, `CLOUDPROBER_ENABLE_MIMIR`, later `ALLOY_ENABLE_LEGACY_PROMETHEUS_WRITE=false`; optional `MIMIR_*` sizing | **companion PR per env** |
+| Vault `secret/default/mimir/s3` | mint per environment before first deploy | manual |
 
 ## 9. Rollout order
 
+0. Prereqs per environment: apply `terraform/volumes-mimir`, run
+   `create-buckets-oracle.sh`, mint `secret/default/mimir/s3`, then rotate the
+   consul pool (attaches volumes, applies the 7947 NSG rules; the new gates
+   skip mimir because it is not deployed yet).
 1. lonely: Phases 0–4, soak 1–2 weeks, kill-testing + load test.
 2. stage/other nonprod: same, shorter soak.
 3. prod, region by region (release pipeline REGIONS param), dual-write soak

--- a/doc/mimir-runbook.md
+++ b/doc/mimir-runbook.md
@@ -1,0 +1,211 @@
+# Mimir cluster runbook
+
+Operations guide for the per-region Grafana Mimir cluster
+([nomad/mimir-cluster.hcl](../nomad/mimir-cluster.hcl)). Design and rollout
+plan: [mimir-cluster-plan.md](mimir-cluster-plan.md). Ticket: JIT-16016.
+
+## What is running
+
+| Thing | Where |
+|---|---|
+| Job | `mimir-<region>` in each Nomad DC; groups `mimir-0/1/2`, one per consul node |
+| Image | `grafana/mimir:<mimir_version>` (default in mimir-cluster.hcl), monolithic `-target=all` |
+| Ring identity | `mimir-N` with tokens in `/mimir/ingester-tokens` and `/mimir/store-gateway-tokens` on the host volume |
+| Host volume | `mimir-N` = OCI block volume tagged `volume-type=mimir volume-role=consul volume-index=N` (terraform/volumes-mimir), mounted at `/mnt/bv/mimir-N` |
+| Object storage | bucket `mimir-<environment>` in the region, prefixes `blocks/`, `ruler/`, `alertmanager/` |
+| Credentials | Vault kv `secret/default/mimir/s3` (`access_key`, `secret_key`), read by the job template |
+| Gossip | memberlist on static **7947**/tcp+udp between consul nodes (loki uses 7946) |
+| HA dedup state | consul KV `mimir/ha-tracker/` on the local consul cluster |
+| Endpoints | `https://<env>-<region>-mimir.<tld>` via Fabio: `/api/v1/push` (write), `/prometheus/*` (query API, Grafana datasource), `/ready`, `/ingester/ring`, `/store-gateway/ring`, `/compactor/ring`, `/distributor/ha-tracker` |
+| Deploy | `scripts/deploy-nomad-mimir.sh`; Jenkins `provision-nomad-mimir` (one region) / `release-nomad-mimir` (all regions, governance) |
+| Writers | the two `alloy-<region>` allocs only (nomad/alloy.hcl). Nothing else remote-writes to Mimir |
+| Alerts | `mimir_alerts` group in prometheus.hcl (enabled with `PROMETHEUS_MIMIR_ALERTS=true`), cloudprober `mimir` + `mimir-query` probes |
+| Dashboards | grafana/dashboards/mimir-overview, mimir-writes, mimir-reads, mimir-ruler-compactor, alloy-monitor |
+
+Handy commands (from the repo root, `ENVIRONMENT`/`ORACLE_REGION` set):
+
+```bash
+export NOMAD_ADDR=https://$ENVIRONMENT-<local-region>-nomad.jitsi.net
+nomad job status mimir-$ORACLE_REGION
+nomad alloc logs -stderr -f <alloc>                    # mimir logs at warn level
+H=https://$ENVIRONMENT-$ORACLE_REGION-mimir.jitsi.net
+curl -s $H/ready
+curl -s -H 'Accept: application/json' $H/ingester/ring | jq '.shards[] | {id,state,zone,address}'
+curl -s -H 'Accept: application/json' $H/store-gateway/ring | jq '.shards[] | {id,state}'
+curl -s "$H/prometheus/api/v1/query?query=count(up)"
+scripts/consul-metrics-health-gate.sh pre               # the same check the consul rotation runs
+```
+
+## Healthy looks like
+
+- `nomad job status mimir-<region>`: 3 running allocs, one per consul node.
+- `/ingester/ring` and `/store-gateway/ring`: exactly 3 members `mimir-0/1/2`,
+  all `ACTIVE`, zones `zone-0/1/2`, no `Unhealthy`.
+- `/ready` returns 200 from every instance (curl the Fabio hostname a few times).
+- `mimir-overview` dashboard: ingestion rate steady, discarded samples ~0,
+  compactor last successful run < 2h ago, object-storage error rate 0.
+- `/distributor/ha-tracker`: one elected replica (`alloy-0` or `alloy-1`) per
+  cluster `<env>-<region>`, elected timestamp changing rarely.
+
+## Rolling restart / config change / version bump
+
+Every change is a Nomad job update; the `update` stanza rolls one group (= one
+zone) at a time with `auto_revert`. Do not `nomad alloc stop` more than one
+mimir alloc at once: RF=3 needs 2 of 3 ingesters for writes.
+
+1. Change `nomad/mimir-cluster.hcl` (or bump `mimir_version`).
+2. Deploy to **lonely** first: Jenkins `provision-nomad-mimir` with
+   `ENVIRONMENT=lonely`. Watch `nomad job status` until all three groups have
+   rolled and the ring is 3/3 ACTIVE.
+3. Watch the `mimir-overview` / `mimir-writes` dashboards for discards, ring
+   health and write latency for at least one compaction cycle (2h).
+4. Roll other environments with `release-nomad-mimir` (region by region,
+   governance ticket for prod).
+
+Version bumps: Mimir supports N to N+1 minor upgrades only; never skip a minor
+version. Read the release notes for removed flags first (3.1 removed several
+2.x-era flags; the config template is validated against 3.x). For a breaking
+config change, ship a config compatible with both versions first, then the
+image.
+
+An ingester restart replays its WAL before `/ready` goes 200. The health
+check's `check_restart` grace is 10 minutes; if an instance legitimately needs
+longer (very large WAL), do not shorten it, fix the WAL size (see "Volume
+full").
+
+## Consul node rotation
+
+`rotate-consul` (Jenkins) rotates pools a, b, c in sequence. Each rotation moves
+the node's `mimir-N` alloc to the replacement node, which attaches the same
+`mimir-N` volume, replays the WAL and rejoins the ring **as the same member**
+(`instance_id: mimir-N`, tokens file on the volume). No manual ring action is
+needed in the happy path.
+
+The pipeline is gated by `scripts/consul-metrics-health-gate.sh`:
+
+- before draining a node (`pre`): refuses to start if mimir or loki are not 3/3
+  ACTIVE with `/ready` 200;
+- after each pool (`post`): waits (default 15 min, `HEALTH_GATE_TIMEOUT_MINUTES`)
+  for the new node's mimir/loki allocs to be running and the rings back to
+  3/3, and **fails the build** instead of rotating the next pool on timeout.
+
+Both gates skip a job that is not deployed in the region (the first rotation,
+which attaches the volumes, runs before mimir exists). `HEALTH_GATE=false` is
+the escape hatch for disaster recovery only.
+
+If the post gate times out:
+
+1. `nomad job status mimir-<region>`: is `mimir-N` running on the new node? If
+   pending with "missing host volume", the volume did not attach/mount. Check
+   the node's `/mnt/bv/`, `oci bv volume list` for the `mimir-N` volume's
+   attachment state, and re-run `terraform/consul-server` for the pool.
+2. If running but not ready: `nomad alloc logs`. WAL replay of a big ingester
+   can take minutes; ring membership problems show as gossip/join errors
+   (check 7947 is open in the consul NSG).
+3. Fix, re-run the gate by hand (`consul-metrics-health-gate.sh post`), then
+   re-run the rotation job for the remaining pools.
+
+## Replacing a failed volume or instance
+
+Symptom: `Mimir_Instance_Down` for a long time, alloc pending on a missing host
+volume, or a volume in a failed state in OCI.
+
+1. Confirm the other two ingesters are ACTIVE (writes and reads are still
+   served; there is no rush that justifies touching a second instance).
+2. Recreate the volume: `terraform/volumes-mimir/create-volumes-mimir-oracle.sh`
+   after removing the dead volume from state (`ACTION=... terraform state rm`
+   or taint the `mimir-volume[N]` resource). Same tags, same index.
+3. Rotate or re-run the consul node for that pool so the new volume is attached
+   and mounted (`rotate-consul` with the other pools already healthy, or
+   `scripts/remount-boot-volumes.sh`).
+4. The new `mimir-N` starts with an empty volume: it generates fresh tokens and
+   joins with the same instance id. Ring members with the same id are replaced,
+   so no `forget` is needed. Its historical blocks are in the bucket; only the
+   un-shipped head (up to 2h) of that replica is lost, and RF=3 means the other
+   two replicas hold that data.
+5. Expect a short window where the ring shows `mimir-N` as `JOINING` /
+   `Unhealthy`; if the old member never leaves (only when the id changed),
+   forget it: `/ingester/ring` page has a **Forget** button per member (POST
+   `forget=<id>`), same on `/store-gateway/ring`.
+
+## Compactor stuck (`Mimir_Compactor_Stalled`)
+
+The three compactors shard work over a ring; any one can run each job.
+
+1. `mimir-ruler-compactor` dashboard: last successful run, runs failed, blocks
+   marked for deletion.
+2. Logs (`grep -i compactor`): the usual causes are object-storage errors
+   (credentials, bucket permissions, OCI throttling) or a corrupt block.
+3. For a corrupt block the log names the block ID; mark it for no-compaction:
+   `mimirtool backfill`/`mimirtool bucket-validation` are not needed, use
+   `curl -XPOST $H/compactor/delete_tenant` only if the whole tenant must go
+   (it must not). Preferred: `mark-blocks -mark-type no-compact` from the Mimir
+   tools image against the `blocks/` prefix, then let the next run continue.
+4. If the compactor ring itself is unhealthy, it heals with the ingester ring
+   (same memberlist); restart the affected group via a normal rolling deploy.
+
+## Ingestion discards (`Mimir_Ingestion_Discards`)
+
+`reason` label tells you which limit: `per_user_series_limit`
+(`max_global_series_per_user`), `rate_limited` (`ingestion_rate` /
+`ingestion_burst_size`), `max_label_names_per_series`, `sample_out_of_order`
+(> 5 min late), `sample_too_old`. Limits are job variables
+(`MIMIR_MAX_GLOBAL_SERIES`, `MIMIR_INGESTION_RATE`, `MIMIR_INGESTION_BURST_SIZE`
+in the environment's stack-env.sh); raise deliberately, and check the ingester
+memory headroom on `mimir-overview` first (every ingester holds every series).
+
+## HA dedup problems
+
+- Both alloy replicas' scraped series appear doubled (two `__replica__` values
+  for the same target): `accept_ha_samples` is off or the scraped streams went
+  through the non-HA writer. Check `limits.accept_ha_samples: true` in the
+  rendered config and that scrape jobs forward to `prometheus.remote_write.mimir_ha`.
+- Scraped metrics have gaps every time an alloy restarts: expected up to the HA
+  failover timeout (30s). Longer gaps: `Mimir_HA_Dedup_Flapping`, look at the
+  `/distributor/ha-tracker` page and alloy remote-write lag.
+- OTLP-relayed or alloy self metrics disappear intermittently: they were sent
+  through an HA writer. They must stay on `prometheus.remote_write.mimir`.
+
+## Object storage credential rotation
+
+1. Mint the new key pair for the mimir bucket user in OCI, write it to Vault
+   `secret/default/mimir/s3` (`access_key`, `secret_key`).
+2. The job uses `vault { change_mode = "noop" }` and a `noop` template on
+   purpose (a credential change must not restart all three ingesters at once),
+   so roll it in with a normal deploy: `provision-nomad-mimir` for the region.
+   The template re-reads the secret on each new alloc, one group at a time.
+3. Verify block uploads resume (`thanos_objstore_bucket_operation_failures_total`
+   back to 0, `mimir-overview` object-storage panel), then revoke the old key.
+
+## Volume full
+
+100 GB per instance holds the WAL, the 2h head block and compactor scratch.
+Growth means blocks are not shipping (object storage errors) or compaction
+scratch is not being cleaned. Fix the upload problem first; blocks ship within a
+minute once the bucket is reachable and the local retention
+(`blocks_storage.tsdb.retention_period`, 13h default) removes them. Never delete
+files under `/mimir/tsdb` by hand while the ingester runs.
+
+## Disaster recovery: rebuild a region from the bucket
+
+Blocks in the bucket are the source of truth; the volumes hold at most ~2h of
+un-shipped data plus tokens.
+
+1. Recreate volumes (terraform/volumes-mimir) and the consul nodes as needed.
+2. Deploy the job. New instances register as `mimir-0/1/2`, store-gateways sync
+   index headers from `blocks/`, queries work as soon as `/ready` is 200.
+3. The lost window is what was in the ingesters and not yet shipped, at most
+   2h. Alloy's WAL re-sends what it still holds; the external 8x8 Mimir has a
+   full copy of the scraped and OTLP streams for anything older.
+4. Ring members from the dead cluster that were never unregistered show as
+   `Unhealthy` only if their ids differ; with the fixed ids they are simply
+   replaced.
+
+## Rollback to the old prometheus (during migration)
+
+Until Phase 6 of the plan, `prometheus-<region>` is still running and scraping.
+To fall back for queries, switch the Grafana datasource back to
+`https://<env>-<region>-prometheus.<tld>`; to fall back for the external feed,
+redeploy alloy with `ALLOY_EXTERNAL_SCRAPE_FORWARD=none` and prometheus.hcl
+with its `remote_write` block (git history, Phase 2 commit). Metrics written only
+to Mimir during the window stay in Mimir.

--- a/grafana/dashboards/alloy-monitor.json
+++ b/grafana/dashboards/alloy-monitor.json
@@ -2639,6 +2639,402 @@
       ],
       "title": "Exporter Queue Capacity",
       "type": "timeseries"
+    },
+    {
+      "type": "row",
+      "title": "Scrape (consul-SD jobs)",
+      "collapsed": false,
+      "id": 109,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 85
+      },
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Scrape targets up by job",
+      "id": 110,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 86
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (job) (up{environment=~\"$environment\", region=~\"$region\", job!~\"integrations/.*\"})",
+          "legendFormat": "{{job}}",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Scrape targets down by job",
+      "id": 111,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 86
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (job) (up{environment=~\"$environment\", region=~\"$region\", job!~\"integrations/.*\"} == 0)",
+          "legendFormat": "{{job}}",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Scrape duration p99 by job",
+      "id": 112,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 86
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le, job) (rate(prometheus_target_interval_length_seconds_bucket{job=\"integrations/self\", environment=~\"$environment\", region=~\"$region\", alloy_type=~\"$alloy_type\"}[$__rate_interval])))",
+          "legendFormat": "{{job}}",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Remote write per endpoint",
+      "collapsed": false,
+      "id": 113,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 94
+      },
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Remote write lag (highest ts - highest sent) by endpoint",
+      "id": 114,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 95
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "max by (instance, component_id) (prometheus_remote_storage_highest_timestamp_in_seconds{job=\"integrations/self\", environment=~\"$environment\", region=~\"$region\", alloy_type=~\"$alloy_type\"}) - on (instance, component_id) group_right () prometheus_remote_storage_queue_highest_sent_timestamp_seconds{job=\"integrations/self\", environment=~\"$environment\", region=~\"$region\", alloy_type=~\"$alloy_type\"}",
+          "legendFormat": "{{instance}} {{component_id}} {{url}}",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Remote write shards by endpoint",
+      "id": 115,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 95
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "prometheus_remote_storage_shards{job=\"integrations/self\", environment=~\"$environment\", region=~\"$region\", alloy_type=~\"$alloy_type\"}",
+          "legendFormat": "{{instance}} {{component_id}}",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Remote write retried / failed / dropped samples per s",
+      "id": 116,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 95
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (component_id) (rate(prometheus_remote_storage_samples_retried_total{job=\"integrations/self\", environment=~\"$environment\", region=~\"$region\", alloy_type=~\"$alloy_type\"}[$__rate_interval]))",
+          "legendFormat": "retried {{component_id}}",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (component_id) (rate(prometheus_remote_storage_samples_failed_total{job=\"integrations/self\", environment=~\"$environment\", region=~\"$region\", alloy_type=~\"$alloy_type\"}[$__rate_interval]))",
+          "legendFormat": "failed {{component_id}}",
+          "refId": "B",
+          "range": true,
+          "instant": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (component_id) (rate(prometheus_remote_storage_samples_dropped_total{job=\"integrations/self\", environment=~\"$environment\", region=~\"$region\", alloy_type=~\"$alloy_type\"}[$__rate_interval]))",
+          "legendFormat": "dropped {{component_id}}",
+          "refId": "C",
+          "range": true,
+          "instant": false
+        }
+      ]
     }
   ],
   "preload": false,

--- a/grafana/dashboards/mimir-overview.json
+++ b/grafana/dashboards/mimir-overview.json
@@ -1,0 +1,1372 @@
+{
+  "uid": "mimir-overview",
+  "title": "Mimir Overview",
+  "tags": [
+    "mimir",
+    "observability"
+  ],
+  "description": "Health of the per-region Mimir cluster: ring, ingestion, latency, object storage, resources. See doc/mimir-runbook.md.",
+  "editable": true,
+  "graphTooltip": 1,
+  "schemaVersion": 42,
+  "version": 1,
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timezone": "browser",
+  "refresh": "1m",
+  "timepicker": {},
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "links": [
+    {
+      "title": "Mimir dashboards",
+      "type": "dashboards",
+      "tags": [
+        "mimir"
+      ],
+      "asDropdown": true,
+      "includeVars": true,
+      "keepTime": true
+    }
+  ],
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "label": "Datasource",
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "options": [],
+        "refresh": 1,
+        "regex": ""
+      },
+      {
+        "name": "environment",
+        "type": "query",
+        "label": "Environment",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "query": {
+          "qryType": 1,
+          "query": "label_values(up{job=\"mimir\"},environment)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "definition": "label_values(up{job=\"mimir\"},environment)",
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "current": {},
+        "options": [],
+        "sort": 1
+      },
+      {
+        "name": "region",
+        "type": "query",
+        "label": "Region",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "query": {
+          "qryType": 1,
+          "query": "label_values(up{job=\"mimir\", environment=~\"$environment\"},region)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "definition": "label_values(up{job=\"mimir\", environment=~\"$environment\"},region)",
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "current": {},
+        "options": [],
+        "sort": 1
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "row",
+      "title": "Cluster",
+      "collapsed": false,
+      "id": 1,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "panels": []
+    },
+    {
+      "type": "stat",
+      "title": "Instances up",
+      "id": 2,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 0,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 3
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "count(up{job=\"mimir\", environment=~\"$environment\", region=~\"$region\"} == 1)",
+          "legendFormat": "up",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Ingester ring ACTIVE",
+      "id": 3,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 4,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 3
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "max(cortex_ring_members{job=\"mimir\", environment=~\"$environment\", region=~\"$region\", name=\"ingester\", state=\"ACTIVE\"})",
+          "legendFormat": "active",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Ring members unhealthy (any ring)",
+      "id": 4,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 8,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(cortex_ring_members{job=\"mimir\", environment=~\"$environment\", region=~\"$region\", state=\"Unhealthy\"})",
+          "legendFormat": "unhealthy",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Active series (per ingester)",
+      "id": 5,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 12,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "max(cortex_ingester_memory_series{job=\"mimir\", environment=~\"$environment\", region=~\"$region\"})",
+          "legendFormat": "series",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Build",
+      "id": 6,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 16,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^version$/",
+          "values": false
+        },
+        "textMode": "name",
+        "colorMode": "none",
+        "graphMode": "none"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "count by (version) (cortex_build_info{job=\"mimir\", environment=~\"$environment\", region=~\"$region\"})",
+          "legendFormat": "{{version}}",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Ingestion",
+      "collapsed": false,
+      "id": 7,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 6
+      },
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Samples received / s (distributor)",
+      "id": 8,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 7
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (instance) (rate(cortex_distributor_received_samples_total{job=\"mimir\", environment=~\"$environment\", region=~\"$region\"}[$__rate_interval]))",
+          "legendFormat": "{{instance}}",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Samples discarded / s by reason",
+      "id": 9,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 7
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (reason) (rate(cortex_discarded_samples_total{job=\"mimir\", environment=~\"$environment\", region=~\"$region\"}[$__rate_interval]))",
+          "legendFormat": "{{reason}}",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Active series per ingester",
+      "id": 10,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 7
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "cortex_ingester_memory_series{job=\"mimir\", environment=~\"$environment\", region=~\"$region\"}",
+          "legendFormat": "{{instance}}",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "HA tracker: elected replica changes / 10m",
+      "id": 11,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 15
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(increase(cortex_ha_tracker_elected_replica_changes_total{job=\"mimir\", environment=~\"$environment\", region=~\"$region\"}[10m]))",
+          "legendFormat": "changes",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Ingester appended samples / s",
+      "id": 12,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 15
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (instance) (rate(cortex_ingester_ingested_samples_total{job=\"mimir\", environment=~\"$environment\", region=~\"$region\"}[$__rate_interval]))",
+          "legendFormat": "{{instance}}",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Out-of-order samples appended / s",
+      "id": 13,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 15
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (instance) (rate(cortex_ingester_tsdb_out_of_order_samples_appended_total{job=\"mimir\", environment=~\"$environment\", region=~\"$region\"}[$__rate_interval]))",
+          "legendFormat": "{{instance}}",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Latency",
+      "collapsed": false,
+      "id": 14,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      },
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Write p99 / p50 (api_v1_push)",
+      "id": 15,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 24
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(cortex_request_duration_seconds_bucket{job=\"mimir\", environment=~\"$environment\", region=~\"$region\", route=~\"api_v1_push.*\"}[$__rate_interval])))",
+          "legendFormat": "p99",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(cortex_request_duration_seconds_bucket{job=\"mimir\", environment=~\"$environment\", region=~\"$region\", route=~\"api_v1_push.*\"}[$__rate_interval])))",
+          "legendFormat": "p50",
+          "refId": "B",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Query p99 / p50 (prometheus_api_v1_query*)",
+      "id": 16,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 24
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(cortex_request_duration_seconds_bucket{job=\"mimir\", environment=~\"$environment\", region=~\"$region\", route=~\"prometheus_api_v1_query.*\"}[$__rate_interval])))",
+          "legendFormat": "p99",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(cortex_request_duration_seconds_bucket{job=\"mimir\", environment=~\"$environment\", region=~\"$region\", route=~\"prometheus_api_v1_query.*\"}[$__rate_interval])))",
+          "legendFormat": "p50",
+          "refId": "B",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Requests / s by route (5xx)",
+      "id": 17,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 24
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (route) (rate(cortex_request_duration_seconds_count{job=\"mimir\", environment=~\"$environment\", region=~\"$region\", status_code=~\"5..\"}[$__rate_interval]))",
+          "legendFormat": "{{route}}",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Object storage",
+      "collapsed": false,
+      "id": 18,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 32
+      },
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Bucket operations / s",
+      "id": 19,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 33
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (operation) (rate(thanos_objstore_bucket_operations_total{job=\"mimir\", environment=~\"$environment\", region=~\"$region\"}[$__rate_interval]))",
+          "legendFormat": "{{operation}}",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Bucket operation failures / s",
+      "id": 20,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 33
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (operation) (rate(thanos_objstore_bucket_operation_failures_total{job=\"mimir\", environment=~\"$environment\", region=~\"$region\"}[$__rate_interval]))",
+          "legendFormat": "{{operation}}",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Blocks shipped (uploads / h)",
+      "id": 21,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 33
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (instance) (increase(cortex_ingester_shipper_uploads_total{job=\"mimir\", environment=~\"$environment\", region=~\"$region\"}[1h]))",
+          "legendFormat": "{{instance}}",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Resources (nomad allocation)",
+      "collapsed": false,
+      "id": 22,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 41
+      },
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Alloc memory (RSS)",
+      "id": 23,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 42
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "nomad_client_allocs_memory_usage{task=\"mimir\", environment=~\"$environment\", region=~\"$region\"} - nomad_client_allocs_memory_cache{task=\"mimir\", environment=~\"$environment\", region=~\"$region\"}",
+          "legendFormat": "{{task_group}}",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "max(nomad_client_allocs_memory_allocated{task=\"mimir\", environment=~\"$environment\", region=~\"$region\"})",
+          "legendFormat": "allocated",
+          "refId": "B",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Alloc CPU (ticks)",
+      "id": 24,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 42
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "nomad_client_allocs_cpu_total_ticks{task=\"mimir\", environment=~\"$environment\", region=~\"$region\"}",
+          "legendFormat": "{{task_group}}",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "max(nomad_client_allocs_cpu_allocated{task=\"mimir\", environment=~\"$environment\", region=~\"$region\"})",
+          "legendFormat": "allocated",
+          "refId": "B",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Go heap in use",
+      "id": 25,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 42
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "go_memstats_heap_inuse_bytes{job=\"mimir\", environment=~\"$environment\", region=~\"$region\"}",
+          "legendFormat": "{{instance}}",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        }
+      ]
+    }
+  ]
+}

--- a/grafana/dashboards/mimir-reads.json
+++ b/grafana/dashboards/mimir-reads.json
@@ -1,0 +1,993 @@
+{
+  "uid": "mimir-reads",
+  "title": "Mimir Reads",
+  "tags": [
+    "mimir",
+    "observability"
+  ],
+  "description": "Read path of the per-region Mimir cluster: query-frontend, scheduler, querier fanout, store-gateway block loading, slow queries.",
+  "editable": true,
+  "graphTooltip": 1,
+  "schemaVersion": 42,
+  "version": 1,
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timezone": "browser",
+  "refresh": "1m",
+  "timepicker": {},
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "links": [
+    {
+      "title": "Mimir dashboards",
+      "type": "dashboards",
+      "tags": [
+        "mimir"
+      ],
+      "asDropdown": true,
+      "includeVars": true,
+      "keepTime": true
+    }
+  ],
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "label": "Datasource",
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "options": [],
+        "refresh": 1,
+        "regex": ""
+      },
+      {
+        "name": "environment",
+        "type": "query",
+        "label": "Environment",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "query": {
+          "qryType": 1,
+          "query": "label_values(up{job=\"mimir\"},environment)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "definition": "label_values(up{job=\"mimir\"},environment)",
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "current": {},
+        "options": [],
+        "sort": 1
+      },
+      {
+        "name": "region",
+        "type": "query",
+        "label": "Region",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "query": {
+          "qryType": 1,
+          "query": "label_values(up{job=\"mimir\", environment=~\"$environment\"},region)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "definition": "label_values(up{job=\"mimir\", environment=~\"$environment\"},region)",
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "current": {},
+        "options": [],
+        "sort": 1
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "row",
+      "title": "Query frontend",
+      "collapsed": false,
+      "id": 1,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Queries / s by route",
+      "id": 2,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (route) (rate(cortex_request_duration_seconds_count{job=\"mimir\", environment=~\"$environment\", region=~\"$region\", route=~\"prometheus_api_v1_.*\"}[$__rate_interval]))",
+          "legendFormat": "{{route}}",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Query latency p99 / p50 (instant + range)",
+      "id": 3,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(cortex_request_duration_seconds_bucket{job=\"mimir\", environment=~\"$environment\", region=~\"$region\", route=~\"prometheus_api_v1_query.*\"}[$__rate_interval])))",
+          "legendFormat": "p99",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(cortex_request_duration_seconds_bucket{job=\"mimir\", environment=~\"$environment\", region=~\"$region\", route=~\"prometheus_api_v1_query.*\"}[$__rate_interval])))",
+          "legendFormat": "p50",
+          "refId": "B",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Query errors / s (5xx)",
+      "id": 4,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (route) (rate(cortex_request_duration_seconds_count{job=\"mimir\", environment=~\"$environment\", region=~\"$region\", route=~\"prometheus_api_v1_.*\", status_code=~\"5..\"}[$__rate_interval]))",
+          "legendFormat": "{{route}}",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Scheduler queue length",
+      "id": 5,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 9
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (instance) (cortex_query_scheduler_queue_length{job=\"mimir\", environment=~\"$environment\", region=~\"$region\"})",
+          "legendFormat": "{{instance}}",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Query result cache hit ratio",
+      "id": 6,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 9
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(cortex_frontend_query_result_cache_hits_total{job=\"mimir\", environment=~\"$environment\", region=~\"$region\"}[$__rate_interval])) / sum(rate(cortex_frontend_query_result_cache_requests_total{job=\"mimir\", environment=~\"$environment\", region=~\"$region\"}[$__rate_interval]))",
+          "legendFormat": "hit ratio",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Querier -> ingester / store-gateway requests / s",
+      "id": 7,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 9
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(cortex_ingester_client_request_duration_seconds_count{job=\"mimir\", environment=~\"$environment\", region=~\"$region\"}[$__rate_interval]))",
+          "legendFormat": "ingester",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(cortex_storegateway_client_request_duration_seconds_count{job=\"mimir\", environment=~\"$environment\", region=~\"$region\"}[$__rate_interval]))",
+          "legendFormat": "store-gateway",
+          "refId": "B",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Store gateway",
+      "collapsed": false,
+      "id": 8,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Blocks loaded",
+      "id": 9,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 18
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (instance) (cortex_bucket_store_blocks_loaded{job=\"mimir\", environment=~\"$environment\", region=~\"$region\"})",
+          "legendFormat": "{{instance}}",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Block sync failures / s",
+      "id": 10,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 18
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (instance) (rate(cortex_bucket_stores_blocks_sync_failures_total{job=\"mimir\", environment=~\"$environment\", region=~\"$region\"}[$__rate_interval]))",
+          "legendFormat": "{{instance}}",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Index-header lazy loads / s",
+      "id": 11,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 18
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (instance) (rate(cortex_bucket_store_indexheader_lazy_load_total{job=\"mimir\", environment=~\"$environment\", region=~\"$region\"}[$__rate_interval]))",
+          "legendFormat": "load {{instance}}",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (instance) (rate(cortex_bucket_store_indexheader_lazy_unload_total{job=\"mimir\", environment=~\"$environment\", region=~\"$region\"}[$__rate_interval]))",
+          "legendFormat": "unload {{instance}}",
+          "refId": "B",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Series fetched per query p99",
+      "id": 12,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 26
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(cortex_bucket_store_series_data_fetched_bucket{job=\"mimir\", environment=~\"$environment\", region=~\"$region\", data_type=\"series\"}[$__rate_interval])))",
+          "legendFormat": "series",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Chunks fetched per query p99",
+      "id": 13,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 26
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(cortex_bucket_store_series_data_fetched_bucket{job=\"mimir\", environment=~\"$environment\", region=~\"$region\", data_type=\"chunks\"}[$__rate_interval])))",
+          "legendFormat": "chunks",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Store-gateway ring members by state",
+      "id": 14,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 26
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "max by (state) (cortex_ring_members{job=\"mimir\", environment=~\"$environment\", region=~\"$region\", name=\"store-gateway\"})",
+          "legendFormat": "{{state}}",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Slow queries",
+      "collapsed": false,
+      "id": 15,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 34
+      },
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Queries slower than 10s (rate)",
+      "id": 16,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 35
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (route) (rate(cortex_request_duration_seconds_count{job=\"mimir\", environment=~\"$environment\", region=~\"$region\", route=~\"prometheus_api_v1_.*\"}[$__rate_interval])) - sum by (route) (rate(cortex_request_duration_seconds_bucket{job=\"mimir\", environment=~\"$environment\", region=~\"$region\", route=~\"prometheus_api_v1_.*\", le=\"10\"}[$__rate_interval]))",
+          "legendFormat": "{{route}}",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Query engine",
+      "id": 17,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 35
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (engine) (rate(cortex_mimir_query_engine_selected_total{job=\"mimir\", environment=~\"$environment\", region=~\"$region\"}[$__rate_interval]))",
+          "legendFormat": "{{engine}}",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        }
+      ]
+    }
+  ]
+}

--- a/grafana/dashboards/mimir-ruler-compactor.json
+++ b/grafana/dashboards/mimir-ruler-compactor.json
@@ -1,0 +1,1108 @@
+{
+  "uid": "mimir-ruler-compactor",
+  "title": "Mimir Ruler and Compactor",
+  "tags": [
+    "mimir",
+    "observability"
+  ],
+  "description": "Ruler evaluations and notifications; compactor runs, block counts, retention deletions.",
+  "editable": true,
+  "graphTooltip": 1,
+  "schemaVersion": 42,
+  "version": 1,
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timezone": "browser",
+  "refresh": "1m",
+  "timepicker": {},
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "links": [
+    {
+      "title": "Mimir dashboards",
+      "type": "dashboards",
+      "tags": [
+        "mimir"
+      ],
+      "asDropdown": true,
+      "includeVars": true,
+      "keepTime": true
+    }
+  ],
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "label": "Datasource",
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "options": [],
+        "refresh": 1,
+        "regex": ""
+      },
+      {
+        "name": "environment",
+        "type": "query",
+        "label": "Environment",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "query": {
+          "qryType": 1,
+          "query": "label_values(up{job=\"mimir\"},environment)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "definition": "label_values(up{job=\"mimir\"},environment)",
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "current": {},
+        "options": [],
+        "sort": 1
+      },
+      {
+        "name": "region",
+        "type": "query",
+        "label": "Region",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "query": {
+          "qryType": 1,
+          "query": "label_values(up{job=\"mimir\", environment=~\"$environment\"},region)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "definition": "label_values(up{job=\"mimir\", environment=~\"$environment\"},region)",
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "current": {},
+        "options": [],
+        "sort": 1
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "row",
+      "title": "Ruler",
+      "collapsed": false,
+      "id": 1,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "panels": []
+    },
+    {
+      "type": "stat",
+      "title": "Rule groups loaded",
+      "id": 2,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(cortex_prometheus_rule_group_rules{job=\"mimir\", environment=~\"$environment\", region=~\"$region\"})",
+          "legendFormat": "rules",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Evaluations / s",
+      "id": 3,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(cortex_prometheus_rule_evaluations_total{job=\"mimir\", environment=~\"$environment\", region=~\"$region\"}[$__rate_interval]))",
+          "legendFormat": "evaluations",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Evaluation failures / s",
+      "id": 4,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(cortex_prometheus_rule_evaluation_failures_total{job=\"mimir\", environment=~\"$environment\", region=~\"$region\"}[$__rate_interval]))",
+          "legendFormat": "failures",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Missed iterations / s",
+      "id": 5,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(cortex_prometheus_rule_group_iterations_missed_total{job=\"mimir\", environment=~\"$environment\", region=~\"$region\"}[$__rate_interval]))",
+          "legendFormat": "missed",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Rule group evaluation duration vs interval",
+      "id": 6,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 9
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "max by (rule_group) (cortex_prometheus_rule_group_last_duration_seconds{job=\"mimir\", environment=~\"$environment\", region=~\"$region\"})",
+          "legendFormat": "duration {{rule_group}}",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "max(cortex_prometheus_rule_group_interval_seconds{job=\"mimir\", environment=~\"$environment\", region=~\"$region\"})",
+          "legendFormat": "interval",
+          "refId": "B",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Alertmanager notifications / s",
+      "id": 7,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 9
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(cortex_prometheus_notifications_sent_total{job=\"mimir\", environment=~\"$environment\", region=~\"$region\"}[$__rate_interval]))",
+          "legendFormat": "sent",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(cortex_prometheus_notifications_errors_total{job=\"mimir\", environment=~\"$environment\", region=~\"$region\"}[$__rate_interval]))",
+          "legendFormat": "errors",
+          "refId": "B",
+          "range": true,
+          "instant": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(cortex_prometheus_notifications_dropped_total{job=\"mimir\", environment=~\"$environment\", region=~\"$region\"}[$__rate_interval]))",
+          "legendFormat": "dropped",
+          "refId": "C",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Ruler ring members by state",
+      "id": 8,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 9
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "max by (state) (cortex_ring_members{job=\"mimir\", environment=~\"$environment\", region=~\"$region\", name=\"ruler\"})",
+          "legendFormat": "{{state}}",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Compactor",
+      "collapsed": false,
+      "id": 9,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "panels": []
+    },
+    {
+      "type": "stat",
+      "title": "Time since last successful run",
+      "id": 10,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 18
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 7200
+              },
+              {
+                "color": "red",
+                "value": 14400
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "time() - max(cortex_compactor_last_successful_run_timestamp_seconds{job=\"mimir\", environment=~\"$environment\", region=~\"$region\"} > 0)",
+          "legendFormat": "age",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Compaction runs / h",
+      "id": 11,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 18
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(increase(cortex_compactor_runs_completed_total{job=\"mimir\", environment=~\"$environment\", region=~\"$region\"}[1h]))",
+          "legendFormat": "completed",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(increase(cortex_compactor_runs_failed_total{job=\"mimir\", environment=~\"$environment\", region=~\"$region\"}[1h]))",
+          "legendFormat": "failed",
+          "refId": "B",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Compaction duration p99",
+      "id": 12,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 18
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(cortex_compactor_block_compaction_duration_seconds_bucket{job=\"mimir\", environment=~\"$environment\", region=~\"$region\"}[$__rate_interval])))",
+          "legendFormat": "p99",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Blocks in bucket (per compactor view)",
+      "id": 13,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 26
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "max(cortex_bucket_blocks_count{job=\"mimir\", environment=~\"$environment\", region=~\"$region\"})",
+          "legendFormat": "blocks",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Blocks marked for deletion / cleaned per h",
+      "id": 14,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 26
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(increase(cortex_compactor_blocks_marked_for_deletion_total{job=\"mimir\", environment=~\"$environment\", region=~\"$region\"}[1h]))",
+          "legendFormat": "marked",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(increase(cortex_compactor_blocks_cleaned_total{job=\"mimir\", environment=~\"$environment\", region=~\"$region\"}[1h]))",
+          "legendFormat": "cleaned",
+          "refId": "B",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Compactor ring members by state",
+      "id": 15,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 26
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "max by (state) (cortex_ring_members{job=\"mimir\", environment=~\"$environment\", region=~\"$region\", name=\"compactor\"})",
+          "legendFormat": "{{state}}",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Blocks marked for no-compaction (corrupt)",
+      "id": 16,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 34
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(increase(cortex_compactor_blocks_marked_for_no_compaction_total{job=\"mimir\", environment=~\"$environment\", region=~\"$region\"}[1d]))",
+          "legendFormat": "24h",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Tenant discovery / meta sync failures per h",
+      "id": 17,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 34
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(increase(cortex_compactor_meta_sync_failures_total{job=\"mimir\", environment=~\"$environment\", region=~\"$region\"}[1h]))",
+          "legendFormat": "meta sync failures",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Object storage failures / s (compactor component)",
+      "id": 18,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 34
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (operation) (rate(thanos_objstore_bucket_operation_failures_total{job=\"mimir\", environment=~\"$environment\", region=~\"$region\", component=\"compactor\"}[$__rate_interval]))",
+          "legendFormat": "{{operation}}",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        }
+      ]
+    }
+  ]
+}

--- a/grafana/dashboards/mimir-writes.json
+++ b/grafana/dashboards/mimir-writes.json
@@ -1,0 +1,1062 @@
+{
+  "uid": "mimir-writes",
+  "title": "Mimir Writes",
+  "tags": [
+    "mimir",
+    "observability"
+  ],
+  "description": "Write path of the per-region Mimir cluster: distributor pushes, HA dedup, ingester appends, WAL, ring.",
+  "editable": true,
+  "graphTooltip": 1,
+  "schemaVersion": 42,
+  "version": 1,
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timezone": "browser",
+  "refresh": "1m",
+  "timepicker": {},
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "links": [
+    {
+      "title": "Mimir dashboards",
+      "type": "dashboards",
+      "tags": [
+        "mimir"
+      ],
+      "asDropdown": true,
+      "includeVars": true,
+      "keepTime": true
+    }
+  ],
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "label": "Datasource",
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "options": [],
+        "refresh": 1,
+        "regex": ""
+      },
+      {
+        "name": "environment",
+        "type": "query",
+        "label": "Environment",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "query": {
+          "qryType": 1,
+          "query": "label_values(up{job=\"mimir\"},environment)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "definition": "label_values(up{job=\"mimir\"},environment)",
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "current": {},
+        "options": [],
+        "sort": 1
+      },
+      {
+        "name": "region",
+        "type": "query",
+        "label": "Region",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "query": {
+          "qryType": 1,
+          "query": "label_values(up{job=\"mimir\", environment=~\"$environment\"},region)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "definition": "label_values(up{job=\"mimir\", environment=~\"$environment\"},region)",
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "current": {},
+        "options": [],
+        "sort": 1
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "row",
+      "title": "Distributor",
+      "collapsed": false,
+      "id": 1,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Push requests / s by status",
+      "id": 2,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "normal"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (status_code) (rate(cortex_request_duration_seconds_count{job=\"mimir\", environment=~\"$environment\", region=~\"$region\", route=~\"api_v1_push.*\"}[$__rate_interval]))",
+          "legendFormat": "{{status_code}}",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Push latency p99 / p50",
+      "id": 3,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(cortex_request_duration_seconds_bucket{job=\"mimir\", environment=~\"$environment\", region=~\"$region\", route=~\"api_v1_push.*\"}[$__rate_interval])))",
+          "legendFormat": "p99",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(cortex_request_duration_seconds_bucket{job=\"mimir\", environment=~\"$environment\", region=~\"$region\", route=~\"api_v1_push.*\"}[$__rate_interval])))",
+          "legendFormat": "p50",
+          "refId": "B",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Received samples / s",
+      "id": 4,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (instance) (rate(cortex_distributor_received_samples_total{job=\"mimir\", environment=~\"$environment\", region=~\"$region\"}[$__rate_interval]))",
+          "legendFormat": "{{instance}}",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Discarded samples / s by reason",
+      "id": 5,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 9
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (reason) (rate(cortex_discarded_samples_total{job=\"mimir\", environment=~\"$environment\", region=~\"$region\"}[$__rate_interval]))",
+          "legendFormat": "{{reason}}",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Deduplicated (HA) samples / s",
+      "id": 6,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 9
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(cortex_distributor_deduped_samples_total{job=\"mimir\", environment=~\"$environment\", region=~\"$region\"}[$__rate_interval]))",
+          "legendFormat": "deduped",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(cortex_distributor_non_ha_samples_received_total{job=\"mimir\", environment=~\"$environment\", region=~\"$region\"}[$__rate_interval]))",
+          "legendFormat": "non-HA (OTLP/self)",
+          "refId": "B",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "HA tracker elected replica changes / 10m",
+      "id": 7,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 9
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (cluster) (increase(cortex_ha_tracker_elected_replica_changes_total{job=\"mimir\", environment=~\"$environment\", region=~\"$region\"}[10m]))",
+          "legendFormat": "{{cluster}}",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Ingesters",
+      "collapsed": false,
+      "id": 8,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Appended samples / s",
+      "id": 9,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 18
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (instance) (rate(cortex_ingester_ingested_samples_total{job=\"mimir\", environment=~\"$environment\", region=~\"$region\"}[$__rate_interval]))",
+          "legendFormat": "{{instance}}",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Append failures / s",
+      "id": 10,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 18
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (instance) (rate(cortex_ingester_ingested_samples_failures_total{job=\"mimir\", environment=~\"$environment\", region=~\"$region\"}[$__rate_interval]))",
+          "legendFormat": "{{instance}}",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "In-memory series",
+      "id": 11,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 18
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "cortex_ingester_memory_series{job=\"mimir\", environment=~\"$environment\", region=~\"$region\"}",
+          "legendFormat": "{{instance}}",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Series created / removed per s",
+      "id": 12,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 26
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (instance) (rate(cortex_ingester_memory_series_created_total{job=\"mimir\", environment=~\"$environment\", region=~\"$region\"}[$__rate_interval]))",
+          "legendFormat": "created {{instance}}",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "-sum by (instance) (rate(cortex_ingester_memory_series_removed_total{job=\"mimir\", environment=~\"$environment\", region=~\"$region\"}[$__rate_interval]))",
+          "legendFormat": "removed {{instance}}",
+          "refId": "B",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "WAL fsync p99",
+      "id": 13,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 26
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le, instance) (rate(cortex_ingester_tsdb_wal_fsync_duration_seconds_bucket{job=\"mimir\", environment=~\"$environment\", region=~\"$region\"}[$__rate_interval])))",
+          "legendFormat": "{{instance}}",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Out-of-order samples appended / s",
+      "id": 14,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 26
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (instance) (rate(cortex_ingester_tsdb_out_of_order_samples_appended_total{job=\"mimir\", environment=~\"$environment\", region=~\"$region\"}[$__rate_interval]))",
+          "legendFormat": "{{instance}}",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Ring",
+      "collapsed": false,
+      "id": 15,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 34
+      },
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Ingester ring members by state",
+      "id": 16,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 35
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "max by (state) (cortex_ring_members{job=\"mimir\", environment=~\"$environment\", region=~\"$region\", name=\"ingester\"})",
+          "legendFormat": "{{state}}",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Ingester TSDB head / compactions per h",
+      "id": 17,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 35
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (instance) (increase(cortex_ingester_tsdb_compactions_total{job=\"mimir\", environment=~\"$environment\", region=~\"$region\"}[1h]))",
+          "legendFormat": "{{instance}}",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Blocks shipped / h",
+      "id": 18,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 35
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (instance) (increase(cortex_ingester_shipper_uploads_total{job=\"mimir\", environment=~\"$environment\", region=~\"$region\"}[1h]))",
+          "legendFormat": "{{instance}}",
+          "refId": "A",
+          "range": true,
+          "instant": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (instance) (increase(cortex_ingester_shipper_upload_failures_total{job=\"mimir\", environment=~\"$environment\", region=~\"$region\"}[1h]))",
+          "legendFormat": "failed {{instance}}",
+          "refId": "B",
+          "range": true,
+          "instant": false
+        }
+      ]
+    }
+  ]
+}

--- a/jenkins/groovy/release-nomad-mimir/Jenkinsfile
+++ b/jenkins/groovy/release-nomad-mimir/Jenkinsfile
@@ -1,0 +1,110 @@
+def provisionJob(job_name,environment,oracle_region,video_infra_branch) {
+    def provision = build job: job_name, parameters: [
+        [$class: 'StringParameterValue', name: 'ENVIRONMENT', value: environment],
+        [$class: 'StringParameterValue', name: 'ORACLE_REGION', value: oracle_region],
+        [$class: 'StringParameterValue', name: 'VIDEO_INFRA_BRANCH', value: video_infra_branch]
+    ]
+
+    return provision
+}
+
+def utils
+def governance
+def artConfig
+
+pipeline {
+    agent any
+    options {
+      ansiColor('xterm')
+      timestamps()
+      buildDiscarder(logRotator(numToKeepStr: '10', artifactNumToKeepStr: '10'))
+    }
+    stages {
+        // output stage, shows off our input parameters
+        stage('prepare') {
+            steps {
+                script {
+                    echo 'mimir release'
+                    // load utility function
+                    def rootDir = pwd()
+                    utils = load "${rootDir}/jenkins/groovy/Utils.groovy"
+                    // checkout repos
+                    utils.SetupRepos(env.VIDEO_INFRA_BRANCH)
+
+                    // setup OCI credentials
+                    utils.SetupOCI()
+
+                    dir('infra-provisioning') {
+                        governance = utils.LoadGovernanceHooks()
+                        artConfig = governance.init([
+                            serviceName:   'nomad-mimir',
+                            version:       env.BUILD_ID,
+                            environment:   env.ENVIRONMENT,
+                            // Standard governance job parameters (see
+                            // the governance provider's JOB_PARAMETERS.md).
+                            // Undefined params resolve to null -> init applies its defaults.
+                            rpTicket:      params.RP_TICKET,
+                            jiraTicket:    params.JIRA_TICKET,
+                            useStaging:    params.GOVERNANCE_STAGING,
+                            fastTrack:     params.FAST_TRACK,
+                            allowOverride: params.GOVERNANCE_ALLOW_OVERRIDE,
+                            disabled:      (params.GOVERNANCE_ENABLED == false),
+                            verbose:       params.GOVERNANCE_VERBOSE,
+                            skipGates:     params.GOVERNANCE_SKIP_GATES,
+                            gateTimeout:   params.GOVERNANCE_GATE_TIMEOUT,
+                        ])
+                    }
+                }
+            }
+        }
+
+        stage('Pre-Release') {
+            steps {
+                script {
+                    governance.preRelease(artConfig)
+                }
+            }
+        }
+        stage('Pre-Deploy') {
+            steps {
+                script {
+                    governance.preDeploy(artConfig)
+                }
+            }
+        }
+        stage("provision mimir jobs") {
+            steps {
+                script {
+                  dir('infra-provisioning') {
+                    echo "Provision mimir stack in environment ${env.ENVIRONMENT}, regions ${env.REGIONS}";
+                    def region_list = utils.SplitNomadRegions(env.ENVIRONMENT,env.REGIONS);
+                    echo "regions: ${region_list}";
+                    def branches = [:]
+                    for (def i = 0; i < region_list.size(); i++) {
+                        def oracle_region = region_list[i]
+                        echo "pipeline branch ${i} for ${oracle_region}";
+                        branches["Build mimir-${oracle_region}"] = {
+                            provisionJob('provision-nomad-mimir',
+                                env.ENVIRONMENT,
+                                oracle_region,
+                                env.VIDEO_INFRA_BRANCH
+                            )
+                        }
+                    }
+                    parallel branches
+                  }
+                }
+            }
+        }
+    }
+
+    post {
+        always {
+            script {
+                if (governance != null) {
+                    governance.postHooks(artConfig, currentBuild.result == 'SUCCESS')
+                }
+            }
+        }
+    }
+}

--- a/jenkins/groovy/rotate-consul/Jenkinsfile
+++ b/jenkins/groovy/rotate-consul/Jenkinsfile
@@ -3,6 +3,9 @@ def rotateConsul(oracle_region) {
         script: '''#!/bin/bash
         export USER_PUBLIC_KEY_PATH=~/.ssh/ssh_key.pub
         export ORACLE_GIT_BRANCH="$RELEASE_BRANCH"
+        # mimir/loki-aware rotation gates (scripts/consul-metrics-health-gate.sh)
+        export HEALTH_GATE="$HEALTH_GATE"
+        export HEALTH_GATE_TIMEOUT_MINUTES="$HEALTH_GATE_TIMEOUT_MINUTES"
         scripts/rotate-consul-oracle.sh $SSH_USERNAME'''
     )
 }

--- a/jenkins/jobs/provision-nomad-mimir.yaml
+++ b/jenkins/jobs/provision-nomad-mimir.yaml
@@ -1,0 +1,50 @@
+- job:
+    name: provision-nomad-mimir
+    display-name: provision nomad mimir
+    description: "release mimir in nomad to an oracle region in an environment"
+    concurrent: true
+    parameters:
+      - string:
+          name: VIDEO_INFRA_BRANCH
+          default: main
+          description: "Controls checkout branch for infra repos, defaults to 'main'."
+          trim: true
+      - string:
+          name: ENVIRONMENT
+          description: "Environment to provision in"
+          trim: true
+      - string:
+          name: ORACLE_REGION
+          description: "Region to provision in"
+          trim: true
+      - string:
+          name: JOB_TYPE
+          default: mimir 
+          description: "Nomad job type to provision, defaults to 'mimir' do not change"
+          trim: true
+      - string:
+          name: INFRA_CONFIGURATION_REPO
+          default: git@github.com:jitsi/infra-configuration.git
+          description: "Repo for configuration code (ansible etc), defaults to 'git@github.com:jitsi/infra-configuration.git'."
+          trim: true
+      - string:
+          name: INFRA_CUSTOMIZATIONS_REPO
+          default: git@github.com:jitsi/infra-customizations.git
+          description: "Repo with customized configurations, defaults to 'git@github.com:jitsi/infra-customizations.git'."
+          trim: true
+ 
+    project-type: pipeline
+    sandbox: true
+    pipeline-scm:
+      scm:
+        - git:
+            url: git@github.com:jitsi/infra-provisioning.git
+            credentials-id: "video-infra"
+            branches:
+              - "origin/${{VIDEO_INFRA_BRANCH}}"
+            browser: githubweb
+            browser-url: https://github.com/jitsi/infra-provisioning
+            submodule:
+              recursive: true
+      script-path: jenkins/groovy/provision-nomad-job/Jenkinsfile
+      lightweight-checkout: true

--- a/jenkins/jobs/release-nomad-mimir.yaml
+++ b/jenkins/jobs/release-nomad-mimir.yaml
@@ -1,0 +1,87 @@
+- job:
+    name: release-nomad-mimir
+    display-name: release nomad mimir
+    description: "release mimir to nomad in one or more regions in an environment."
+    concurrent: true
+    parameters:
+      - string:
+          name: VIDEO_INFRA_BRANCH
+          default: main
+          description: "Controls checkout branch for infra repos, defaults to 'main'."
+          trim: true
+      - string:
+          name: ENVIRONMENT
+          default: lonely
+          description: "Environment to build in, defaults to 'lonely'."
+          trim: true
+      - string:
+          name: REGIONS
+          description: "REGIONS to build in, defaults to NOMAD_REGIONS for the environment."
+          trim: true
+      - string:
+          name: INFRA_CONFIGURATION_REPO
+          default: git@github.com:jitsi/infra-configuration.git
+          description: "Repo for configuration code (ansible etc), defaults to 'git@github.com:jitsi/infra-configuration.git'."
+          trim: true
+      - string:
+          name: INFRA_CUSTOMIZATIONS_REPO
+          default: git@github.com:jitsi/infra-customizations.git
+          description: "Repo with customized configurations, defaults to 'git@github.com:jitsi/infra-customizations.git'."
+          trim: true
+      # ---- governance (standard) ----
+      - string:
+          name: RP_TICKET
+          default: ""
+          description: "RP ticket (format: RP-1234) for governance change tracking. Auto-extracted from governance if left empty."
+          trim: true
+      - string:
+          name: JIRA_TICKET
+          default: ""
+          description: "Optional JIRA ticket associated with this change, for governance tracking."
+          trim: true
+      - bool:
+          name: GOVERNANCE_ENABLED
+          default: true
+          description: "Enable governance hooks (pre/post release & deploy gates)."
+      - bool:
+          name: GOVERNANCE_STAGING
+          default: false
+          description: "Target the governance STAGING endpoint instead of production."
+      - bool:
+          name: FAST_TRACK
+          default: false
+          description: "Fast-track the change — skip manual verification/approval gates."
+      - bool:
+          name: GOVERNANCE_VERBOSE
+          default: false
+          description: "Mirror governance hook output (payloads, responses, gate results, shell traces) to the console. When off it goes only to the archived governance log artifact; warnings always show."
+      # ---- governance (advanced, optional) ----
+      - bool:
+          name: GOVERNANCE_ALLOW_OVERRIDE
+          default: true
+          description: "Allow a human to override a governance DENY via an input prompt instead of failing the build."
+      - bool:
+          name: GOVERNANCE_SKIP_GATES
+          default: false
+          description: "Send governance notifications but do not poll/block on the gate result."
+      - string:
+          name: GOVERNANCE_GATE_TIMEOUT
+          default: "60"
+          description: "Seconds a gate may stay PENDING before offering an interactive 'skip' prompt (0 disables the prompt)."
+          trim: true
+
+    project-type: pipeline
+    sandbox: true
+    pipeline-scm:
+      scm:
+        - git:
+            url: git@github.com:jitsi/infra-provisioning.git
+            credentials-id: "video-infra"
+            branches:
+              - "origin/${{VIDEO_INFRA_BRANCH}}"
+            browser: githubweb
+            browser-url: https://github.com/jitsi/infra-provisioning
+            submodule:
+              recursive: true
+      script-path: jenkins/groovy/release-nomad-mimir/Jenkinsfile
+      lightweight-checkout: true

--- a/jenkins/jobs/rotate-consul.yaml
+++ b/jenkins/jobs/rotate-consul.yaml
@@ -35,6 +35,15 @@
           name: ORACLE_REGION
           description: "Oracle Region to build in"
           trim: true
+      - bool:
+          name: HEALTH_GATE
+          default: true
+          description: "Gate each pool rotation on the Mimir and Loki clusters being fully healthy (rings 3/3 ACTIVE, /ready 200) before and after. Disable only for disaster recovery when the gate can never pass."
+      - string:
+          name: HEALTH_GATE_TIMEOUT_MINUTES
+          default: "15"
+          description: "How long to wait after each pool rotation for the replacement node's mimir/loki allocs to become healthy before failing the build."
+          trim: true
       - string:
           name: INFRA_CONFIGURATION_REPO
           default: git@github.com:jitsi/infra-configuration.git

--- a/nomad/alloy.hcl
+++ b/nomad/alloy.hcl
@@ -19,6 +19,88 @@ variable "alloy_loki_hostname" {
   type = string
 }
 
+# ---- metrics pipeline switches (doc/mimir-cluster-plan.md, Phase 2) ----
+
+# Write metrics to the regional mimir-cluster (nomad/mimir-cluster.hcl). Off until
+# the cluster exists in the region.
+variable "enable_mimir_write" {
+  type = bool
+  default = false
+}
+
+# Keep relaying OTLP metrics to the legacy regional prometheus during the soak.
+# Turned off at cutover (Phase 5), after which prometheus.hcl only scrapes for
+# its own alert evaluation.
+variable "enable_legacy_prometheus_write" {
+  type = bool
+  default = true
+}
+
+# Alloy takes over the consul-SD scrape jobs prometheus.hcl runs today. Both
+# alloy replicas scrape everything; mimir's HA tracker keeps one copy.
+variable "enable_scrape" {
+  type = bool
+  default = false
+}
+
+# How the *scraped* streams reach the external 8x8-hosted Mimir:
+#   primary - only the alloc with NOMAD_ALLOC_INDEX 0 forwards, no HA labels
+#             (safe when the external tenant has no HA dedup; ~30s gap on reschedule)
+#   ha      - both replicas forward with cluster/__replica__ labels
+#             (ONLY once the external tenant is confirmed to dedup on those labels,
+#             otherwise every scraped series is doubled there)
+#   none    - scraped streams stay local
+variable "external_scrape_forward" {
+  type = string
+  default = "primary"
+  validation {
+    condition     = contains(["primary", "ha", "none"], var.external_scrape_forward)
+    error_message = "The external_scrape_forward variable must be one of primary, ha or none."
+  }
+}
+
+# Extra metric relabel rules applied to every scraped stream, in Alloy `rule {}`
+# syntax (config/vars.yml alloy_custom_relabel_rules; the alloy translation of
+# prometheus_custom_relabels).
+variable "custom_relabel_rules" {
+  type = string
+  default = ""
+}
+
+# Extra external labels for the mimir writers, as Alloy map entries
+# (config/vars.yml alloy_custom_external_labels).
+variable "custom_external_labels" {
+  type = string
+  default = ""
+}
+
+locals {
+  mimir_push_url = "https://[[ env \"meta.environment\" ]]-[[ env \"meta.cloud_region\" ]]-mimir.${var.top_level_domain}/api/v1/push"
+
+  # receivers for OTLP-relayed metrics and alloy's own metrics (NO HA labels)
+  direct_targets = compact([
+    var.enable_legacy_prometheus_write ? "prometheus.remote_write.default.receiver" : "",
+    var.enable_mimir_write ? "prometheus.remote_write.mimir.receiver" : "",
+    "prometheus.remote_write.external.receiver",
+  ])
+
+  # receivers for the shared consul-SD scrape targets (HA-deduplicated)
+  scrape_targets = compact([
+    var.enable_mimir_write ? "prometheus.remote_write.mimir_ha.receiver" : "",
+    var.external_scrape_forward != "none" ? "prometheus.relabel.external_ha_gate.receiver" : "",
+  ])
+
+  # job -> [consul service, scrape interval, service label ("" = leave as-is)]
+  scrape_jobs = {
+    alertmanager                   = ["alertmanager", "15s", "alertmanager"]
+    cloudprober                    = ["cloudprober", "10s", "cloudprober"]
+    telegraf                       = ["telegraf", "30s", ""]
+    opus-transcriber-proxy-monitor = ["opus-transcriber-proxy-monitor", "30s", "jitsi"]
+    gitea-mirror                   = ["gitea-mirror-metrics", "60s", "infra"]
+    mimir                          = ["mimir", "15s", "infra"]
+  }
+}
+
 job "[JOB_NAME]" {
   datacenters = ["${var.dc}"]
   type        = "service"
@@ -210,8 +292,10 @@ otelcol.processor.batch "default" {
 
 prometheus.exporter.self "self" {}
 
+// Alloy's own metrics are per-instance and must NOT go through the HA-deduped
+// writers (the non-elected replica's metrics would be dropped).
 prometheus.relabel "add_labels" {
-  forward_to = [prometheus.remote_write.default.receiver]
+  forward_to = [${join(", ", local.direct_targets)}]
   rule {
     target_label = "alloy_type"
     replacement  = "internal"
@@ -253,16 +337,136 @@ otelcol.exporter.otlphttp "tempo" {
   }
 }
 
-// Export metrics to Prometheus via remote write through internal LB
+// OTLP-relayed metrics. Each client sends to ONE alloy (via the LB), so these
+// streams are not duplicated and must not carry HA labels.
 otelcol.exporter.prometheus "default" {
-  forward_to = [prometheus.remote_write.default.receiver, prometheus.remote_write.external.receiver]
+  forward_to = [${join(", ", local.direct_targets)}]
 }
 
+%{ if var.enable_legacy_prometheus_write }
+// Legacy regional prometheus (remote-write receiver). Removed at Phase 5 cutover.
 prometheus.remote_write "default" {
   endpoint {
     url = "https://[[ env "meta.environment" ]]-[[ env "meta.cloud_region" ]]-prometheus.${var.top_level_domain}/api/v1/write"
   }
 }
+%{ endif }
+
+%{ if var.enable_mimir_write }
+// ---- Regional mimir-cluster ----
+// Two writers to the same endpoint on purpose. Mimir's HA tracker decides per
+// *request* from the first series' labels, so streams that carry
+// cluster/__replica__ (shared scrape targets, scraped by both replicas) must never
+// share a WAL/request with streams that don't (OTLP relays, alloy self metrics):
+// a mixed batch would either be dropped wholesale or stored with a stray
+// __replica__ label.
+
+// direct: OTLP relays + alloy self metrics
+prometheus.remote_write "mimir" {
+  endpoint {
+    url = "${local.mimir_push_url}"
+  }
+  external_labels = {
+    "datacenter"  = "${var.dc}",
+    "environment" = "[[ env "meta.environment" ]]",
+    "region"      = "[[ env "meta.cloud_region" ]]",
+    ${var.custom_external_labels}
+  }
+}
+
+// HA-deduplicated: shared consul-SD scrape targets
+prometheus.remote_write "mimir_ha" {
+  endpoint {
+    url = "${local.mimir_push_url}"
+  }
+  external_labels = {
+    "datacenter"  = "${var.dc}",
+    "environment" = "[[ env "meta.environment" ]]",
+    "region"      = "[[ env "meta.cloud_region" ]]",
+    "cluster"     = "[[ env "meta.environment" ]]-[[ env "meta.cloud_region" ]]",
+    "__replica__" = "alloy-[[ env "NOMAD_ALLOC_INDEX" ]]",
+    ${var.custom_external_labels}
+  }
+}
+%{ endif }
+
+%{ if var.enable_scrape }
+// ---- consul-SD scrape jobs (replacing prometheus.hcl's scrape_configs) ----
+// Both alloy replicas scrape every target; dedup happens in mimir (HA tracker)
+// and, in "ha" mode, in the external Mimir.
+%{ for name, spec in local.scrape_jobs }
+discovery.consul "${replace(name, "-", "_")}" {
+  server           = "[[ env "NOMAD_IP_http" ]]:8500"
+  services         = ["${spec[0]}"]
+  refresh_interval = "30s"
+}
+
+prometheus.scrape "${replace(name, "-", "_")}" {
+  targets         = discovery.consul.${replace(name, "-", "_")}.targets
+  job_name        = "${name}"
+  scrape_interval = "${spec[1]}"
+  metrics_path    = "/metrics"
+  forward_to      = [prometheus.relabel.${replace(name, "-", "_")}.receiver]
+}
+
+prometheus.relabel "${replace(name, "-", "_")}" {
+  forward_to = [prometheus.relabel.scrape_common.receiver]
+%{ if spec[2] != "" }
+  rule {
+    target_label = "service"
+    replacement  = "${spec[2]}"
+  }
+%{ else }
+  // no service label override for this job (matches prometheus.hcl)
+  rule {
+    action = "labeldrop"
+    regex  = "__tmp_.*"
+  }
+%{ endif }
+}
+%{ endfor }
+
+// Common metric relabels for every scraped stream, then fan out to the
+// HA-deduplicated writers.
+prometheus.relabel "scrape_common" {
+  forward_to = [${join(", ", local.scrape_targets)}]
+  // keeps the block valid when no custom rules are configured
+  rule {
+    action = "labeldrop"
+    regex  = "__tmp_.*"
+  }
+${var.custom_relabel_rules}
+}
+%{ endif }
+
+%{ if var.external_scrape_forward != "none" }
+// Gate in front of the external HA writer. In "primary" mode only the alloc with
+// index 0 forwards scraped streams externally; the other replica drops them here.
+prometheus.relabel "external_ha_gate" {
+  forward_to = [prometheus.remote_write.external_ha.receiver]
+%{ if var.external_scrape_forward == "primary" }
+  [[ if ne (env "NOMAD_ALLOC_INDEX") "0" ]]
+  // not the primary replica: the external tenant has no HA dedup, drop everything
+  rule {
+    action        = "drop"
+    source_labels = ["__name__"]
+    regex         = ".*"
+  }
+  [[ else ]]
+  // primary replica: pass through
+  rule {
+    action = "labeldrop"
+    regex  = "__tmp_.*"
+  }
+  [[ end ]]
+%{ else }
+  rule {
+    action = "labeldrop"
+    regex  = "__tmp_.*"
+  }
+%{ endif }
+}
+%{ endif }
 
 // --- External endpoints (Grafana Cloud) sourced from Vault ---
 [[ with secret "secret/default/alloy/external-auth" ]]
@@ -305,7 +509,7 @@ otelcol.exporter.otlphttp "external_tempo" {
   }
 }
 
-// Export metrics to external Mimir via remote write
+// Export metrics to external Mimir via remote write (OTLP relays + alloy self)
 prometheus.remote_write "external" {
   endpoint {
     url = "[[ index .Data.data "${var.environment_type}-01-oci-metrics-url" ]]"
@@ -315,13 +519,40 @@ prometheus.remote_write "external" {
     }
   }
 }
+
+%{ if var.external_scrape_forward != "none" }
+// Scraped streams to the external Mimir. Same tenant as "external" above; carries
+// the labels the legacy prometheus.hcl remote_write attached, so the external
+// alerting keeps working when prometheus.hcl stops writing.
+prometheus.remote_write "external_ha" {
+  endpoint {
+    url = "[[ index .Data.data "${var.environment_type}-01-oci-metrics-url" ]]"
+    basic_auth {
+      username = "[[ index .Data.data "meetings-oci-hosts-${var.environment_type}-01-oci-metrics-username" ]]"
+      password = "[[ index .Data.data "meetings-oci-hosts-${var.environment_type}-01-oci-metrics-password" ]]"
+    }
+  }
+  external_labels = {
+    "datacenter"  = "${var.dc}",
+    "environment" = "[[ env "meta.environment" ]]",
+    "region"      = "[[ env "meta.cloud_region" ]]",
+%{ if var.external_scrape_forward == "ha" }
+    "cluster"     = "[[ env "meta.environment" ]]-[[ env "meta.cloud_region" ]]",
+    "__replica__" = "alloy-[[ env "NOMAD_ALLOC_INDEX" ]]",
+%{ endif }
+    ${var.custom_external_labels}
+  }
+}
+%{ endif }
 [[ end ]]
 EOF
       }
 
+      # Sized for the OTLP relay plus the consul-SD scrape jobs and up to four
+      # remote-write WALs. Calibrate with the alloy-monitor dashboard.
       resources {
-        cpu    = 256
-        memory = 512
+        cpu    = 512
+        memory = 1536
       }
     }
   }

--- a/nomad/jitsi_packs/packs/jitsi_cloudprober/templates/_cloudprober_config.tpl
+++ b/nomad/jitsi_packs/packs/jitsi_cloudprober/templates/_cloudprober_config.tpl
@@ -467,4 +467,62 @@ probe {
 }
 [[ end -]]
 
+[[ if var "enable_mimir" . -]]
+# probes mimir readiness in the local datacenter (all three instances behind fabio)
+probe {
+  name: "mimir"
+  type: HTTP
+  targets {
+    host_names: "[[ var "environment" . ]]-[[ var "oracle_region" . ]]-mimir.[[ var "top_level_domain" . ]]"
+  }
+  http_probe {
+    protocol: HTTPS
+    relative_url: "/ready"
+  }
+  validator {
+      name: "status_code_2xx"
+      http_validator {
+          success_status_codes: "200-299"
+      }
+  }
+  interval_msec: 30000
+  timeout_msec: 10000
+  latency_unit: "ms"
+  additional_label {
+    key: "service"
+    value: "infra"
+  }
+}
+
+# end-to-end read path: an instant query through query-frontend -> querier
+probe {
+  name: "mimir-query"
+  type: HTTP
+  targets {
+    host_names: "[[ var "environment" . ]]-[[ var "oracle_region" . ]]-mimir.[[ var "top_level_domain" . ]]"
+  }
+  http_probe {
+    protocol: HTTPS
+    relative_url: "/prometheus/api/v1/query?query=vector(1)"
+  }
+  validator {
+      name: "status_code_2xx"
+      http_validator {
+          success_status_codes: "200-299"
+      }
+  }
+  validator {
+      name: "query_success"
+      regex: "\\"status\\":\\"success\\""
+  }
+  interval_msec: 30000
+  timeout_msec: 10000
+  latency_unit: "ms"
+  additional_label {
+    key: "service"
+    value: "infra"
+  }
+}
+[[ end -]]
+
 [[ end -]]

--- a/nomad/jitsi_packs/packs/jitsi_cloudprober/variables.hcl
+++ b/nomad/jitsi_packs/packs/jitsi_cloudprober/variables.hcl
@@ -127,3 +127,8 @@ variable "enable_alloy" {
   type        = bool
   default     = false
 }
+variable "enable_mimir" {
+  description = "Whether to enable mimir monitoring (readiness + synthetic query probe)"
+  type        = bool
+  default     = false
+}

--- a/nomad/mimir-cluster.hcl
+++ b/nomad/mimir-cluster.hcl
@@ -1,0 +1,359 @@
+variable "dc" {
+  type = string
+}
+
+variable "mimir_hostname" {
+  type = string
+}
+
+variable "oracle_s3_namespace" {
+  type = string
+}
+
+variable "internal_dns_zone" {
+  type = string
+  default = "oracle.infra.jitsi.net"
+}
+
+# Mimir supports N -> N+1 rolling upgrades only; never skip a minor version.
+# See doc/mimir-runbook.md before bumping.
+variable "mimir_version" {
+  type = string
+  default = "3.1.5"
+}
+
+variable "environment_type" {
+  type = string
+  description = "prod or nonprod; sizes the task resources"
+  default = "nonprod"
+}
+
+# Block retention in object storage. The compactor owns deletion; the bucket has
+# no lifecycle policy on purpose.
+variable "retention_period" {
+  type = string
+  default = "2160h"
+}
+
+# Per-tenant limits (single tenant "anonymous"). These are deliberately NOT the
+# Mimir defaults (150k series / 10k samples/s), which are far below what a
+# region's telegraf fleet produces, but they are also not unlimited: with RF=3
+# every ingester holds every series, so the series cap is what protects the
+# 3 GB / 8 GB task memory from a cardinality explosion. Re-derive from
+# prometheus_tsdb_head_series of the region being migrated before prod rollout.
+variable "max_global_series_per_user" {
+  type = number
+  default = 1000000
+}
+
+variable "ingestion_rate" {
+  type = number
+  description = "samples/s per tenant"
+  default = 250000
+}
+
+variable "ingestion_burst_size" {
+  type = number
+  default = 1000000
+}
+
+locals {
+  mimir = [0, 1, 2]
+}
+
+job "[JOB_NAME]" {
+  datacenters = [var.dc]
+  type        = "service"
+  priority    = 75
+
+  # One group (= one zone = one ingester replica) at a time. RF=3 keeps write
+  # quorum (2/3) with one zone down. An ingester restart replays its WAL from
+  # the host volume before /ready goes 200, so the deadlines are generous.
+  update {
+    max_parallel      = 1
+    health_check      = "checks"
+    min_healthy_time  = "30s"
+    healthy_deadline  = "10m"
+    progress_deadline = "15m"
+    auto_revert       = true
+    stagger           = "60s"
+  }
+
+  dynamic "group" {
+    for_each = local.mimir
+    labels   = ["mimir-${group.key}"]
+    content {
+      count = 1
+      restart {
+        attempts = 3
+        interval = "10m"
+        delay    = "25s"
+        mode     = "delay"
+      }
+      network {
+        mode = "host"
+        port "http" {
+        }
+        port "grpc" {
+        }
+        # loki-cluster owns static 7946 on the same consul nodes.
+        port "gossip" {
+          static = 7947
+        }
+      }
+      constraint {
+        attribute  = "${meta.pool_type}"
+        value     = "consul"
+      }
+      # /mnt/bv/mimir-N, attached by tag to the consul node with group-index N
+      # (terraform/volumes-mimir). Holds the ingester WAL + head block, ring
+      # tokens, store-gateway index headers and compactor scratch.
+      volume "mimir" {
+        type      = "host"
+        read_only = false
+        source    = "mimir-${group.key}"
+      }
+
+      task "mimir" {
+        driver = "docker"
+        user = "root"
+
+        # noop on purpose: a Vault credential rotation must not bounce all three
+        # ingesters at once. Roll the new secret in with a normal (rolling)
+        # deploy instead -- see doc/mimir-runbook.md.
+        vault {
+          change_mode = "noop"
+        }
+
+        config {
+          network_mode = "host"
+          image = "grafana/mimir:${var.mimir_version}"
+          args = [
+            "-config.file=/local/mimir.yaml",
+          ]
+          ports = ["http", "gossip", "grpc"]
+        }
+        volume_mount {
+          volume      = "mimir"
+          destination = "/mimir"
+          read_only   = false
+        }
+        template {
+          destination = "local/mimir.yaml"
+          # noop: consul service churn (alertmanager moving hosts) must not
+          # restart a stateful ingester. Config changes ship as a new job
+          # version, which rolls one group at a time.
+          change_mode = "noop"
+          data = <<EOH
+# Grafana Mimir ${var.mimir_version}, monolithic mode, 3 replicas per region.
+# Validated against the 3.x configuration reference; do not copy 2.x examples.
+target: all
+multitenancy_enabled: false
+no_auth_tenant: anonymous
+
+usage_stats:
+  enabled: false
+
+activity_tracker:
+  filepath: /mimir/metrics-activity.log
+
+api:
+  prometheus_http_prefix: /prometheus
+
+server:
+  http_listen_address: 0.0.0.0
+  http_listen_port: {{ env "NOMAD_HOST_PORT_http" }}
+  grpc_listen_address: 0.0.0.0
+  grpc_listen_port: {{ env "NOMAD_HOST_PORT_grpc" }}
+  log_level: warn
+
+common:
+  storage:
+    backend: s3
+    s3:
+      endpoint: ${var.oracle_s3_namespace}.compat.objectstorage.{{ env "meta.cloud_region" }}.oraclecloud.com:443
+      region: {{ env "meta.cloud_region" }}
+      bucket_name: mimir-{{ env "meta.environment" }}
+      # OCI's S3-compat endpoint needs path-style addressing (loki/tempo do the same).
+      bucket_lookup_type: path
+      insecure: false
+{{ with secret "secret/default/mimir/s3" }}
+      access_key_id: {{ .Data.data.access_key }}
+      secret_access_key: {{ .Data.data.secret_key }}
+{{ end }}
+
+# One bucket, three prefixes.
+blocks_storage:
+  storage_prefix: blocks
+  tsdb:
+    dir: /mimir/tsdb
+  bucket_store:
+    sync_dir: /mimir/tsdb-sync
+
+ruler_storage:
+  storage_prefix: ruler
+
+alertmanager_storage:
+  storage_prefix: alertmanager
+
+memberlist:
+  # Stops a misrouted packet from another memberlist cluster (loki on 7946)
+  # from ever being accepted.
+  cluster_label: mimir-${var.dc}
+  bind_port: {{ env "NOMAD_HOST_PORT_gossip" }}
+  advertise_addr: {{ env "NOMAD_IP_gossip" }}
+  advertise_port: {{ env "NOMAD_HOST_PORT_gossip" }}
+  # Seeds are the consul-node DNS names; after a consul-node rotation the name
+  # points at a new host, so periodically re-join to heal any split.
+  rejoin_interval: 1m
+  join_members:
+    - ${var.dc}-consul-a.${var.internal_dns_zone}:{{ env "NOMAD_HOST_PORT_gossip" }}
+    - ${var.dc}-consul-b.${var.internal_dns_zone}:{{ env "NOMAD_HOST_PORT_gossip" }}
+    - ${var.dc}-consul-c.${var.internal_dns_zone}:{{ env "NOMAD_HOST_PORT_gossip" }}
+
+# Every ring member registers as the STABLE identity mimir-N with tokens
+# persisted on the host volume, so a consul-node rotation or alloc reschedule
+# rejoins as the same member with the same tokens (no unhealthy squatter, no
+# resharding). Tokens files live at the top of the volume: Mimir does not
+# create parent directories for them.
+ingester:
+  ring:
+    kvstore:
+      store: memberlist
+    instance_id: mimir-${group.key}
+    instance_addr: {{ env "NOMAD_IP_grpc" }}
+    instance_port: {{ env "NOMAD_HOST_PORT_grpc" }}
+    instance_availability_zone: zone-${group.key}
+    replication_factor: 3
+    zone_awareness_enabled: true
+    tokens_file_path: /mimir/ingester-tokens
+    unregister_on_shutdown: false
+    final_sleep: 0s
+    min_ready_duration: 15s
+
+distributor:
+  ring:
+    kvstore:
+      store: memberlist
+    instance_id: mimir-${group.key}
+    instance_addr: {{ env "NOMAD_IP_grpc" }}
+  # HA dedup for the two alloy scrapers (cluster / __replica__ labels). The
+  # elected-replica state must be shared by all distributors, so it lives in
+  # the consul KV of the local consul cluster, not in per-process memory.
+  ha_tracker:
+    enable_ha_tracker: true
+    kvstore:
+      store: consul
+      prefix: mimir/ha-tracker/
+      consul:
+        host: {{ env "NOMAD_IP_grpc" }}:8500
+
+store_gateway:
+  sharding_ring:
+    kvstore:
+      store: memberlist
+    instance_id: mimir-${group.key}
+    instance_addr: {{ env "NOMAD_IP_grpc" }}
+    instance_availability_zone: zone-${group.key}
+    replication_factor: 3
+    zone_awareness_enabled: true
+    tokens_file_path: /mimir/store-gateway-tokens
+    unregister_on_shutdown: false
+    wait_stability_min_duration: 1m
+
+compactor:
+  data_dir: /mimir/compactor
+  sharding_ring:
+    kvstore:
+      store: memberlist
+    instance_id: mimir-${group.key}
+    instance_addr: {{ env "NOMAD_IP_grpc" }}
+
+ruler:
+  rule_path: /mimir/ruler
+  ring:
+    kvstore:
+      store: memberlist
+    instance_id: mimir-${group.key}
+    instance_addr: {{ env "NOMAD_IP_grpc" }}
+
+# 3.x queriers have their own lifecycler. Without an explicit address it
+# auto-detects from interfaces eth0/en0 and refuses to start on hosts that name
+# them differently (OCI: ens3/enp*), so every ring member gets its address from
+# Nomad rather than from interface detection.
+querier:
+  ring:
+    kvstore:
+      store: memberlist
+    instance_id: mimir-${group.key}
+    instance_addr: {{ env "NOMAD_IP_grpc" }}
+
+# Ring-based scheduler discovery so every query-frontend sees all three
+# schedulers (the default DNS mode would need a stable scheduler address).
+query_scheduler:
+  service_discovery_mode: ring
+  ring:
+    kvstore:
+      store: memberlist
+    instance_id: mimir-${group.key}
+    instance_addr: {{ env "NOMAD_IP_grpc" }}
+
+frontend:
+  address: {{ env "NOMAD_IP_grpc" }}
+
+limits:
+  # HA tracker (see distributor.ha_tracker). Only alloy's *scraped* streams carry
+  # cluster/__replica__; OTLP-relayed and alloy self metrics must not (they
+  # would be dropped as "non-elected replica").
+  accept_ha_samples: true
+  ha_cluster_label: cluster
+  ha_replica_label: __replica__
+  max_global_series_per_user: ${var.max_global_series_per_user}
+  ingestion_rate: ${var.ingestion_rate}
+  ingestion_burst_size: ${var.ingestion_burst_size}
+  # telegraf inputs carry many labels; the default of 30 would silently discard.
+  max_label_names_per_series: 60
+  # tolerate agent WAL replay after an alloy or distributor restart
+  out_of_order_time_window: 5m
+  compactor_blocks_retention_period: ${var.retention_period}
+  # Ruler notifications. No rules are loaded until JIT-16017 syncs the alert
+  # catalog; the target list is rendered once at alloc start (change_mode noop
+  # above), so that ticket must decide between a re-render strategy and
+  # Mimir's own alertmanager.
+  ruler_alertmanager_client_config:
+    alertmanager_url: {{ range $i, $s := service "alertmanager" }}{{ if ne $i 0 }},{{ end }}http://{{ $s.Address }}:{{ $s.Port }}{{ end }}
+EOH
+        }
+        resources {
+          cpu    = "%{ if var.environment_type == "prod" }2000%{ else }1000%{ endif }"
+          memory = "%{ if var.environment_type == "prod" }8192%{ else }3072%{ endif }"
+        }
+        shutdown_delay = "10s"
+        service {
+          name = "mimir"
+          port = "http"
+          tags = ["int-urlprefix-${var.mimir_hostname}/", "ip-${attr.unique.network.ip-address}","mimir-${group.key}"]
+          check {
+            name     = "Mimir healthcheck"
+            port     = "http"
+            type     = "http"
+            path     = "/ready"
+            interval = "20s"
+            timeout  = "5s"
+            # /ready stays 503 while the ingester replays its WAL and joins the
+            # ring; a 60s grace (loki's value) would restart a large ingester in
+            # a loop and never let it come up.
+            check_restart {
+              limit           = 3
+              grace           = "10m"
+              ignore_warnings = false
+            }
+          }
+          meta {
+            mimir_index = "${group.key}"
+          }
+        }
+      }
+    }
+  }
+}

--- a/nomad/prometheus.hcl
+++ b/nomad/prometheus.hcl
@@ -61,6 +61,12 @@ variable "autoscaler_alerts" {
   default = false
 }
 
+variable "mimir_alerts" {
+  type = bool
+  description = "a mimir cluster (nomad/mimir-cluster.hcl) is deployed in this region; scrape it and evaluate the mimir_alerts group"
+  default = false
+}
+
 variable "custom_alerts" {
   type = string
   description = "custom alerts to be added to the alerts.yml file"
@@ -215,7 +221,17 @@ ${var.custom_relabels}
       - target_label: service
         replacement: 'infra'
 ${var.custom_relabels}
-  - job_name: 'prometheus'
+%{ if var.mimir_alerts }  - job_name: 'mimir'
+    scrape_interval: 15s
+    metrics_path: /metrics
+    consul_sd_configs:
+    - server: '{{ env "NOMAD_IP_prometheus_ui" }}:8500'
+      services: ['mimir']
+    metric_relabel_configs:
+      - target_label: service
+        replacement: 'infra'
+${var.custom_relabels}
+%{ endif }  - job_name: 'prometheus'
     scrape_interval: 5s
     static_configs:
       - targets: ['localhost:9090']
@@ -516,7 +532,224 @@ groups:
       dashboard_url: ${var.grafana_url}
       alert_url: https://${var.prometheus_hostname}/alerts?search=gitea_mirror
 
-- name: cloudprober_alerts
+%{ if var.mimir_alerts }# Self-monitoring for the regional Mimir cluster (doc/mimir-cluster-plan.md 6).
+# Evaluated by this prometheus until JIT-16017 moves the catalog to the Mimir ruler.
+- name: mimir_alerts
+  rules:
+  - alert: Mimir_Down
+    expr: absent(up{job="mimir"})
+    for: 5m
+    labels:
+      service: infra
+      severity: severe
+    annotations:
+      summary: no mimir instance is being scraped in ${var.dc}
+      description: >-
+        None of the three mimir instances in ${var.dc} are exposing metrics. Metrics
+        ingestion and Grafana queries for this region are down; alloy is buffering
+        samples in its WAL and will replay them when mimir returns.
+      dashboard_url: ${var.grafana_url}
+      alert_url: https://${var.prometheus_hostname}/alerts?search=mimir_down
+  - alert: Mimir_Instance_Down
+    expr: count(up{job="mimir"} == 1) < 3
+    for: 5m
+    labels:
+      service: infra
+      severity: warn
+    annotations:
+      summary: a mimir instance is down in ${var.dc}
+      description: >-
+        Only {{ $value }} of 3 mimir instances are up in ${var.dc}. With replication
+        factor 3 the cluster is still serving reads and writes, but one more failure
+        means a write outage. Check nomad job mimir-${var.dc} and the mimir host volumes.
+      dashboard_url: ${var.grafana_url}
+      alert_url: https://${var.prometheus_hostname}/alerts?search=mimir_instance_down
+  - alert: Mimir_Instance_Down
+    expr: count(up{job="mimir"} == 1) < 3
+    for: 30m
+    labels:
+      service: infra
+      severity: severe
+    annotations:
+      summary: a mimir instance has been down for 30 minutes in ${var.dc}
+      description: >-
+        Only {{ $value }} of 3 mimir instances have been up for the last 30 minutes in
+        ${var.dc}. The cluster has no remaining redundancy. See doc/mimir-runbook.md.
+      dashboard_url: ${var.grafana_url}
+      alert_url: https://${var.prometheus_hostname}/alerts?search=mimir_instance_down
+  - alert: Mimir_Ring_Unhealthy
+    expr: max(cortex_ring_members{job="mimir", state="Unhealthy"}) > 0
+    for: 5m
+    labels:
+      service: infra
+      severity: severe
+    annotations:
+      summary: mimir ring has unhealthy members in ${var.dc}
+      description: >-
+        A mimir ring in ${var.dc} reports {{ $value }} unhealthy member(s). Ring
+        members are pinned to the stable identities mimir-0/1/2, so an unhealthy
+        member usually means an instance is down or cannot gossip on 7947. If the
+        instance is gone for good, forget it from the ring (doc/mimir-runbook.md).
+      dashboard_url: ${var.grafana_url}
+      alert_url: https://${var.prometheus_hostname}/alerts?search=mimir_ring_unhealthy
+  - alert: Mimir_Ingestion_Discards
+    expr: sum by (reason) (rate(cortex_discarded_samples_total{job="mimir"}[5m])) > 10
+    for: 15m
+    labels:
+      service: infra
+      severity: warn
+    annotations:
+      summary: mimir is discarding samples ({{ $labels.reason }}) in ${var.dc}
+      description: >-
+        Mimir in ${var.dc} has been discarding {{ $value | printf "%.1f" }} samples/s for
+        reason {{ $labels.reason }} for 15 minutes. Common causes are per-tenant limits
+        (max_global_series_per_user, ingestion_rate, max_label_names_per_series) or
+        out-of-order samples beyond the 5m window.
+      dashboard_url: ${var.grafana_url}
+      alert_url: https://${var.prometheus_hostname}/alerts?search=mimir_ingestion_discards
+  - alert: Mimir_HA_Dedup_Flapping
+    expr: sum(increase(cortex_ha_tracker_elected_replica_changes_total{job="mimir"}[10m])) > 3
+    for: 15m
+    labels:
+      service: infra
+      severity: smoke
+    annotations:
+      summary: mimir HA tracker keeps re-electing the alloy replica in ${var.dc}
+      description: >-
+        The elected alloy scrape replica in ${var.dc} changed {{ $value | printf "%.0f" }} times
+        in 10 minutes. Usually one alloy replica is unhealthy or its remote write is
+        lagging past the HA failover timeout; expect small gaps in scraped metrics.
+      dashboard_url: ${var.grafana_url}
+      alert_url: https://${var.prometheus_hostname}/alerts?search=mimir_ha_dedup_flapping
+  - alert: Mimir_Compactor_Stalled
+    expr: max(cortex_compactor_last_successful_run_timestamp_seconds{job="mimir"}) > 0 and time() - max(cortex_compactor_last_successful_run_timestamp_seconds{job="mimir"}) > 4 * 3600
+    for: 30m
+    labels:
+      service: infra
+      severity: warn
+    annotations:
+      summary: mimir compactor has not completed a run in 4 hours in ${var.dc}
+      description: >-
+        No mimir compactor in ${var.dc} has finished a compaction run for over 4 hours
+        (runs every hour). Query performance degrades and retention is not applied
+        until compaction resumes. Check the compactor logs and object storage.
+      dashboard_url: ${var.grafana_url}
+      alert_url: https://${var.prometheus_hostname}/alerts?search=mimir_compactor_stalled
+  - alert: Mimir_Compactor_Stalled
+    expr: max(cortex_compactor_last_successful_run_timestamp_seconds{job="mimir"}) > 0 and time() - max(cortex_compactor_last_successful_run_timestamp_seconds{job="mimir"}) > 24 * 3600
+    for: 30m
+    labels:
+      service: infra
+      severity: severe
+    annotations:
+      summary: mimir compactor has not completed a run in 24 hours in ${var.dc}
+      description: >-
+        No mimir compactor in ${var.dc} has finished a compaction run for over a day.
+        Uncompacted blocks pile up in the bucket and the store-gateways will start
+        struggling. See doc/mimir-runbook.md (compactor stuck).
+      dashboard_url: ${var.grafana_url}
+      alert_url: https://${var.prometheus_hostname}/alerts?search=mimir_compactor_stalled
+  - alert: Mimir_StoreGateway_Sync_Failing
+    expr: sum(rate(cortex_bucket_stores_blocks_sync_failures_total{job="mimir"}[10m])) > 0
+    for: 15m
+    labels:
+      service: infra
+      severity: warn
+    annotations:
+      summary: mimir store-gateway block sync is failing in ${var.dc}
+      description: >-
+        Store-gateways in ${var.dc} are failing to sync blocks from the mimir bucket.
+        Queries beyond the ingesters' in-memory window will return stale or partial
+        data. Check object storage credentials and connectivity.
+      dashboard_url: ${var.grafana_url}
+      alert_url: https://${var.prometheus_hostname}/alerts?search=mimir_storegateway_sync_failing
+  - alert: Mimir_Object_Storage_Errors
+    expr: sum by (operation) (rate(thanos_objstore_bucket_operation_failures_total{job="mimir"}[5m])) / sum by (operation) (rate(thanos_objstore_bucket_operations_total{job="mimir"}[5m])) > 0.05
+    for: 15m
+    labels:
+      service: infra
+      severity: warn
+    annotations:
+      summary: mimir object storage {{ $labels.operation }} operations are failing in ${var.dc}
+      description: >-
+        More than 5% of mimir {{ $labels.operation }} operations against the mimir bucket
+        in ${var.dc} failed over the last 15 minutes ({{ $value | printf "%.2f" }} ratio).
+        Blocks may not be shipping; the ingesters keep them on the host volume until
+        the bucket recovers.
+      dashboard_url: ${var.grafana_url}
+      alert_url: https://${var.prometheus_hostname}/alerts?search=mimir_object_storage_errors
+  - alert: Mimir_Query_Latency_High
+    expr: histogram_quantile(0.99, sum by (le) (rate(cortex_request_duration_seconds_bucket{job="mimir", route=~"prometheus_api_v1_query.*"}[5m]))) > 10
+    for: 15m
+    labels:
+      service: infra
+      severity: warn
+    annotations:
+      summary: mimir query p99 latency is above 10s in ${var.dc}
+      description: >-
+        The p99 latency of Prometheus API queries against mimir in ${var.dc} has been
+        {{ $value | printf "%.1f" }}s for 15 minutes. Look for expensive dashboard
+        queries, store-gateway lazy loading, or an overloaded querier.
+      dashboard_url: ${var.grafana_url}
+      alert_url: https://${var.prometheus_hostname}/alerts?search=mimir_query_latency_high
+  - alert: Mimir_Write_Latency_High
+    expr: histogram_quantile(0.99, sum by (le) (rate(cortex_request_duration_seconds_bucket{job="mimir", route=~"api_v1_push.*"}[5m]))) > 2.5
+    for: 15m
+    labels:
+      service: infra
+      severity: warn
+    annotations:
+      summary: mimir remote-write p99 latency is above 2.5s in ${var.dc}
+      description: >-
+        The p99 latency of remote-write pushes into mimir in ${var.dc} has been
+        {{ $value | printf "%.1f" }}s for 15 minutes. Alloy will start sharding up and
+        buffering; check ingester CPU/memory and the mimir host volumes.
+      dashboard_url: ${var.grafana_url}
+      alert_url: https://${var.prometheus_hostname}/alerts?search=mimir_write_latency_high
+  - alert: Mimir_Ruler_Failing
+    expr: sum(rate(cortex_prometheus_rule_evaluation_failures_total{job="mimir"}[5m])) > 0
+    for: 10m
+    labels:
+      service: infra
+      severity: severe
+    annotations:
+      summary: mimir ruler rule evaluations are failing in ${var.dc}
+      description: >-
+        The mimir ruler in ${var.dc} is failing rule evaluations. Once the alert
+        catalog lives on the ruler these evaluations ARE our alerting, so treat this
+        as an alerting outage.
+      dashboard_url: ${var.grafana_url}
+      alert_url: https://${var.prometheus_hostname}/alerts?search=mimir_ruler_failing
+  - alert: Alloy_Scrape_Down
+    expr: count(up{job="integrations/self", alloy_type="internal"} == 1) < 2
+    for: 10m
+    labels:
+      service: infra
+      severity: severe
+    annotations:
+      summary: fewer than 2 alloy collectors are up in ${var.dc}
+      description: >-
+        Only {{ $value }} alloy collector(s) are reporting in ${var.dc}. Alloy is the only
+        scraper and the only writer to mimir and the external 8x8 Mimir; with one
+        replica left there is no scrape redundancy, with zero all metrics stop.
+      dashboard_url: ${var.grafana_url}
+      alert_url: https://${var.prometheus_hostname}/alerts?search=alloy_scrape_down
+  - alert: Alloy_RemoteWrite_Backlog
+    expr: (max by (instance, component_id) (prometheus_remote_storage_highest_timestamp_in_seconds{alloy_type="internal"}) - on (instance, component_id) group_right () prometheus_remote_storage_queue_highest_sent_timestamp_seconds{alloy_type="internal"}) > 120
+    for: 10m
+    labels:
+      service: infra
+      severity: warn
+    annotations:
+      summary: alloy remote write to {{ $labels.url }} is lagging in ${var.dc}
+      description: >-
+        Alloy {{ $labels.instance }} ({{ $labels.component_id }}) in ${var.dc} has samples
+        more than 2 minutes old still unsent to {{ $labels.url }}. The destination is slow
+        or rejecting writes; the WAL is absorbing it for now. This is the earliest
+        signal of a mimir (or external Mimir) write-path problem.
+      dashboard_url: ${var.grafana_url}
+      alert_url: https://${var.prometheus_hostname}/alerts?search=alloy_remotewrite_backlog
+%{ endif }- name: cloudprober_alerts
   rules:
   - alert: Probe_Unhealthy
     expr: (cloudprober_failure{probe!~"shard|shard_https"} > 0) or (cloudprober_timeouts{probe!~"shard|shard_https"} > 0)

--- a/scripts/consul-metrics-health-gate.sh
+++ b/scripts/consul-metrics-health-gate.sh
@@ -1,0 +1,192 @@
+#!/bin/bash
+# consul-metrics-health-gate.sh -- Mimir/Loki-aware health gate for consul-node rotations.
+#
+# The consul pool carries one mimir-N ingester (RF=3) and one loki-N instance
+# (RF=1) per node. Rotating a node moves its allocs to the replacement node, which
+# has to attach the volume, replay the WAL and rejoin the ring before the NEXT
+# node may be touched. This script is what rotate-consul-oracle.sh waits on
+# instead of a blind sleep (doc/mimir-cluster-plan.md section 5a).
+#
+#   consul-metrics-health-gate.sh pre    one-shot: exit non-zero if the clusters are not
+#                                        fully healthy (never start a rotation against an
+#                                        already-degraded cluster)
+#   consul-metrics-health-gate.sh post   poll until healthy or HEALTH_GATE_TIMEOUT_MINUTES
+#                                        elapses (default 15); exit non-zero on timeout
+#
+# A job that is not deployed in the region is skipped (the very first rotation, the
+# one that attaches the mimir volumes, happens before mimir exists). A nomad API
+# failure is NOT treated as "not deployed": the gate fails closed.
+#
+# Env: ENVIRONMENT, ORACLE_REGION (required); HEALTH_GATE_TIMEOUT_MINUTES,
+#      HEALTH_GATE_POLL_SECONDS, HEALTH_GATE_REQUIRE_LOKI (default true),
+#      MIMIR_HOSTNAME, LOKI_HOSTNAME, NOMAD_ADDR (all optional).
+
+[ -e ./stack-env.sh ] && . ./stack-env.sh
+
+if [ -z "$ENVIRONMENT" ]; then
+  echo "## health-gate: ERROR no ENVIRONMENT set"
+  exit 2
+fi
+
+LOCAL_PATH=$(dirname "${BASH_SOURCE[0]}")
+
+[ -e "$LOCAL_PATH/../sites/$ENVIRONMENT/stack-env.sh" ] && . "$LOCAL_PATH/../sites/$ENVIRONMENT/stack-env.sh"
+[ -e "$LOCAL_PATH/../clouds/all.sh" ] && . "$LOCAL_PATH/../clouds/all.sh"
+[ -e "$LOCAL_PATH/../clouds/oracle.sh" ] && . "$LOCAL_PATH/../clouds/oracle.sh"
+
+if [ -z "$ORACLE_REGION" ]; then
+  echo "## health-gate: ERROR no ORACLE_REGION set"
+  exit 2
+fi
+
+MODE="${1:-post}"
+if [[ "$MODE" != "pre" && "$MODE" != "post" ]]; then
+  echo "## health-gate: ERROR unknown mode '$MODE' (expected pre|post)"
+  exit 2
+fi
+
+[ -z "$HEALTH_GATE_TIMEOUT_MINUTES" ] && HEALTH_GATE_TIMEOUT_MINUTES=15
+[ -z "$HEALTH_GATE_POLL_SECONDS" ] && HEALTH_GATE_POLL_SECONDS=20
+[ -z "$HEALTH_GATE_REQUIRE_LOKI" ] && HEALTH_GATE_REQUIRE_LOKI="true"
+[ -z "$HEALTH_GATE_EXPECTED_REPLICAS" ] && HEALTH_GATE_EXPECTED_REPLICAS=3
+
+[ -z "$LOCAL_REGION" ] && LOCAL_REGION="$OCI_LOCAL_REGION"
+[ -z "$LOCAL_REGION" ] && LOCAL_REGION="us-phoenix-1"
+if [ -z "$NOMAD_ADDR" ]; then
+  export NOMAD_ADDR="https://$ENVIRONMENT-$LOCAL_REGION-nomad.$TOP_LEVEL_DNS_ZONE_NAME"
+fi
+
+[ -z "$MIMIR_HOSTNAME" ] && MIMIR_HOSTNAME="$ENVIRONMENT-$ORACLE_REGION-mimir.$TOP_LEVEL_DNS_ZONE_NAME"
+[ -z "$LOKI_HOSTNAME" ] && LOKI_HOSTNAME="$ENVIRONMENT-$ORACLE_REGION-loki.$TOP_LEVEL_DNS_ZONE_NAME"
+MIMIR_JOB="mimir-$ORACLE_REGION"
+LOKI_JOB="loki-$ORACLE_REGION"
+
+log() { echo "## health-gate[$MODE]: $*"; }
+
+# prints present | missing | error
+job_state() {
+  local out
+  out=$(nomad job status -short "$1" 2>&1)
+  local rc=$?
+  if [[ $rc -eq 0 ]]; then
+    echo present
+  elif echo "$out" | grep -qi 'No job(s) with prefix or ID'; then
+    echo missing
+  else
+    log "nomad job status $1 failed: $out"
+    echo error
+  fi
+}
+
+# running (desired=run, client=running) allocation count for a job
+running_allocs() {
+  nomad job allocs -json "$1" 2>/dev/null | jq -r '[.[] | select(.DesiredStatus=="run" and .ClientStatus=="running")] | length' 2>/dev/null
+}
+
+# dskit ring status page as JSON -> "active not_active total"
+ring_summary() {
+  curl -sf -m 10 -H 'Accept: application/json' "$1" 2>/dev/null \
+    | jq -r '[.shards[]?] | "\(map(select(.state=="ACTIVE"))|length) \(map(select(.state!="ACTIVE"))|length) \(length)"' 2>/dev/null
+}
+
+# N consecutive 200s through the LB so more than one backend is sampled
+ready_ok() {
+  local url="$1" i code
+  for i in 1 2 3; do
+    code=$(curl -s -m 10 -o /dev/null -w '%{http_code}' "$url" 2>/dev/null)
+    [[ "$code" == "200" ]] || { log "$url -> $code"; return 1; }
+  done
+  return 0
+}
+
+# check_cluster <name> <job> <hostname> <ready path> <ring path> -> 0 healthy, 1 not
+check_cluster() {
+  local name="$1" job="$2" host="$3" ready_path="$4" ring_path="$5"
+  local allocs summary active other total
+
+  allocs=$(running_allocs "$job")
+  if [[ -z "$allocs" || "$allocs" -lt "$HEALTH_GATE_EXPECTED_REPLICAS" ]]; then
+    log "$name: ${allocs:-?}/$HEALTH_GATE_EXPECTED_REPLICAS allocs running"
+    return 1
+  fi
+
+  if ! ready_ok "https://$host$ready_path"; then
+    log "$name: $ready_path not 200"
+    return 1
+  fi
+
+  summary=$(ring_summary "https://$host$ring_path")
+  if [[ -z "$summary" ]]; then
+    log "$name: could not read ring at $ring_path"
+    return 1
+  fi
+  read -r active other total <<< "$summary"
+  if [[ "$active" -ne "$HEALTH_GATE_EXPECTED_REPLICAS" || "$other" -ne 0 ]]; then
+    log "$name: ring $active ACTIVE / $other not-active / $total total (want $HEALTH_GATE_EXPECTED_REPLICAS/0)"
+    return 1
+  fi
+  log "$name: $allocs allocs running, $ready_path 200, ring $active/$total ACTIVE"
+  return 0
+}
+
+# one full pass over everything we gate on -> 0 healthy, 1 not healthy, 2 fatal
+check_all() {
+  local healthy=0 state
+
+  state=$(job_state "$MIMIR_JOB")
+  case "$state" in
+    present)
+      check_cluster mimir "$MIMIR_JOB" "$MIMIR_HOSTNAME" /ready /ingester/ring || healthy=1
+      ;;
+    missing)
+      log "mimir: job $MIMIR_JOB not deployed in this region, skipping"
+      ;;
+    *) return 2 ;;
+  esac
+
+  if [[ "$HEALTH_GATE_REQUIRE_LOKI" == "true" ]]; then
+    state=$(job_state "$LOKI_JOB")
+    case "$state" in
+      present)
+        check_cluster loki "$LOKI_JOB" "$LOKI_HOSTNAME" /ready /ring || healthy=1
+        ;;
+      missing)
+        log "loki: job $LOKI_JOB not deployed in this region, skipping"
+        ;;
+      *) return 2 ;;
+    esac
+  fi
+  return $healthy
+}
+
+if [[ "$MODE" == "pre" ]]; then
+  check_all
+  RET=$?
+  if [[ $RET -eq 0 ]]; then
+    log "clusters healthy, rotation may proceed"
+  else
+    log "REFUSING to rotate: metrics/logs cluster is not fully healthy (set HEALTH_GATE=false to override)"
+  fi
+  exit $RET
+fi
+
+# post: poll until healthy or timeout
+DEADLINE=$(( $(date +%s) + HEALTH_GATE_TIMEOUT_MINUTES * 60 ))
+log "waiting up to ${HEALTH_GATE_TIMEOUT_MINUTES}m for mimir/loki to be fully healthy in $ORACLE_REGION"
+while true; do
+  check_all
+  RET=$?
+  if [[ $RET -eq 0 ]]; then
+    log "clusters healthy after wait"
+    exit 0
+  fi
+  if [[ $RET -eq 2 ]]; then
+    log "nomad API unavailable; failing closed"
+    exit 2
+  fi
+  if [[ $(date +%s) -ge $DEADLINE ]]; then
+    log "TIMEOUT after ${HEALTH_GATE_TIMEOUT_MINUTES}m; not rolling on to the next pool"
+    exit 1
+  fi
+  sleep "$HEALTH_GATE_POLL_SECONDS"
+done

--- a/scripts/create-buckets-oracle.sh
+++ b/scripts/create-buckets-oracle.sh
@@ -160,4 +160,10 @@ for ORACLE_REGION in $ORACLE_REGIONS; do
 
   BUCKET_NAME="loki-$ENVIRONMENT"
   create_bucket_if_not_present $BUCKET_NAME $ORACLE_REGION $COMPARTMENT_OCID false Disabled
+
+  # mimir TSDB blocks + ruler/alertmanager state (one bucket per region, same name in every
+  # region, like loki). No lifecycle policy and no versioning on purpose: the mimir compactor owns
+  # retention (limits.compactor_blocks_retention_period) and churns objects constantly.
+  BUCKET_NAME="mimir-$ENVIRONMENT"
+  create_bucket_if_not_present $BUCKET_NAME $ORACLE_REGION $COMPARTMENT_OCID false Disabled
 done

--- a/scripts/deploy-nomad-alloy.sh
+++ b/scripts/deploy-nomad-alloy.sh
@@ -11,6 +11,7 @@ LOCAL_PATH=$(dirname "${BASH_SOURCE[0]}")
 [ -e "$LOCAL_PATH/../sites/$ENVIRONMENT/stack-env.sh" ] && . "$LOCAL_PATH/../sites/$ENVIRONMENT/stack-env.sh"
 [ -e "$LOCAL_PATH/../clouds/all.sh" ] && . "$LOCAL_PATH/../clouds/all.sh"
 [ -e "$LOCAL_PATH/../clouds/oracle.sh" ] && . "$LOCAL_PATH/../clouds/oracle.sh"
+[ -z "$MAIN_CONFIGURATION_FILE" ] && MAIN_CONFIGURATION_FILE="$LOCAL_PATH/../config/vars.yml"
 
 if [ -z "$ORACLE_REGION" ]; then
     echo "No ORACLE_REGION set, exiting"
@@ -38,6 +39,30 @@ if [[ "$ENVIRONMENT_TYPE" = "prod" ]]; then
     export NOMAD_VAR_environment_type="prod"
 else
     export NOMAD_VAR_environment_type="nonprod"
+fi
+
+# ---- metrics pipeline (doc/mimir-cluster-plan.md Phase 2); override per env in stack-env.sh ----
+# write metrics to the regional mimir-cluster (deploy it first: scripts/deploy-nomad-mimir.sh)
+[ -z "$ALLOY_ENABLE_MIMIR_WRITE" ] && ALLOY_ENABLE_MIMIR_WRITE="false"
+export NOMAD_VAR_enable_mimir_write="$ALLOY_ENABLE_MIMIR_WRITE"
+# keep relaying OTLP metrics to the legacy regional prometheus (off at cutover)
+[ -z "$ALLOY_ENABLE_LEGACY_PROMETHEUS_WRITE" ] && ALLOY_ENABLE_LEGACY_PROMETHEUS_WRITE="true"
+export NOMAD_VAR_enable_legacy_prometheus_write="$ALLOY_ENABLE_LEGACY_PROMETHEUS_WRITE"
+# take over the consul-SD scrape jobs from prometheus.hcl
+[ -z "$ALLOY_ENABLE_SCRAPE" ] && ALLOY_ENABLE_SCRAPE="false"
+export NOMAD_VAR_enable_scrape="$ALLOY_ENABLE_SCRAPE"
+# primary | ha | none -- how scraped streams reach the external 8x8 Mimir (see alloy.hcl)
+[ -z "$ALLOY_EXTERNAL_SCRAPE_FORWARD" ] && ALLOY_EXTERNAL_SCRAPE_FORWARD="primary"
+export NOMAD_VAR_external_scrape_forward="$ALLOY_EXTERNAL_SCRAPE_FORWARD"
+
+# alloy-syntax equivalents of prometheus_custom_relabels / prometheus_custom_external_labels
+ALLOY_CUSTOM_RELABEL_RULES=$(cat $MAIN_CONFIGURATION_FILE | yq eval ".alloy_custom_relabel_rules")
+if [[ "$ALLOY_CUSTOM_RELABEL_RULES" != "null" ]]; then
+    export NOMAD_VAR_custom_relabel_rules="$ALLOY_CUSTOM_RELABEL_RULES"
+fi
+ALLOY_CUSTOM_EXTERNAL_LABELS=$(cat $MAIN_CONFIGURATION_FILE | yq eval ".alloy_custom_external_labels")
+if [[ "$ALLOY_CUSTOM_EXTERNAL_LABELS" != "null" ]]; then
+    export NOMAD_VAR_custom_external_labels="$ALLOY_CUSTOM_EXTERNAL_LABELS"
 fi
 
 sed -e "s/\[JOB_NAME\]/$JOB_NAME/" "$NOMAD_JOB_PATH/alloy.hcl" | nomad job run -var="dc=$NOMAD_DC" -

--- a/scripts/deploy-nomad-cloudprober.sh
+++ b/scripts/deploy-nomad-cloudprober.sh
@@ -54,6 +54,8 @@ CLOUDPROBER_ENABLE_PROMETHEUS="true"
 CLOUDPROBER_ENABLE_WAVEFRONT_PROXY="false"
 CLOUDPROBER_ENABLE_LATENCY="true"
 CLOUDPROBER_ENABLE_ALLOY="false"
+# set CLOUDPROBER_ENABLE_MIMIR=true in sites/$ENVIRONMENT/stack-env.sh once the region runs mimir-cluster
+[ -z "$CLOUDPROBER_ENABLE_MIMIR" ] && CLOUDPROBER_ENABLE_MIMIR="false"
 
 # init generic probes used by specific environments
 CLOUDPROBER_ENABLE_AUTOSCALER="false"
@@ -116,6 +118,7 @@ enable_alert_emailer=$CLOUDPROBER_ENABLE_ALERT_EMAILER
 enable_vault=$CLOUDPROBER_ENABLE_VAULT
 enable_canary=$CLOUDPROBER_ENABLE_LATENCY
 enable_alloy=$CLOUDPROBER_ENABLE_ALLOY
+enable_mimir=$CLOUDPROBER_ENABLE_MIMIR
 EOF
 
 RENDER_DIR="/tmp/cloudprober-render-$$"

--- a/scripts/deploy-nomad-mimir.sh
+++ b/scripts/deploy-nomad-mimir.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Deploys the per-region Mimir cluster (nomad/mimir-cluster.hcl) and its CNAME.
+# Pattern from deploy-nomad-loki.sh. Object-storage credentials come from the
+# dedicated Vault kv secret/default/mimir/s3 (read by the job template, tempo
+# pattern), NOT from nomad_s3fs_credentials.
+#
+# Prerequisites (Phase 0 of doc/mimir-cluster-plan.md):
+#   - terraform/volumes-mimir applied and the consul nodes rotated so
+#     /mnt/bv/mimir-N is mounted and registered as nomad host volume mimir-N
+#   - bucket mimir-$ENVIRONMENT exists in the region (scripts/create-buckets-oracle.sh)
+#   - Vault kv secret/default/mimir/s3 with access_key / secret_key scoped to that bucket
+#   - consul NSG allows 7947/tcp+udp (terraform/consul-server)
+
+if [ -z "$ENVIRONMENT" ]; then
+    echo "No ENVIRONMENT set, exiting"
+    exit 2
+fi
+
+LOCAL_PATH=$(dirname "${BASH_SOURCE[0]}")
+
+[ -e "$LOCAL_PATH/../sites/$ENVIRONMENT/stack-env.sh" ] && . "$LOCAL_PATH/../sites/$ENVIRONMENT/stack-env.sh"
+
+[ -e "$LOCAL_PATH/../clouds/all.sh" ] && . "$LOCAL_PATH/../clouds/all.sh"
+[ -e "$LOCAL_PATH/../clouds/oracle.sh" ] && . "$LOCAL_PATH/../clouds/oracle.sh"
+
+if [ -z "$ORACLE_REGION" ]; then
+    echo "No ORACLE_REGION set, exiting"
+    exit 2
+fi
+
+[ -z "$LOCAL_REGION" ] && LOCAL_REGION="$OCI_LOCAL_REGION"
+[ -z "$LOCAL_REGION" ] && LOCAL_REGION="us-phoenix-1"
+
+if [ -z "$NOMAD_ADDR" ]; then
+    export NOMAD_ADDR="https://$ENVIRONMENT-$LOCAL_REGION-nomad.$TOP_LEVEL_DNS_ZONE_NAME"
+fi
+
+[ -z "$MIMIR_HOSTNAME" ] && MIMIR_HOSTNAME="$ENVIRONMENT-$ORACLE_REGION-mimir.$TOP_LEVEL_DNS_ZONE_NAME"
+
+NOMAD_JOB_PATH="$LOCAL_PATH/../nomad"
+NOMAD_DC="$ENVIRONMENT-$ORACLE_REGION"
+export NOMAD_VAR_mimir_hostname="${MIMIR_HOSTNAME}"
+export NOMAD_VAR_oracle_s3_namespace="$ORACLE_S3_NAMESPACE"
+JOB_NAME="mimir-$ORACLE_REGION"
+
+[ -z "$ENVIRONMENT_TYPE" ] && ENVIRONMENT_TYPE="dev"
+if [[ "$ENVIRONMENT_TYPE" = "prod" ]]; then
+    export NOMAD_VAR_environment_type="prod"
+else
+    export NOMAD_VAR_environment_type="nonprod"
+fi
+
+# optional per-environment overrides (sites/$ENVIRONMENT/stack-env.sh)
+[ -n "$MIMIR_VERSION" ] && export NOMAD_VAR_mimir_version="$MIMIR_VERSION"
+[ -n "$MIMIR_RETENTION_PERIOD" ] && export NOMAD_VAR_retention_period="$MIMIR_RETENTION_PERIOD"
+[ -n "$MIMIR_MAX_GLOBAL_SERIES" ] && export NOMAD_VAR_max_global_series_per_user="$MIMIR_MAX_GLOBAL_SERIES"
+[ -n "$MIMIR_INGESTION_RATE" ] && export NOMAD_VAR_ingestion_rate="$MIMIR_INGESTION_RATE"
+[ -n "$MIMIR_INGESTION_BURST_SIZE" ] && export NOMAD_VAR_ingestion_burst_size="$MIMIR_INGESTION_BURST_SIZE"
+
+sed -e "s/\[JOB_NAME\]/$JOB_NAME/" "$NOMAD_JOB_PATH/mimir-cluster.hcl" | nomad job run -var="dc=$NOMAD_DC" -
+
+if [ $? -ne 0 ]; then
+    echo "Failed to run nomad mimir job, exiting"
+    exit 5
+fi
+
+export RESOURCE_NAME_ROOT="${ENVIRONMENT}-${ORACLE_REGION}-mimir"
+
+export CNAME_VALUE="$RESOURCE_NAME_ROOT"
+export STACK_NAME="${RESOURCE_NAME_ROOT}-cname"
+export UNIQUE_ID="${RESOURCE_NAME_ROOT}"
+export CNAME_TARGET="${ENVIRONMENT}-${ORACLE_REGION}-nomad-pool-general-internal.${DEFAULT_DNS_ZONE_NAME}"
+export CNAME_VALUE="${RESOURCE_NAME_ROOT}"
+$LOCAL_PATH/create-oracle-cname-stack.sh

--- a/scripts/deploy-nomad-prometheus.sh
+++ b/scripts/deploy-nomad-prometheus.sh
@@ -55,6 +55,13 @@ if [ "$PROMETHEUS_AUTOSCALER_ALERTS" == "true" ]; then
     export NOMAD_VAR_autoscaler_alerts="true"
 fi
 
+# a mimir cluster is deployed in this environment (scripts/deploy-nomad-mimir.sh):
+# scrape it and evaluate the mimir_alerts group
+[ -z "$PROMETHEUS_MIMIR_ALERTS" ] && PROMETHEUS_MIMIR_ALERTS="false"
+if [ "$PROMETHEUS_MIMIR_ALERTS" == "true" ]; then
+    export NOMAD_VAR_mimir_alerts="true"
+fi
+
 PROMETHEUS_CUSTOM_ALERTS=$(cat $ENVIRONMENT_CONFIGURATION_FILE | yq eval ".prometheus_custom_alerts")
 if [[ "$PROMETHEUS_CUSTOM_ALERTS" != "null" ]]; then
     export NOMAD_VAR_custom_alerts="$PROMETHEUS_CUSTOM_ALERTS"

--- a/scripts/rotate-consul-oracle.sh
+++ b/scripts/rotate-consul-oracle.sh
@@ -88,6 +88,15 @@ fi
 # by default wait 5 minutes in between rotating consul instances
 [ -z "$STARTUP_GRACE_PERIOD_SECONDS" ] && STARTUP_GRACE_PERIOD_SECONDS=150
 
+# Mimir/Loki health gates (doc/mimir-cluster-plan.md 5a). Each consul node carries a
+# mimir-N ingester and a loki-N instance; the next pool is only rotated once the
+# replacement node's allocs have re-attached their volumes and rejoined the rings.
+# HEALTH_GATE=false falls back to the blind sleep (disaster recovery when the gate
+# can never pass).
+[ -z "$HEALTH_GATE" ] && HEALTH_GATE="true"
+[ -z "$HEALTH_GATE_TIMEOUT_MINUTES" ] && HEALTH_GATE_TIMEOUT_MINUTES=15
+export HEALTH_GATE HEALTH_GATE_TIMEOUT_MINUTES
+
 # iterate across the three instance pools
 for x in {a..c}; do
   INSTANCE_POOL_NAME=$INSTANCE_POOL_BASE_NAME-$x
@@ -129,7 +138,17 @@ for x in {a..c}; do
     exit $RET
   fi
 
-  if [[ "$x" != "c" ]]; then
+  if [[ "$HEALTH_GATE" == "true" ]]; then
+    # gate on the new node's mimir/loki allocs being healthy before touching the next pool
+    # (also after pool c, so the job ends with a proven-healthy cluster)
+    echo "## health gate: waiting for mimir/loki to be fully healthy after rotating $INSTANCE_POOL_NAME (timeout ${HEALTH_GATE_TIMEOUT_MINUTES}m)"
+    $LOCAL_PATH/consul-metrics-health-gate.sh post
+    RET=$?
+    if [[ $RET -gt 0 ]]; then
+      echo "## ERROR: health gate failed after rotating $INSTANCE_POOL_NAME; NOT rotating further pools"
+      exit $RET
+    fi
+  elif [[ "$x" != "c" ]]; then
     # there is only one instance per pool so this sleep has to be outside of the rotate-instance-pool-oracle loop
     echo "sleeping for $STARTUP_GRACE_PERIOD_SECONDS seconds to allow for consul to come up"
     sleep $STARTUP_GRACE_PERIOD_SECONDS

--- a/scripts/rotate-consul-pre-detach.sh
+++ b/scripts/rotate-consul-pre-detach.sh
@@ -8,6 +8,22 @@ else
   echo "## will ssh as $SSH_USER"
 fi
 
+LOCAL_PATH=$(dirname "${BASH_SOURCE[0]}")
+
+# Never take a consul node (and its mimir-N / loki-N allocs) down while the metrics
+# or logs cluster is already degraded: that would take mimir from 3/3 to 1/3 and
+# lose write quorum. This script is sourced by rotate-instance-pool-oracle.sh, so
+# exit here aborts the whole rotation before anything has been drained.
+if [[ "${HEALTH_GATE:-true}" == "true" ]]; then
+    echo "## rotate-consul-pre-detach: running mimir/loki health gate before draining $INSTANCE_ID"
+    $LOCAL_PATH/consul-metrics-health-gate.sh pre
+    RET=$?
+    if [[ $RET -gt 0 ]]; then
+        echo "## ERROR: rotate-consul-pre-detach: health gate failed (code $RET); aborting rotation. Set HEALTH_GATE=false to override."
+        exit $RET
+    fi
+fi
+
 echo "## rotate-consul-pre-detch: getting private IP"
 INSTANCE_PRIMARY_PRIVATE_IP=$(oci compute instance list-vnics --region $ORACLE_REGION --instance-id $INSTANCE_ID | jq -r '.data[] | select(.["is-primary"] == true) | .["private-ip"]')
 if [ "$INSTANCE_PRIMARY_PRIVATE_IP" == "null" ]; then

--- a/terraform/consul-server/create-consul-server-oracle.tf
+++ b/terraform/consul-server/create-consul-server-oracle.tf
@@ -320,6 +320,39 @@ resource "oci_core_network_security_group_security_rule" "consul_nsg_rule_loki_g
   }
 }
 
+# mimir-cluster memberlist gossip. Loki already owns static 7946 on the same consul nodes, so
+# mimir gossips on its own static port 7947 (nomad/mimir-cluster.hcl). memberlist uses TCP for
+# push/pull and UDP for probes, so open both.
+resource "oci_core_network_security_group_security_rule" "consul_nsg_rule_mimir_gossip_tcp" {
+  network_security_group_id = oci_core_network_security_group.consul_security_group.id
+  direction = "INGRESS"
+  protocol = "6"
+  source = data.oci_core_vcns.vcns.virtual_networks[0].cidr_block
+  stateless = false
+
+  tcp_options {
+    destination_port_range {
+      max = 7947
+      min = 7947
+    }
+  }
+}
+
+resource "oci_core_network_security_group_security_rule" "consul_nsg_rule_mimir_gossip_udp" {
+  network_security_group_id = oci_core_network_security_group.consul_security_group.id
+  direction = "INGRESS"
+  protocol = "17"
+  source = data.oci_core_vcns.vcns.virtual_networks[0].cidr_block
+  stateless = false
+
+  udp_options {
+    destination_port_range {
+      max = 7947
+      min = 7947
+    }
+  }
+}
+
 resource "oci_core_instance_configuration" "oci_instance_configuration_a" {
   compartment_id = var.compartment_ocid
   display_name = var.instance_config_name

--- a/terraform/volumes-mimir/create-volumes-mimir-oracle.sh
+++ b/terraform/volumes-mimir/create-volumes-mimir-oracle.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+set -x #echo on
+
+#IF THE CURRENT DIRECTORY HAS stack-env.sh THEN INCLUDE IT
+[ -e ./stack-env.sh ] && . ./stack-env.sh
+
+if [ -z "$ENVIRONMENT" ]; then
+  echo "No ENVIRONMENT found. Exiting..."
+  exit 203
+fi
+
+[ -e ./sites/$ENVIRONMENT/stack-env.sh ] && . ./sites/$ENVIRONMENT/stack-env.sh
+
+# e.g. /terraform/standalone
+LOCAL_PATH=$(dirname "${BASH_SOURCE[0]}")
+
+#pull in cloud-specific variables, e.g. tenancy
+[ -e "$LOCAL_PATH/../../clouds/oracle.sh" ] && . $LOCAL_PATH/../../clouds/oracle.sh
+
+if [ -z "$ORACLE_REGION" ]; then
+  echo "No ORACLE_REGION found.  Exiting..."
+  exit 203
+fi
+
+ORACLE_CLOUD_NAME="$ORACLE_REGION-$ENVIRONMENT-oracle"
+[ -e "$LOCAL_PATH/../../${ORACLE_CLOUD_NAME}.sh" ] && . $LOCAL_PATH/../../clouds/${ORACLE_CLOUD_NAME}.sh
+
+[ -z "$S3_PROFILE" ] && S3_PROFILE="oracle"
+[ -z "$S3_STATE_BUCKET" ] && S3_STATE_BUCKET="tf-state-$ENVIRONMENT"
+[ -z "$S3_ENDPOINT" ] && S3_ENDPOINT="https://$ORACLE_S3_NAMESPACE.compat.objectstorage.$ORACLE_REGION.oraclecloud.com"
+
+S3_STATE_BASE="$ENVIRONMENT/volumes-mimir"
+[ -z "$S3_STATE_KEY" ] && S3_STATE_KEY="${S3_STATE_BASE}/terraform.tfstate"
+
+TERRAFORM_MAJOR_VERSION=$(terraform -v | head -1  | awk '{print $2}' | cut -d'.' -f1)
+TF_GLOBALS_CHDIR=
+if [[ "$TERRAFORM_MAJOR_VERSION" == "v1" ]]; then
+  TF_GLOBALS_CHDIR="-chdir=$LOCAL_PATH"
+  TF_CLI_ARGS=""
+  TF_POST_PARAMS=
+else
+  TF_POST_PARAMS="$LOCAL_PATH"
+fi
+#The —reconfigure option disregards any existing configuration, preventing migration of any existing state
+terraform $TF_GLOBALS_CHDIR init \
+    -backend-config="bucket=$S3_STATE_BUCKET" \
+    -backend-config="key=$S3_STATE_KEY" \
+    -backend-config="region=$ORACLE_REGION" \
+    -backend-config="profile=$S3_PROFILE" \
+    -backend-config="endpoint=$S3_ENDPOINT" \
+    -reconfigure $TF_POST_PARAMS
+    
+
+[ -z "$ACTION" ] && ACTION="apply"
+
+if [[ "$ACTION" == "apply" ]]; then
+  ACTION_POST_PARAMS="-auto-approve"
+fi
+if [[ "$ACTION" == "import" ]]; then
+  ACTION_POST_PARAMS="$1 $2"
+fi
+
+terraform $TF_GLOBALS_CHDIR $ACTION \
+  -var="oracle_region=$ORACLE_REGION"\
+  -var="tenancy_ocid=$TENANCY_OCID"\
+  -var="compartment_ocid=$COMPARTMENT_OCID"\
+  -var="environment=$ENVIRONMENT"\
+  $ACTION_POST_PARAMS $TF_POST_PARAMS

--- a/terraform/volumes-mimir/volumes-mimir.tf
+++ b/terraform/volumes-mimir/volumes-mimir.tf
@@ -1,0 +1,90 @@
+variable "volume_count" {
+    type = number
+    default = 3
+    description = "count of volumes"
+}
+
+variable "volume_size_in_gbs" {
+    type = number
+    default = 100
+}
+
+variable "tenancy_ocid" {}
+variable "compartment_ocid" {}
+variable "oracle_region" {}
+variable "environment" {}
+variable "tag_namespace" {
+    type = string
+    default = "jitsi"
+}
+
+provider "oci" {
+  region = var.oracle_region
+  tenancy_ocid = var.tenancy_ocid
+}
+
+
+terraform {
+  backend "s3" {
+    skip_region_validation = true
+    skip_credentials_validation = true
+    skip_metadata_api_check = true
+    force_path_style = true
+  }
+  required_providers {
+      oci = {
+          source  = "oracle/oci"
+      }
+  }
+}
+
+data "oci_identity_availability_domains" "availability_domains" {
+	#Required
+	compartment_id = var.tenancy_ocid
+}
+
+resource "oci_core_volume" "mimir-volume" {
+    count             = var.volume_count
+
+    #Required
+    compartment_id = var.compartment_ocid
+
+    #Optional
+    # autotune_policies {
+    #     #Required
+    #     autotune_type = var.volume_autotune_policies_autotune_type
+
+    #     #Optional
+    #     max_vpus_per_gb = var.volume_autotune_policies_max_vpus_per_gb
+    # }
+    availability_domain = data.oci_identity_availability_domains.availability_domains.availability_domains[count.index%length(data.oci_identity_availability_domains.availability_domains.availability_domains)].name
+
+    # backup_policy_id = data.oci_core_volume_backup_policies.test_volume_backup_policies.volume_backup_policies.0.id
+    # block_volume_replicas {
+    #     #Required
+    #     availability_domain = var.volume_block_volume_replicas_availability_domain
+
+    #     #Optional
+    #     display_name = var.volume_block_volume_replicas_display_name
+    # }
+    defined_tags = {"${var.tag_namespace}.environment" = var.environment}
+    display_name = "mimir-volume-${count.index}"
+    freeform_tags = {
+        "volume-index" = "${count.index}"
+        "volume-type" = "mimir"
+        "volume-role" = "consul"
+    }
+
+    # is_auto_tune_enabled = var.volume_is_auto_tune_enabled
+    # kms_key_id = oci_kms_key.test_key.id
+    size_in_gbs = var.volume_size_in_gbs
+    # size_in_mbs = var.volume_size_in_mbs
+    # source_details {
+    #     #Required
+    #     id = var.volume_source_details_id
+    #     type = var.volume_source_details_type
+    # }
+    # vpus_per_gb = var.volume_vpus_per_gb
+    # block_volume_replicas_deletion = true
+
+}


### PR DESCRIPTION
Implements [doc/mimir-cluster-plan.md](doc/mimir-cluster-plan.md) (JIT-16016) after a risk review of the plan. **Nothing is deployed by this PR**; every new behaviour is behind a flag that defaults off, so merging is safe for all environments. Rollout order is section 9 of the plan; operations are in [doc/mimir-runbook.md](doc/mimir-runbook.md).

Companion: jitsi/infra-customizations-private#1099 (`config/vars.yml` alloy_custom_* keys). Merge order does not matter; the deploy script tolerates the keys being absent.

## Review findings fixed (plan section "Review", R1-R13)

- **R1 HA dedup would drop OTLP + alloy self metrics.** Mimir's HA tracker judges a push request by its first series. Alloy now has separate writers for HA-labelled scrape streams (`mimir_ha`, `external_ha`) and direct streams (`mimir`, `external`); `limits.accept_ha_samples: true` (the plan omitted it, which would have doubled every scraped series).
- **R2/R3 external 8x8 Mimir.** Alloy already writes there with its own Vault secret, so that writer is reused. Scraped streams go out in `primary` mode (alloc 0 only, no HA labels) until the tenant's HA dedup is confirmed; deleting prometheus.hcl's `remote_write` is gated on proving both Vault secrets hit the same tenant, so it is *not* in this PR.
- **R4 ingester restart loop.** `check_restart` grace 10m (WAL replay), deploy deadlines 10m/15m.
- **R5/R13 3.x config paths.** Retention and ruler alertmanager URL live under `limits`; tokens files at the volume root; `bucket_lookup_type: path` for OCI; every ring gets `instance_addr` from Nomad (the 3.x querier lifecycler auto-detects `eth0`/`en0` and refuses to start on OCI's `ens3`).
- **Version.** 3.1.5 instead of the stale 3.1.2; 3.2 is the first N->N+1 upgrade after soak.
- Also: `vault`/`template` change_mode `noop` so a credential rotation or alertmanager move cannot bounce all three ingesters at once (R6); rotation gates skip undeployed jobs and fail closed on nomad API errors (R7); 7947 opened for TCP **and** UDP with a memberlist cluster label (R8); non-default ingestion limits (R9); `Mimir_Down` gated so it cannot page regions without Mimir (R10); ring ids pinned but memberlist node names left host-unique (R12).

## What is in the PR

New
- `nomad/mimir-cluster.hcl`: 3-replica monolithic Mimir 3.1.5, RF=3 zone-aware, stable ring ids `mimir-N` with tokens on the host volume, HA tracker in consul KV, S3 creds from Vault `secret/default/mimir/s3`, gossip on 7947
- `scripts/deploy-nomad-mimir.sh`, `jenkins/jobs/provision-nomad-mimir.yaml`, `release-nomad-mimir` job + pipeline
- `scripts/consul-metrics-health-gate.sh`: pre/post consul-rotation gate on mimir/loki rings + readiness
- `terraform/volumes-mimir/`: 3x100 GB block volumes, consul role, indexed
- `grafana/dashboards/mimir-{overview,writes,reads,ruler-compactor}.json`
- `doc/mimir-runbook.md`

Changed
- `nomad/alloy.hcl`: consul-SD scrape jobs, split direct/HA writers, `external_scrape_forward` primary|ha|none, 512 MHz / 1.5 GB. Flags: `ALLOY_ENABLE_MIMIR_WRITE`, `ALLOY_ENABLE_SCRAPE`, `ALLOY_ENABLE_LEGACY_PROMETHEUS_WRITE`, `ALLOY_EXTERNAL_SCRAPE_FORWARD`
- `nomad/prometheus.hcl`: `mimir` scrape job + 15-rule `mimir_alerts` group behind `PROMETHEUS_MIMIR_ALERTS`
- `scripts/rotate-consul-*.sh`, `rotate-consul` Jenkins job: health gates replace the blind `sleep 150`; `HEALTH_GATE` / `HEALTH_GATE_TIMEOUT_MINUTES` params
- `terraform/consul-server`: NSG rules 7947 tcp+udp
- `scripts/create-buckets-oracle.sh`: `mimir-$ENVIRONMENT` bucket
- cloudprober pack: `enable_mimir` readiness + synthetic query probes (`CLOUDPROBER_ENABLE_MIMIR`)
- `grafana/dashboards/alloy-monitor.json`: scrape + per-endpoint remote-write rows
- `doc/mimir-cluster-plan.md`: review section, corrected config sketch, status per file

## Validation

- `nomad job validate` on mimir-cluster, alloy and prometheus job files
- all 48 alloy flag combinations rendered and passed `alloy validate` in the official image
- Mimir 3.1.5 booted on the rendered config: strict YAML parse clean, all modules initialise up to the object-storage sanity check (dummy creds)
- rendered alert rules pass `promtool check rules` (88 rules)

## Before first deploy (per environment, manual)

Mint Vault `secret/default/mimir/s3`, apply `terraform/volumes-mimir`, run `create-buckets-oracle.sh`, rotate the consul pool (attaches volumes, applies the NSG rules), then `provision-nomad-mimir` on lonely.
