### PR TITLE
feat(jitsi-meet-web): wire jitsi_meet_disable_av1_decode_for_ff

### DIFF
--- a/nomad/jitsi_packs/packs/jitsi_meet_web/templates/_custom-config.js.tpl
+++ b/nomad/jitsi_packs/packs/jitsi_meet_web/templates/_custom-config.js.tpl
@@ -288,6 +288,7 @@ config.testing.dumpTranscript = true;
 config.testing.skipInterimTranscriptions = true;
 [[- end ]]
 
+config.testing.disableAV1DecodeForFF = [[ or (env "CONFIG_jitsi_meet_disable_av1_decode_for_ff") "true" ]];
 config.testing.enableCodecSelectionAPI = [[ or (env "CONFIG_jitsi_meet_enable_codec_selection_api") "true" ]];
 config.testing.enableGracefulReconnect = [[ or ( env "CONFIG_jitsi_meet_enable_graceful_reconnect") "false" ]];
 config.testing.showSpotConsentDialog = [[ or ( env "CONFIG_jitsi_meet_show_spot_consent_dialog") "false" ]];


### PR DESCRIPTION
## Summary

Wires `jitsi_meet_disable_av1_decode_for_ff` through the Nomad path, rendering `config.testing.disableAV1DecodeForFF` into the web pack config.

Firefox assembles the frames of an AV1 stream that carries spatial layers but never emits them from the jitter buffer, so video from an endpoint sending AV1 SVC never decodes: https://bugzilla.mozilla.org/show_bug.cgi?id=2071030

The client-side flag removes AV1 from the codec list on Firefox, so it is neither advertised nor sent to it and remote endpoints fall back to VP9.

**Defaults to `true`** when the env var is absent, matching the ansible role default. Set `jitsi_meet_disable_av1_decode_for_ff: false` in a site's `vars.yml` to keep AV1 enabled there.

## Companion changes

- lib-jitsi-meet: https://github.com/jitsi/lib-jitsi-meet/pull/3108 (implements the flag)
- jitsi-meet: https://github.com/jitsi/jitsi-meet/pull/17813 (config docs and typing)
- infra-configuration: https://github.com/jitsi/infra-configuration/pull/953 (ansible var and template)
- docker-jitsi-meet: https://github.com/jitsi/docker-jitsi-meet/pull/2322 (`DISABLE_AV1_DECODE_FOR_FF`)

No effect until the lib-jitsi-meet change is released; the client ignores the unknown key until then.

## Test plan

- Assignment is placed after the existing `if (!config.hasOwnProperty('testing')) config.testing = {};` guard, so setting the leaf cannot throw on an undefined parent.
- Rendered config on a shard with no override contains `config.testing.disableAV1DecodeForFF = true;`.
- With `jitsi_meet_disable_av1_decode_for_ff: false` in the site vars, `yamltoenv` exports `CONFIG_jitsi_meet_disable_av1_decode_for_ff=false` and the rendered line is `false`.
