### PR TITLE
fix: remove duplicate variable declaration in expand-release-core Jenkinsfile

### DIFF
--- a/jenkins/groovy/expand-release-core/Jenkinsfile
+++ b/jenkins/groovy/expand-release-core/Jenkinsfile
@@ -102,7 +102,6 @@ pipeline {				//indicate the job is written in Declarative Pipeline
                             oracle_shards_by_cloud = shards_by_cloud.oracleShardsByCloud
                             aws_shards_by_cloud = shards_by_cloud.awsShardsByCloud
                             def branches = [:]
-                            def i = 0;
                             for (def i = 0; i < cloud_list.size(); i++) {
                                 def curr = i
                                 echo "pipeline branch ${curr} for shard ${cloud_list[curr]}";


### PR DESCRIPTION
## Summary
- Jenkins job `expand-release-core` failed to even parse: `org.codehaus.groovy.control.MultipleCompilationErrorsException: The current scope already contains a variable of the name i` at lines 106 and 129.
- Cause: `def i = 0;` at line 105 declared `i` in the enclosing scope, and the `for (def i = 0; ...)` loop right below it redeclared it — Jenkins' Groovy CPS sandbox rejects that redeclaration at compile time.
- Fix: removed the unused `def i = 0;` line; the `for` loop already declares and scopes its own `i`.

## Test plan
- [ ] Re-run the `expand-release-core` Jenkins job and confirm the pipeline script compiles and starts executing.