### PR TITLE
JIT-16385: run autoscaler as node and hand it readable OCI secrets

### DIFF
--- a/nomad/jitsi_packs/packs/jitsi_autoscaler/templates/jitsi_autoscaler.nomad.tpl
+++ b/nomad/jitsi_packs/packs/jitsi_autoscaler/templates/jitsi_autoscaler.nomad.tpl
@@ -129,6 +129,11 @@ job [[ template "job_name" . ]] {
 [[ end ]]
       driver = "docker"
 
+      # The image declares `USER node` (uid/gid 1000). Pinned here so the
+      # uid/gid on the secrets templates below stay tied to something visible
+      # in the jobspec rather than silently tracking the base image.
+      user = "node"
+
       config {
         image = "jitsi/autoscaler:[[ var "version" . ]]"
         ports = ["http"]
@@ -182,6 +187,8 @@ job [[ template "job_name" . ]] {
 EOF
         destination = "secrets/oci_api_key.pem"
         perms = "600"
+        uid = 1000
+        gid = 1000
       }
 
       template {
@@ -199,6 +206,8 @@ region={{ .Data.data.region }}
 EOF
         destination = "secrets/oci.config"
         perms = "600"
+        uid = 1000
+        gid = 1000
       }
 
       template {


### PR DESCRIPTION
Tracked by [JIT-16385](https://agile.8x8.com/browse/JIT-16385).

## What broke

jitsi-autoscaler `sha-81e134e` ([JIT-16014](https://agile.8x8.com/browse/JIT-16014), jitsi/jitsi-autoscaler#189) added `USER node` (uid/gid 1000) to the Dockerfile. Rolled out to `beta-meet-jit-si` on 2026-09-09 ~08:41 UTC, the container died ~1.1s after start in all three regions:

```
Error: EACCES: permission denied, open '/secrets/oci.config'
    at ConfigFileReader.parseFileFromPath (oci-common/lib/config-file-reader.js:70:38)
    at new ConfigFileAuthenticationDetailsProvider (oci-common/lib/auth/config-file-auth.js:39:93)
    at new OracleInstanceManager (/usr/src/app/oracle_instance_manager.js:133:25)
    at Object.<anonymous> (/usr/src/app/app.js:233:22)
```

That's the `CloudManager` constructor at process boot — the app failing to read its own mounted credentials, not an OCI capacity problem. Nomad burned 2 restarts per alloc, marked them Unhealthy and rescheduled (1 failed alloc in us-phoenix-1, 3 in uk-london-1, 4 in us-ashburn-1); `sha-81e134e` never completed a startup cycle anywhere, and `auto_revert` rolled all three jobs back. No user-facing impact — the pre-existing allocs were never interrupted.

## The fix

Nomad writes both secret templates with `perms = "600"` and no `uid`/`gid`, so they land root-owned. Confirmed against a live alloc that the directory was never the issue:

```
$ nomad alloc fs 147dd7fe autoscaler/
drwxrwxrwx   secrets/          <- 0777, traversal is fine for uid 1000
$ nomad alloc fs 147dd7fe autoscaler/secrets
-rw-------   oci.config        <- root:root, the actual blocker
-rw-------   oci_api_key.pem   <- same
```

So: `uid = 1000` / `gid = 1000` on both templates, `perms` unchanged at `600` — still owner-only, just owned by `node`. Both files are needed, since `oci.config` carries `key_file=/secrets/oci_api_key.pem` and fixing only the first would move the EACCES down one line. Same pattern already in use in `nomad/transcriber.hcl`.

`user = "node"` on the task isn't strictly required — the image declares it — but it keeps the uid/gid tied to something visible in the jobspec instead of silently tracking the base image, which is how this broke in the first place.

## Verification

```
$ nomad-pack render --name autoscaler-test --var enable_oci=true ... 
      user = "node"
        destination = "secrets/oci_api_key.pem"
        perms       = "600"
        uid         = 1000
        gid         = 1000
$ nomad job validate rendered.nomad
Job validation successful
```

## Not in this PR

- uk-london-1 and us-ashburn-1 reverted to image `0.1.0`, not the Aug-27 `sha-1ccdf96` that us-phoenix-1 landed on — neither job had been redeployed since March, so the retry is a bigger version jump there than it looks. Worth watching those two.
- Autoscaler allocs keep drifting onto `consul`-pool nodes: the group `constraint` permits `consul,general` and the general preference is only a `-100` affinity, so with 2 general nodes per region carrying 6–19 allocs against 3 freshly-rotated consul nodes carrying 4–7, binpack plus the `spread` over `node.unique.id` out-score it. Needs a hard constraint or general-pool headroom.
- Companion chart fix in jitsi-k8s: see the linked PR on JIT-16385.
