### PR TITLE
JIT-16092: only mirror jitsi-meet where the build tooling actually runs

### DIFF
--- a/doc/git-mirror-bootstrap-plan.md
+++ b/doc/git-mirror-bootstrap-plan.md
@@ -329,6 +329,16 @@ today.
   **Resolved (2026-07-28):** mirror `jitsi-meet` only in `us-phoenix-1` (where
   the Jenkins/build host lives); everywhere else mirror just the three infra
   repos. Implemented in `scripts/deploy-nomad-gitea-mirror.sh`.
+  **Refined (2026-09-11):** that check keyed on the region alone, so *every*
+  environment's `us-phoenix-1` mirror pulled `jitsi-meet` — ops-dev, ops-prod,
+  stage-8x8, beta-meet-jit-si and torture-test all did, and prod-8x8 would have.
+  Only the ops environments run the build tooling, and no VM boot has ever
+  needed the repo (`checkout_repos` clones infra-configuration and
+  infra-customizations only), so the default is now keyed on environment as well
+  as region via `GITEA_JITSI_MEET_ENVIRONMENTS` (default `ops-dev ops-prod`).
+  Note that nothing consumes the mirrored copy yet either way:
+  `scripts/validate-shard.sh` still clones `jitsi-meet` straight from
+  github.com.
 - ~~Confirm the per-env `VAULT_ENVIRONMENT` / `DNS_ZONE` values used to construct
   `VAULT_ADDR` at boot for each environment.~~ **Resolved (2026-07-28):** the
   established form is `https://${VAULT_ENVIRONMENT}-${VAULT_REGION}-vault.jitsi.net`

--- a/scripts/deploy-nomad-gitea-mirror.sh
+++ b/scripts/deploy-nomad-gitea-mirror.sh
@@ -44,12 +44,26 @@ NOMAD_DC="$ENVIRONMENT-$ORACLE_REGION"
 [ -z "$GITEA_HOSTNAME" ] && GITEA_HOSTNAME="${ENVIRONMENT}-${ORACLE_REGION}-git.${TOP_LEVEL_DNS_ZONE_NAME}"
 export NOMAD_VAR_gitea_hostname="$GITEA_HOSTNAME"
 
-# Repos to mirror. jitsi-meet is only cloned by boots in us-phoenix-1 (where the
-# Jenkins/build host lives), so it is mirrored there only; everywhere else just
-# the three infra repos. Override wholesale with GITEA_REQUIRED_REPOS (HCL/JSON
-# list syntax, e.g. '["infra-configuration","jitsi-meet"]').
+# Repos to mirror. The three infra repos everywhere: those are what a VM boot
+# clones (infra-configuration and infra-customizations) and what the Jenkins
+# checkouts use.
+#
+# jitsi-meet is extra, and only for the build tooling, which runs in the ops
+# environments. It is by far the largest repo mirrored (~890MB against ~150MB
+# for the rest combined), it dominates a cold replica's first sync, and the
+# health gate makes the whole replica wait on it, which is why this job carries
+# a 20m healthy_deadline. No VM boot has ever needed it.
+#
+# The test used to be on the region alone, so *every* environment's us-phoenix-1
+# mirror pulled jitsi-meet -- prod-8x8, stage-8x8, beta and torture-test
+# included, none of which have any use for it. Keyed on the environment as well
+# now. Override either list, or GITEA_REQUIRED_REPOS wholesale (HCL/JSON list
+# syntax, e.g. '["infra-configuration","jitsi-meet"]').
+[ -z "$GITEA_JITSI_MEET_ENVIRONMENTS" ] && GITEA_JITSI_MEET_ENVIRONMENTS="ops-dev ops-prod"
+[ -z "$GITEA_JITSI_MEET_REGION" ] && GITEA_JITSI_MEET_REGION="us-phoenix-1"
+
 if [ -z "$GITEA_REQUIRED_REPOS" ]; then
-    if [ "$ORACLE_REGION" == "us-phoenix-1" ]; then
+    if [[ " $GITEA_JITSI_MEET_ENVIRONMENTS " == *" $ENVIRONMENT "* ]] && [ "$ORACLE_REGION" == "$GITEA_JITSI_MEET_REGION" ]; then
         GITEA_REQUIRED_REPOS='["infra-configuration","infra-provisioning","infra-customizations-private","jitsi-meet"]'
     else
         GITEA_REQUIRED_REPOS='["infra-configuration","infra-provisioning","infra-customizations-private"]'


### PR DESCRIPTION
Follow-up to the prod-8x8 rollout (RP-107287), so the deploy is uniform across all ten regions instead of needing a special-cased `GITEA_REQUIRED_REPOS` for us-phoenix-1.

## Problem

The default repo set tested the **region alone**:

```sh
if [ "$ORACLE_REGION" == "us-phoenix-1" ]; then   # + jitsi-meet
```

So every environment's us-phoenix-1 mirror pulls `jitsi-meet`. Verified live — ops-dev, ops-prod, stage-8x8, beta-meet-jit-si and torture-test all carry it right now, and prod-8x8 would have picked it up on deploy.

It is the expensive one: ~890MB against ~150MB for the three infra repos combined. It dominates a cold replica's first sync, and the health gate keeps the whole replica out of the Fabio route until every required repo finishes, which is why this job carries a 20m `healthy_deadline`. No VM boot has ever needed it — `checkout_repos` clones infra-configuration and infra-customizations, nothing else.

## Fix

Key it on environment as well as region, via `GITEA_JITSI_MEET_ENVIRONMENTS` (default `ops-dev ops-prod`), matching the plan's original intent of "where the Jenkins/build host lives".

| environment | us-phoenix-1 | effect |
|---|---|---|
| ops-dev, ops-prod | 3 infra + jitsi-meet | unchanged |
| stage-8x8, beta-meet-jit-si, torture-test | 3 infra repos | drops jitsi-meet on next redeploy |
| prod-8x8 | 3 infra repos | never picks it up |

All other regions are unaffected. `GITEA_REQUIRED_REPOS` still overrides wholesale, and both the environment list and the region are overridable. Logic tested across every environment/region combination plus both override paths.

## Worth knowing

Nothing consumes the mirrored `jitsi-meet` in any environment today — `scripts/validate-shard.sh` still clones it straight from github.com with a hardcoded URL, and there is no `JITSI_MEET_MIRROR_REPO` anywhere. This PR keeps it in the ops environments rather than dropping it outright, since the plan pinned that decision in anticipation of the build tooling using it. If that is not coming, it could be removed everywhere.

Plan doc updated. Related: JIT-16092, RP-107287.