### PR TITLE
fix: migrate transcriber to s6-overlay v3 and repair with-contenv change scripts

### DIFF
--- a/docker/ops-git/rootfs/etc/cont-init.d/11-update-cron
+++ b/docker/ops-git/rootfs/etc/cont-init.d/11-update-cron
@@ -1,3 +1,3 @@
-#!/usr/bin/with-contenv bash
+#!/command/with-contenv bash
 
 echo '* * * * * /usr/bin/timeout 50 /opt/jitsi/update-repos.sh > /tmp/update.log 2>&1' | crontab -u git -

--- a/docker/ops-git/rootfs/etc/services.d/20-ssh/run
+++ b/docker/ops-git/rootfs/etc/services.d/20-ssh/run
@@ -1,3 +1,3 @@
-#!/usr/bin/with-contenv bash
+#!/command/with-contenv bash
 
 exec /usr/sbin/sshd -D -e

--- a/docker/ops-git/rootfs/etc/services.d/60-cron/run
+++ b/docker/ops-git/rootfs/etc/services.d/60-cron/run
@@ -1,3 +1,3 @@
-#!/usr/bin/with-contenv bash
+#!/command/with-contenv bash
 
 exec cron -f

--- a/docker/ops-git/rootfs/etc/services.d/70-tail/run
+++ b/docker/ops-git/rootfs/etc/services.d/70-tail/run
@@ -1,4 +1,4 @@
-#!/usr/bin/with-contenv bash
+#!/command/with-contenv bash
 
 touch /tmp/update.log
 chmod 777 /tmp/update.log

