### PR TITLE
fix(selenium-grid): pass the detected nomad flag to the provisioning script

### DIFF
--- a/jenkins/groovy/provision-selenium-grid/Jenkinsfile
+++ b/jenkins/groovy/provision-selenium-grid/Jenkinsfile
@@ -59,11 +59,28 @@ pipeline {
                         ]) {
                             sshagent (credentials: ['ssh-ubuntu']) {
                             utils.SetupSSH()
+                            // Hand the script the same answer the Check Nomad Flag stage
+                            // already worked out. Without this it only ever sees the job
+                            // parameter, and its own fallback -- SELENIUM_GRID_NOMAD_FLAG --
+                            // is set nowhere in either repo, so an unticked run defaulted to
+                            // "false" and provisioned a nomad grid down the instance-pool
+                            // path: IMAGE_TYPE SeleniumGrid instead of NobleBase (no aarch64
+                            // SeleniumGrid image exists, so exit 210), the "<grid> Grid Nodes"
+                            // pool name instead of the x86/Arm pair, and the instance-pool
+                            // module against state written by instance-pool-nomad.
+                            //
+                            // This propagates the detection rather than forcing it: the value
+                            // comes from selenium_grid_enable_nomad in the environment's vars,
+                            // so a genuinely instance-pool grid still resolves to false. An
+                            // explicit SELENIUM_GRID_NOMAD_ENABLED=true parameter still wins,
+                            // because Check Nomad Flag honours it first.
+                            withEnv(["SELENIUM_GRID_NOMAD_ENABLED=${skipNomad ? 'false' : 'true'}"]) {
                             sh '''#!/bin/bash
                             export USER_PUBLIC_KEY_PATH=~/.ssh/ssh_key.pub
                             export ORACLE_GIT_BRANCH=\"$RELEASE_BRANCH\"
                             terraform/selenium-grid/create-selenium-grid-oracle.sh $SSH_USERNAME
                             '''
+                            }
                             }
                         }
                     }


### PR DESCRIPTION
## The bug

`Check Nomad Flag` works out whether a grid is nomad-based, then uses that answer **only** to gate the `selenium grid nomad jobs` stage. The provisioning stage never exported it, so `create-selenium-grid-oracle.sh` saw `SELENIUM_GRID_NOMAD_ENABLED` from the job parameter alone.

Its secondary fallback is no help either — `SELENIUM_GRID_NOMAD_FLAG` appears exactly once across infra-provisioning and infra-customizations-private, on the line that reads it:

```bash
[ -z "$SELENIUM_GRID_NOMAD_ENABLED" ] && SELENIUM_GRID_NOMAD_ENABLED="$SELENIUM_GRID_NOMAD_FLAG"
[ -z "$SELENIUM_GRID_NOMAD_ENABLED" ] && SELENIUM_GRID_NOMAD_ENABLED="false"
```

So the script went down the nomad path only when a human ticked the checkbox.

## What that broke

An unticked run provisioned a nomad grid down the **instance-pool** path. From the failing `validate` build:

```
+ SELENIUM_GRID_NOMAD_ENABLED=
+ SELENIUM_GRID_NOMAD_ENABLED=false
+ [[ false == \t\r\u\e ]]
...
+ IMAGE_TYPE=SeleniumGrid
No image found matching type SeleniumGrid and version latest and arch aarch64
No IMAGE_OCID_ARM found.  Exiting...
+ exit 210
```

| consequence | detail |
|---|---|
| **Wrong image type** | `IMAGE_TYPE=SeleniumGrid` instead of `NobleBase`. No aarch64 `SeleniumGrid` image exists, so the ARM lookup found nothing → `exit 210`. |
| **Wrong pool names** | Looked up `validate Grid Nodes` rather than the `validate Grid x86 Nodes` / `validate Grid Arm Nodes` pair, reported `No existing node pool found`, and fell through to the non-nomad size defaults. |
| **Wrong terraform module** | `TF_GLOBALS_CHDIR` would have selected `instance-pool` for a grid whose state was written by `instance-pool-nomad`. `exit 210` stopped the run before terraform — the only reason that didn't matter. |

Survivable while a human was driving. Not survivable for `auto-update-selenium-grid`, which deliberately does not pass the flag (forcing it would deploy nomad jobs to genuinely instance-pool grids), so every unattended fortnightly run would have died at `exit 210`.

## The fix

Wrap the provisioning `sh` in `withEnv`, handing the script the answer the pipeline already computed:

```groovy
withEnv(["SELENIUM_GRID_NOMAD_ENABLED=${skipNomad ? 'false' : 'true'}"]) {
```

This **propagates the detection rather than forcing it**, which is the distinction `auto-update-selenium-grid`'s header argues for. The value originates in `selenium_grid_enable_nomad` in the environment's vars, so a genuinely instance-pool grid still resolves to `false` and keeps its existing path. An explicit `SELENIUM_GRID_NOMAD_ENABLED=true` parameter still wins, because `Check Nomad Flag` consults the parameter before falling back to the ansible var.

## Testing

- Jenkinsfile parses under **groovy 4** (`new GroovyShell().parse(...)`).
- Traced against the failing build log: with the flag propagated, `IMAGE_TYPE` resolves to `NobleBase`, the pool lookup uses the x86/Arm display names, and `TF_GLOBALS_CHDIR` selects `instance-pool-nomad`.
- **Not tested**: a live Jenkins run.

## Reviewer attention

- **This changes behaviour for every caller** of `provision-selenium-grid` against a torture-test grid. Runs that previously took the non-nomad path because nobody ticked the box will now take the nomad one. That's the intent, but worth confirming no grid in `torture-test` is deliberately instance-pool — the environment sets `selenium_grid_enable_nomad: "true"` at the site level, so detection is all-or-nothing per environment.
- Follow-up to #1145, which fixed the *stage gating* half of this (`selenium_grid_nomad_enabled` → `selenium_grid_enable_nomad`). The provisioning stage was always a separate, unfixed determination; the new unattended job is simply the first caller that never ticks the box.
