### PR TITLE
JIT-16092: add scripts/verify-nomad-gitea-mirror.sh

### DIFF
--- a/scripts/verify-nomad-gitea-mirror.sh
+++ b/scripts/verify-nomad-gitea-mirror.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Verifies a deployed Gitea mirror the way a booting VM would: the credential
+# from the environment's boot bucket, against EACH replica directly (replicas
+# have independent databases, so the Fabio hostname only ever tests one).
+# Usage: ENVIRONMENT=stage-8x8 ORACLE_REGION=us-phoenix-1 scripts/verify-nomad-gitea-mirror.sh
+# Exits non-zero if any check fails on any replica. See JIT-16092.
+[ -z "$ENVIRONMENT" ] && { echo "No ENVIRONMENT set"; exit 2; }
+[ -z "$ORACLE_REGION" ] && { echo "No ORACLE_REGION set"; exit 2; }
+[ -z "$LOCAL_REGION" ] && LOCAL_REGION="us-phoenix-1"
+[ -z "$NOMAD_ADDR" ] && export NOMAD_ADDR="https://$ENVIRONMENT-$LOCAL_REGION-nomad.jitsi.net"
+[ -z "$JOB" ] && JOB="gitea-mirror-$ORACLE_REGION"
+[ -z "$PRIVATE_REPO" ] && PRIVATE_REPO="infra-customizations-private"
+[ -z "$PUBLIC_REPO" ] && PUBLIC_REPO="infra-provisioning"
+# Shallow: this runs once per region and a full clone of the private repo takes
+# ~80s against a warm replica. Auth happens at the same point either way.
+SHALLOW="--depth 1 --no-tags"
+H=$(mktemp -d); trap 'rm -rf "$H"' EXIT
+oci os object get -bn "jvb-bucket-$ENVIRONMENT" --region "$ORACLE_REGION" --name gitea-read-user --file "$H/c.json" >/dev/null 2>&1 \
+  || { echo "no gitea-read-user in jvb-bucket-$ENVIRONMENT ($ORACLE_REGION); run publish-gitea-read-user-bucket.sh"; exit 1; }
+U=$(jq -r .username "$H/c.json"); P=$(jq -r .password "$H/c.json"); rm -f "$H/c.json"
+echo "$ENVIRONMENT $ORACLE_REGION, credential user $U"
+RET=0
+for a in $(nomad job allocs -json "$JOB" | jq -r '.[] | select(.ClientStatus=="running") | .ID'); do
+  addr=$(nomad alloc status -json "$a" | jq -r '.AllocatedResources.Shared.Ports[] | select(.Label=="http") | "\(.HostIP):\(.Value)"')
+  health=$(nomad alloc status -json "$a" | jq -r '.AllocatedResources.Shared.Ports[] | select(.Label=="health") | "\(.HostIP):\(.Value)"')
+  echo "== ${a:0:8} on $(nomad alloc status -json "$a" | jq -r .NodeName) at $addr"
+  printf '  anonymous private API (want 404): %s\n' "$(curl -s -m 10 -o /dev/null -w '%{http_code}' "http://$addr/api/v1/repos/jitsi/$PRIVATE_REPO")"
+  rm -rf "$H/anon"; if GIT_TERMINAL_PROMPT=0 git clone -q $SHALLOW "http://$addr/jitsi/$PRIVATE_REPO.git" "$H/anon" >/dev/null 2>&1; then echo "  anonymous private clone:          SUCCEEDED (BAD)"; RET=1; else echo "  anonymous private clone:          refused (good)"; fi
+  printf 'machine %s login %s password %s\n' "${addr%%:*}" "$U" "$P" > "$H/.netrc"; chmod 600 "$H/.netrc"
+  rm -rf "$H/priv"; if HOME="$H" GIT_TERMINAL_PROMPT=0 git clone -q $SHALLOW "http://$addr/jitsi/$PRIVATE_REPO.git" "$H/priv" >/dev/null 2>&1; then echo "  netrc private clone:              ok ($(git -C "$H/priv" rev-parse --short HEAD))"; else echo "  netrc private clone:              FAILED"; RET=1; fi
+  rm -rf "$H/pub"; if GIT_TERMINAL_PROMPT=0 git clone -q $SHALLOW "http://$addr/jitsi/$PUBLIC_REPO.git" "$H/pub" >/dev/null 2>&1; then echo "  anonymous public clone:           ok"; else echo "  anonymous public clone:           FAILED"; RET=1; fi
+  if [ -d "$H/priv" ]; then (cd "$H/priv" && git -c user.email=x@y -c user.name=x commit -q --allow-empty -m x >/dev/null 2>&1 && HOME="$H" git push -q origin HEAD:refs/heads/verify-push-test >/dev/null 2>&1) && { echo "  netrc push (want refused):        SUCCEEDED (BAD)"; RET=1; } || echo "  netrc push (want refused):        refused (good)"; fi
+  echo "  gate ready=$(curl -s -m 5 -o /dev/null -w '%{http_code}' "http://$health/ready")  $(curl -s -m 5 "http://$health/metrics" | grep 'read_access{' | tr '\n' ' ')"
+done
+exit $RET


### PR DESCRIPTION
Missed the #1166 merge by a couple of minutes, so it comes as its own PR. One new file, nothing else changes.

## What it does

Checks a deployed Gitea mirror the way a booting VM would: it pulls the credential from `jvb-bucket-<env>`, writes a netrc, and tests **each replica directly** by its allocation address. That last part matters. The replicas run independent ephemeral databases, so a check through the Fabio hostname only ever exercises whichever one it happens to land on, which is exactly the failure mode that killed the original shared-token design.

Per replica it asserts:

| check | expected |
|---|---|
| anonymous private repo API | 404 |
| anonymous private clone | refused |
| netrc private clone | succeeds, prints HEAD |
| anonymous public clone | succeeds |
| netrc push | refused |
| gate `/ready` + `read_access` metric | 200, 1 |

Exits non-zero if any replica fails any check, so it can gate a rollout step.

## Usage

```bash
ENVIRONMENT=stage-8x8 ORACLE_REGION=us-phoenix-1 scripts/verify-nomad-gitea-mirror.sh
```

## Verified

Passes against both ops-dev replicas, exit 0, ~25s for the pair. Clones are `--depth 1 --no-tags`: a full clone of `infra-customizations-private` takes ~80s per replica against a warm mirror, which does not scale to prod-8x8's ten regions, and auth is exercised at the same point either way. Guards checked too: missing bucket object exits 1 with the fix named, missing `ENVIRONMENT` exits 2.