--- a/nomad/jibri.hcl
+++ b/nomad/jibri.hcl
@@ -312,7 +312,18 @@ EOF
       }
       template {
         data = <<EOF
-#!/command/with-contenv bash
+#!/bin/bash
+
+# Nomad runs this through `docker exec`, whose PATH does not contain /command,
+# so a #!/command/with-contenv shebang cannot be used here: execlineb cannot
+# find its own builtins and the script dies with exit 127. Put /command on PATH
+# (the image scripts called below do use with-contenv) and import the s6
+# container environment by hand, which is what with-contenv would have done.
+export PATH="/command:$PATH"
+for _f in /run/s6/container_environment/*; do
+    [ -f "$_f" ] || continue
+    export "$(basename "$_f")=$(cat "$_f")"
+done
 
 # Refresh XMPP_SERVER from the updated servers file, re-render config into
 # /run/jibri/config, then ask jibri to reconnect to the new shard list.

--- a/nomad/jitsi_packs/packs/jitsi_meet_backend/templates/jitsi_meet_backend.nomad.tpl
+++ b/nomad/jitsi_packs/packs/jitsi_meet_backend/templates/jitsi_meet_backend.nomad.tpl
@@ -595,7 +595,19 @@ EOF
 [[ if eq (or (env "CONFIG_jigasi_vault_enabled") "true") "true" ]]
       template {
         data = <<EOF
-#!/command/with-contenv bash
+#!/bin/bash
+
+# Nomad runs this through `docker exec`, whose PATH does not contain /command,
+# so a #!/command/with-contenv shebang cannot be used here: execlineb cannot
+# find its own builtins and the script dies with exit 127. Put /command on PATH
+# (the image scripts called below do use with-contenv) and import the s6
+# container environment by hand, which is what with-contenv would have done.
+export PATH="/command:$PATH"
+for _f in /run/s6/container_environment/*; do
+    [ -f "$_f" ] || continue
+    export "$(basename "$_f")=$(cat "$_f")"
+done
+
 # The rootless image renders the live config under /run/prosody/config.
 PROSODY_CFG="/run/prosody/config/prosody.cfg.lua"
 

--- a/nomad/jitsi_packs/packs/jitsi_meet_jvb/templates/_helpers.tpl
+++ b/nomad/jitsi_packs/packs/jitsi_meet_jvb/templates/_helpers.tpl
@@ -197,7 +197,18 @@ block
 [[- end ]]
 
 [[ define "reload-shards" -]]
-#!/command/with-contenv bash
+#!/bin/bash
+
+# Nomad runs this through `docker exec`, whose PATH does not contain /command,
+# so a #!/command/with-contenv shebang cannot be used here: execlineb cannot
+# find its own builtins and the script dies with exit 127. Put /command on PATH
+# (the image scripts called below do use with-contenv) and import the s6
+# container environment by hand, which is what with-contenv would have done.
+export PATH="/command:$PATH"
+for _f in /run/s6/container_environment/*; do
+    [ -f "$_f" ] || continue
+    export "$(basename "$_f")=$(cat "$_f")"
+done
 
 SHARD_FILE=/config/shards.json
 UPLOAD_FILE=/config/upload.json

--- a/nomad/transcriber.hcl
+++ b/nomad/transcriber.hcl
@@ -182,14 +182,33 @@ job "[JOB_NAME]" {
         ports = ["http"]
         volumes = [
           "local/xmpp-servers:/opt/jitsi/xmpp-servers",
-          "local/01-xmpp-servers:/etc/cont-init.d/01-xmpp-servers",
-#          "local/11-status-cron:/etc/cont-init.d/11-status-cron",
           "local/reload-config.sh:/opt/jitsi/scripts/reload-config.sh",
-#          "local/jibri-status.sh:/opt/jitsi/scripts/jigasi-stats.sh",
-#          "local/cron-service-run:/etc/services.d/60-cron/run",
           "local/config:/config",
-          "secrets/oci:/usr/share/jigasi/.oci"
+          # Migrated to s6-overlay v3 / rootless.
+          #
+          # env oneshot: seeds JIGASI_VERSION / XMPP_SERVER into the s6 container
+          # environment, ordered before the image's 10-config.
+          "local/jigasi-env-type:/etc/s6-overlay/s6-rc.d/00-jigasi-env/type",
+          "local/jigasi-env-up:/etc/s6-overlay/s6-rc.d/00-jigasi-env/up",
+          "local/jigasi-env-contents:/etc/s6-overlay/s6-rc.d/user/contents.d/00-jigasi-env",
+          "local/jigasi-env-config-dep:/etc/s6-overlay/s6-rc.d/10-config/dependencies.d/00-jigasi-env",
+          "local/jigasi-env-script:/etc/s6-overlay/scripts/jigasi-env",
+          # jigasi's OCI transcription service reads ~/.oci/config; the rootless
+          # image runs as the s6 user (uid 1000, HOME=/home/s6), not the old
+          # jigasi user (uid 998, HOME=/usr/share/jigasi).
+          "secrets/oci:/home/s6/.oci"
     	  ]
+
+        # In transcriber mode the image's 10-config fails fast unless
+        # /tmp/transcripts exists and is writable by uid 1000. It is a VOLUME in
+        # the image, so docker would otherwise create it root-owned and 0755.
+        mount {
+          type   = "tmpfs"
+          target = "/tmp/transcripts"
+          tmpfs_options {
+            size = 67108864
+          }
+        }
       }
 
       env {
@@ -284,7 +303,7 @@ region={{ env "meta.cloud_region" }}
 EOF
         destination = "secrets/oci/config"
         perms = "600"
-        uid = 998
+        uid = 1000
         gid = 1000
       }
 
@@ -295,20 +314,54 @@ EOF
 EOF
         destination = "secrets/oci/oci_api_key.pem"
         perms = "600"
-        uid = 998
+        uid = 1000
         gid = 1000
       }
 
+      # --- 00-jigasi-env: oneshot seeding JIGASI_VERSION / XMPP_SERVER into the s6
+      # container environment, ordered before the image's 10-config. The script
+      # both exports (so reload-config.sh can source it) and writes the s6
+      # container_environment (so services started later see the values). ---
       template {
         data = <<EOF
-#!/usr/bin/with-contenv bash
-export JIGASI_VERSION="$(dpkg -s jigasi | grep Version | awk '{print $2}' | sed 's/..$//')"
-echo -n "$JIGASI_VERSION" > /var/run/s6/container_environment/JIGASI_VERSION
-
-export XMPP_SERVER="$(cat /opt/jitsi/xmpp-servers/servers)"
-echo -n "$XMPP_SERVER" > /var/run/s6/container_environment/XMPP_SERVER
+oneshot
 EOF
-        destination = "local/01-xmpp-servers"
+        destination = "local/jigasi-env-type"
+        perms = "644"
+      }
+      template {
+        data = <<EOF
+/etc/s6-overlay/scripts/jigasi-env
+EOF
+        destination = "local/jigasi-env-up"
+        perms = "644"
+      }
+      template {
+        data = <<EOF
+# managed by nomad
+EOF
+        destination = "local/jigasi-env-contents"
+        perms = "644"
+      }
+      template {
+        data = <<EOF
+# managed by nomad
+EOF
+        destination = "local/jigasi-env-config-dep"
+        perms = "644"
+      }
+      template {
+        data = <<EOF
+#!/command/with-contenv bash
+JIGASI_VERSION="$(dpkg -s jigasi | grep Version | awk '{print $2}' | sed 's/..$//')"
+export JIGASI_VERSION
+printf '%s' "$JIGASI_VERSION" > /run/s6/container_environment/JIGASI_VERSION
+
+XMPP_SERVER="$(cat /opt/jitsi/xmpp-servers/servers)"
+export XMPP_SERVER
+printf '%s' "$XMPP_SERVER" > /run/s6/container_environment/XMPP_SERVER
+EOF
+        destination = "local/jigasi-env-script"
         perms = "755"
       }
 
@@ -335,11 +388,24 @@ EOF
       }
       template {
         data = <<EOF
-#!/usr/bin/with-contenv bash
+#!/bin/bash
 
-. /etc/cont-init.d/01-xmpp-servers
-/etc/cont-init.d/10-config
-CONFIG_PATH=/config/sip-communicator.properties /usr/share/jigasi/reconfigure_xmpp.sh
+# Nomad runs this through `docker exec`, whose PATH does not contain /command,
+# so a #!/command/with-contenv shebang cannot be used here: execlineb cannot
+# find its own builtins and the script dies with exit 127. Put /command on PATH
+# (the image scripts called below do use with-contenv) and import the s6
+# container environment by hand, which is what with-contenv would have done.
+export PATH="/command:$PATH"
+for _f in /run/s6/container_environment/*; do
+    [ -f "$_f" ] || continue
+    export "$(basename "$_f")=$(cat "$_f")"
+done
+
+# Refresh XMPP_SERVER from the updated servers file, re-render config into
+# /run/jigasi/config, then re-add/remove call-control MUCs in running jigasi.
+. /etc/s6-overlay/scripts/jigasi-env
+/etc/s6-overlay/scripts/config
+CONFIG_PATH=/run/jigasi/config/sip-communicator.properties /usr/share/jigasi/reconfigure_xmpp.sh
 EOF
         destination = "local/reload-config.sh"
         perms = "755"


### PR DESCRIPTION
Follow-up to #1100, which migrated jicofo/jvb/jibri/prosody/web to the rootless
s6-overlay v3 images but missed the transcriber, and which left a latent problem
in the change scripts it did touch.

## Context

`ghcr.io/jitsi/jigasi:{stable,unstable}` (and `docker.io/jitsi/base:unstable`
since ~2026-06) are s6-overlay **v3.2.3.0**, rootless (`USER s6`, uid/gid 1000,
`HOME=/home/s6`), `S6_READ_ONLY_ROOT=1`. In those images `/usr/bin/with-contenv`
is gone (it is `/command/with-contenv`), `/etc/cont-init.d` and
`/etc/services.d` no longer exist, and s6 state lives in
`/run/s6/container_environment`.

## transcriber — currently broken on the shipping image

`nomad/transcriber.hcl` still injected `/etc/cont-init.d/01-xmpp-servers` with a
`#!/usr/bin/with-contenv` shebang. s6 stage2 fails, and with
`S6_BEHAVIOUR_IF_STAGE2_FAILS=2` the container is stopped.

- Replaced the `cont-init.d` injection with a v3 `00-jigasi-env` oneshot
  (`type`/`up`/`user/contents.d` + a `dependencies.d` entry on the image's
  `10-config`), body under `/etc/s6-overlay/scripts`, matching `jibri.hcl`.
- `reload-config.sh` called `/etc/cont-init.d/10-config`, which is gone → now
  `/etc/s6-overlay/scripts/config`, with `CONFIG_PATH` pointed at
  `/run/jigasi/config/sip-communicator.properties` (the rootless image renders
  its live config under `/run`).
- Jigasi's `OracleTranscriptionService` reads `~/.oci/config`. That used to
  resolve to `/usr/share/jigasi/.oci` for the old `jigasi` user (uid 998); the
  rootless image runs as `s6` with `HOME=/home/s6`. Mount moved, secrets written
  as uid 1000.
- In transcriber mode `10-config` now runs `check-writable /tmp/transcripts` and
  exits 1 on failure. It is a `VOLUME`, so docker creates it root-owned 0755 —
  added a tmpfs `mount`.

## `#!/command/with-contenv` does not work in a Nomad change script

A `#!/command/with-contenv` shebang only resolves when `PATH` contains
`/command`. That holds for s6-rc-supervised services, but Nomad runs template
`change_script`s through `docker exec`, which uses the image's `PATH` — no
`/command`. The script dies with `execlineb: fatal: unable to exec ifelse`,
exit 127. Since `fail_on_error` defaults to false, it fails silently: **JVB
shard reloads have been no-ops wherever the migrated pack is deployed** (beta is
running it).

Affected, all now `#!/bin/bash` with a preamble that puts `/command` on `PATH`
(the image scripts they call do use `with-contenv`) and imports
`/run/s6/container_environment` by hand:

- `nomad/jibri.hcl` — `reload-config.sh`
- `jitsi_meet_jvb/templates/_helpers.tpl` — `reload-shards.sh`
- `jitsi_meet_backend/templates/jitsi_meet_backend.nomad.tpl` — `jigasi_xmpp.sh`
- `nomad/transcriber.hcl` — `reload-config.sh`

## docker/ops-git

Base is `jitsi/base:unstable`, already s6 v3 — fixed the four shebangs so the
image can run if it is ever rebuilt. (It is the unused prototype superseded by
Gitea per `doc/git-mirror-bootstrap-plan.md`.)

## Deliberately not changed

`nomad/multitrack-recorder.hcl`. `jitsi/jitsi-multitrack-recorder` is still
s6-overlay **v1.22.1.0** on a bookworm `base-java`, so its
`/usr/bin/with-contenv` and `/etc/cont-init.d` mounts are correct today and
would break if "fixed" — the running prod alloc has been up on it for two
months. It needs the same migration when that image is rebuilt on the new base,
including replacing the `boot-config` `apt-get`/`pip install oci-cli` step,
which uid 1000 cannot do on a read-only root (same treatment as
jicofo-rtcstats-push in #1100).

## Testing

- Booted `ghcr.io/jitsi/jigasi:stable` locally with the new layout bind-mounted:
  `00-jigasi-env` runs before `10-config`, then `10-config` → `jigasi` →
  `50-autoscaler-sidecar` all come up, with `XMPP_SERVER` and `JIGASI_VERSION`
  present in the container environment.
- Reproduced the exit-127 `docker exec` failure on the same base image, and
  confirmed `PATH` inside a live beta JVB container has no `/command`.
- Verified `~/.oci/config` is readable by uid 1000 through the new mount point.
- `nomad job validate` on transcriber and jibri; `nomad-pack render` +
  `nomad job validate` on the JVB pack. The backend pack render has a
  pre-existing `MAX_PARTICIPANTS =` artifact from empty `CONFIG_` vars,
  identical on `main`.

Not yet deployed anywhere — transcriber and jibri will need a redeploy, and the
JVB/backend packs pick the change up on their next shard deploy.