### PR TITLE
JIT-16092: don't let Jenkins' JOB_NAME rename the gitea mirror nomad job

### DIFF
--- a/scripts/deploy-nomad-gitea-mirror.sh
+++ b/scripts/deploy-nomad-gitea-mirror.sh
@@ -65,11 +65,15 @@ export NOMAD_VAR_dc="$NOMAD_DC"
 
 # Per-region job name, same pattern as loki-/prometheus-/tempo-$ORACLE_REGION:
 # the Nomad region is shared across all of an environment's datacenters, so a
-# fixed name would be clobbered by the next region's deploy. Overridable so a
-# test instance can run alongside the real one.
-[ -z "$JOB_NAME" ] && JOB_NAME="gitea-mirror-$ORACLE_REGION"
+# fixed name would be clobbered by the next region's deploy.
+#
+# Overridable through GITEA_JOB_NAME, so a test instance can run alongside the
+# real one. Deliberately NOT JOB_NAME: Jenkins exports JOB_NAME as the name of
+# the running job, so reading that here would deploy a nomad job called
+# "provision-nomad-gitea-mirror" and leave the real mirror untouched.
+[ -z "$GITEA_JOB_NAME" ] && GITEA_JOB_NAME="gitea-mirror-$ORACLE_REGION"
 
-sed -e "s/\[JOB_NAME\]/$JOB_NAME/" "$NOMAD_JOB_PATH/gitea-mirror.hcl" | nomad job run -var="dc=$NOMAD_DC" -
+sed -e "s/\[JOB_NAME\]/$GITEA_JOB_NAME/" "$NOMAD_JOB_PATH/gitea-mirror.hcl" | nomad job run -var="dc=$NOMAD_DC" -
 RET=$?
 
 # Route53 CNAME for the mirror hostname -> the region's internal general-pool


### PR DESCRIPTION
Prerequisite for the `provision-nomad-gitea-mirror` / `release-nomad-gitea-mirror` Jenkins jobs (infra-customizations-private #1103).

## The bug

`scripts/deploy-nomad-gitea-mirror.sh` derived the Nomad job name as:

```sh
[ -z "$JOB_NAME" ] && JOB_NAME="gitea-mirror-$ORACLE_REGION"
```

Harmless by hand, wrong under Jenkins. Jenkins exports `JOB_NAME` as the name of the running job, so a `provision-nomad-gitea-mirror` build would have deployed a Nomad job literally called **`provision-nomad-gitea-mirror`**, left the real `gitea-mirror-<region>` job untouched, and ended up running two mirrors in the region.

The generic provision pipeline runs `scripts/deploy-nomad-${JOB_TYPE}.sh` with the build environment inherited, so this would have fired on the very first Jenkins run.

## The fix

Rename the override to `GITEA_JOB_NAME`. The other Jenkins-driven deploy scripts (`deploy-nomad-alloy.sh`, `deploy-nomad-loki.sh`) avoid the collision by assigning `JOB_NAME` unconditionally; keeping a distinctly-named override preserves the ability to run a test instance alongside the real one.

Verified both paths:

```
with Jenkins JOB_NAME set -> gitea-mirror-us-ashburn-1
with explicit override    -> gitea-mirror-test
```

No behaviour change for existing manual deploys, which never set `JOB_NAME`.

Related: JIT-16092, RP-107287.