### PR TITLE
JIT-16092: stop the boot credential being published from the wrong vault

### DIFF
--- a/scripts/publish-gitea-read-user-bucket.sh
+++ b/scripts/publish-gitea-read-user-bucket.sh
@@ -33,6 +33,26 @@ LOCAL_PATH=$(dirname "${BASH_SOURCE[0]}")
 [ -e "$LOCAL_PATH/../clouds/all.sh" ] && . "$LOCAL_PATH/../clouds/all.sh"
 [ -e "$LOCAL_PATH/../clouds/oracle.sh" ] && . "$LOCAL_PATH/../clouds/oracle.sh"
 
+# Which vault the credential is read FROM. Derived from VAULT_ENVIRONMENT the
+# same way the vault-* terraform wrappers do, rather than inherited from an
+# ambient VAULT_ADDR: ENVIRONMENT selects the destination bucket, so letting the
+# shell's VAULT_ADDR select the source secret makes it easy to publish one
+# vault's credential into another environment's bucket. That is exactly what
+# happened to ops-dev on 2026-09-09 -- its bucket ended up holding a password no
+# mirror had, so every boot silently fell back to github.
+#
+# ops-dev (and anything else whose nomad talks to a non-default vault) needs
+# VAULT_ENVIRONMENT set explicitly. Being logged in to a different vault now
+# fails outright instead of publishing the wrong credential.
+[ -z "$VAULT_ENVIRONMENT" ] && VAULT_ENVIRONMENT="ops-prod"
+if [ -z "$VAULT_ADDR" ] || [ "$VAULT_ADDR_DERIVE" != "false" ]; then
+  if [ -n "$VAULT_REGION" ]; then
+    export VAULT_ADDR="https://${VAULT_ENVIRONMENT}-${VAULT_REGION}-vault.jitsi.net"
+  else
+    export VAULT_ADDR="https://${VAULT_ENVIRONMENT}-vault.jitsi.net"
+  fi
+fi
+
 [ -z "$SECRET_PATH" ] && SECRET_PATH="secret/default/gitea/read-user"
 [ -z "$OBJECT_NAME" ] && OBJECT_NAME="gitea-read-user"
 [ -z "$BUCKET_NAME" ] && BUCKET_NAME="jvb-bucket-${ENVIRONMENT}"
@@ -55,8 +75,10 @@ if [ "$DELETE" == "true" ]; then
   exit $FINAL_RET
 fi
 
+echo "reading $SECRET_PATH from $VAULT_ADDR -> jvb-bucket-${ENVIRONMENT} ($REGIONS)"
 if ! vault token lookup >/dev/null 2>&1; then
   echo "Not logged in to vault at ${VAULT_ADDR:-<unset>}; run scripts/vault-login.sh from infra-customizations-private first"
+  echo "(VAULT_ENVIRONMENT=$VAULT_ENVIRONMENT selected that vault; set it to the vault this environment's nomad uses)"
   exit 203
 fi
 
@@ -77,5 +99,10 @@ for REGION in $REGIONS; do
     FINAL_RET=1
   fi
 done
+
+# Publishing succeeds regardless of whether the credential matches the user the
+# mirrors actually created, and a mismatch is silent -- boots just fall back to
+# github. Always confirm.
+[ $FINAL_RET -eq 0 ] && echo "now confirm it works: ENVIRONMENT=$ENVIRONMENT ORACLE_REGION=<region> scripts/verify-nomad-gitea-mirror.sh"
 
 exit $FINAL_RET

--- a/scripts/verify-nomad-gitea-mirror.sh
+++ b/scripts/verify-nomad-gitea-mirror.sh
@@ -6,6 +6,14 @@
 # Exits non-zero if any check fails on any replica. See JIT-16092.
 [ -z "$ENVIRONMENT" ] && { echo "No ENVIRONMENT set"; exit 2; }
 [ -z "$ORACLE_REGION" ] && { echo "No ORACLE_REGION set"; exit 2; }
+
+# Same lookup deploy-nomad-gitea-mirror.sh does, so the nomad endpoint follows the
+# environment rather than being assumed. Not every environment has a nomad in
+# us-phoenix-1: meet-jit-si runs in ap-sydney-1, eu-frankfurt-1 and us-ashburn-1,
+# and assuming phoenix there just fails to connect.
+LOCAL_PATH=$(dirname "${BASH_SOURCE[0]}")
+[ -e "$LOCAL_PATH/../sites/$ENVIRONMENT/stack-env.sh" ] && . "$LOCAL_PATH/../sites/$ENVIRONMENT/stack-env.sh"
+[ -z "$LOCAL_REGION" ] && LOCAL_REGION="$OCI_LOCAL_REGION"
 [ -z "$LOCAL_REGION" ] && LOCAL_REGION="us-phoenix-1"
 [ -z "$NOMAD_ADDR" ] && export NOMAD_ADDR="https://$ENVIRONMENT-$LOCAL_REGION-nomad.jitsi.net"
 [ -z "$JOB" ] && JOB="gitea-mirror-$ORACLE_REGION"


### PR DESCRIPTION
Found while verifying the mirror fleet: **ops-dev's boot bucket held a password no mirror had**, so every ops-dev boot was silently falling back to GitHub for the private repo — the exact failure this ticket exists to remove.

Nothing surfaced it. The mirror was healthy, the sync gate reported the read user had access, both replicas served fine. Only a clone using the *bucket* credential failed. `scripts/verify-nomad-gitea-mirror.sh` caught it because it fetches the credential the way a booting VM does.

## Cause

`publish-gitea-read-user-bucket.sh` takes the destination from `ENVIRONMENT` but the source secret from whatever `VAULT_ADDR` happens to be in the shell. Publishing while logged in to the wrong vault writes one vault's credential into another environment's bucket, with no error. ops-dev's object was overwritten on 2026-09-09 12:47 UTC with a value matching neither vault.

## Fix

- Derive `VAULT_ADDR` from `VAULT_ENVIRONMENT` (default `ops-prod`), as the `vault-*` terraform wrappers already do. ops-dev now needs `VAULT_ENVIRONMENT=ops-dev`; being logged in elsewhere fails outright instead of publishing the wrong password.
- Print source and destination together: `reading secret/default/gitea/read-user from https://ops-dev-vault.jitsi.net -> jvb-bucket-ops-dev (us-phoenix-1)`.
- Point at the verify script on success, because a mismatch is invisible until something clones.

Also: `verify-nomad-gitea-mirror.sh` assumed the Nomad endpoint was in us-phoenix-1. meet-jit-si has none there, so verifying it needed `LOCAL_REGION` by hand. It now reads `OCI_LOCAL_REGION` from `sites/<env>/stack-env.sh` like the deploy script.

## Verified

- ops-dev bucket republished from its own vault; both replicas pass again.
- Hardening tested both ways: without `VAULT_ENVIRONMENT` it refuses and names the vault it picked; with `VAULT_ENVIRONMENT=ops-dev` it publishes correctly.
- meet-jit-si verifies with no `LOCAL_REGION` now; ops-dev and stage-8x8 unaffected.
- Delete path untouched.

Related: JIT-16092, RP-107287.